### PR TITLE
Fix sparkline query

### DIFF
--- a/packages/ingest/db.ts
+++ b/packages/ingest/db.ts
@@ -84,7 +84,7 @@ export async function getSparkline(chainId: number, address: string, label: stri
       CAST($3 AS text) AS label,
       CAST($4 AS text) AS component,
       time_bucket(CAST('7 day' AS interval), block_time) AS "blockTime",
-      COALESCE(LAST(NULLIF(value, 0), block_time), 0) AS close
+      COALESCE(LAST(NULLIF(value, 0), block_number), 0) AS close
     FROM output
     WHERE chain_id = $1 AND address = $2 AND label = $3 AND (component = $4 OR $4 IS NULL)
     GROUP BY "blockTime"


### PR DESCRIPTION
The sparkline query was choosing latest TVL based on block_time sort within a weekly bucket. This doesn't work because we consider block_time to be fixed within a particular bucket which means effectively no sorting, natural record order. 

Sometimes we miss a price and get TVL = 0. Missing price is rare tho, so we expect the indexer to eventually correct itself. And it does. But because of the sparkline sorting issue, a TVL=0 may appear to persist across index runs because we use sparkline[latest] as our official latest TVL.

Simple fix. Sort latest sparkline TVLs by block_number instead. 

