### PR TITLE
feat: add deposits to query

### DIFF
--- a/packages/web/app/api/gql/resolvers/deposits.ts
+++ b/packages/web/app/api/gql/resolvers/deposits.ts
@@ -1,0 +1,28 @@
+import db from '@/app/api/db'
+
+const deposits = async (_: object, args: { chainId: number, address: string }) => {
+  const { chainId, address } = args
+  try {
+    const result = await db.query(`
+    SELECT
+      args->>'assets' AS amount,
+      args->>'shares' AS shares,
+      args->>'owner' AS recipient
+    FROM
+      evmlog
+    WHERE
+      (chain_id = $1 OR $1 IS NULL) AND (address = $2 OR $2 IS NULL)
+      AND event_name = 'Deposit'
+    ORDER BY
+      chain_id, block_time DESC, log_index DESC
+    LIMIT 100;`,
+    [chainId, address])
+
+    return result.rows
+  } catch (error) {
+    console.error(error)
+    throw new Error('!deposits')
+  }
+}
+
+export default deposits

--- a/packages/web/app/api/gql/resolvers/deposits.ts
+++ b/packages/web/app/api/gql/resolvers/deposits.ts
@@ -5,6 +5,8 @@ const deposits = async (_: object, args: { chainId: number, address: string }) =
   try {
     const result = await db.query(`
     SELECT
+      chain_id AS "chainId",
+      address AS "vaultAddress",
       args->>'assets' AS amount,
       args->>'shares' AS shares,
       args->>'owner' AS recipient

--- a/packages/web/app/api/gql/resolvers/index.ts
+++ b/packages/web/app/api/gql/resolvers/index.ts
@@ -5,6 +5,7 @@ import vaults from './vaults'
 import vault from './vault'
 import strategies from './strategies'
 import transfers from './transfers'
+import deposits from './deposits'
 import timeseries from './timeseries'
 import { bigintScalar } from './bigintScalar'
 import accountRoles from './accountRoles'
@@ -45,6 +46,7 @@ const resolvers = {
     strategy,
     strategyReports,
     transfers,
+    deposits,
     timeseries,
     tvls,
     accountRoles,

--- a/packages/web/app/api/gql/typeDefs/deposit.ts
+++ b/packages/web/app/api/gql/typeDefs/deposit.ts
@@ -1,0 +1,9 @@
+import gql from 'graphql-tag'
+
+export default gql`
+type Deposit {
+  amount: String!
+  shares: String!
+  recipient: String!
+}
+`

--- a/packages/web/app/api/gql/typeDefs/deposit.ts
+++ b/packages/web/app/api/gql/typeDefs/deposit.ts
@@ -2,6 +2,8 @@ import gql from 'graphql-tag'
 
 export default gql`
 type Deposit {
+  chainId: Int!
+  vaultAddress: String!
   amount: String!
   shares: String!
   recipient: String!

--- a/packages/web/app/api/gql/typeDefs/index.ts
+++ b/packages/web/app/api/gql/typeDefs/index.ts
@@ -4,6 +4,7 @@ import vault from './vault'
 import output from './output'
 import strategy from './strategy'
 import transfer from './transfer'
+import deposit from './deposit'
 import latestBlock from './latestBlock'
 import monitor from './monitor'
 import accountRole from './accountRole'
@@ -51,6 +52,7 @@ const query = gql`
     strategy(chainId: Int, address: String): Strategy
     strategyReports(chainId: Int, address: String): [StrategyReport]
     transfers(chainId: Int, address: String): [Transfer]
+    deposits(chainId: Int, address: String): [Deposit]
     timeseries(chainId: Int, address: String, label: String!, component: String, period: String, limit: Int, timestamp: BigInt, yearn: Boolean): [Output]
     tvls(chainId: Int!, address: String, period: String, limit: Int, timestamp: BigInt): [Tvl]
     accountRoles(chainId: Int, account: String!): [AccountRole]
@@ -74,6 +76,7 @@ const typeDefs = [
   strategy,
   strategyReport,
   transfer,
+  deposit,
   output,
   tvl,
   price,


### PR DESCRIPTION
Add vault deposit logs:

```
query Query {
  deposits(address: "0xE007CA01894c863d7898045ed5A3B4Abf0b18f37", chainId: 747474) {
    amount
    shares
    recipient
  }
}
```

Example return:
```
{
  "data": {
    "deposits": [
      {
        "amount": "432128030437629920",
        "shares": "432122935473436835",
        "recipient": "0xB9De0DBCEb422751f637CF4E15F48E90FB0405D5"
      },
      ...
```