### PR TITLE
Add GraphQL tokens query for ERC20 tokens

### DIFF
--- a/packages/web/app/api/gql/resolvers/index.ts
+++ b/packages/web/app/api/gql/resolvers/index.ts
@@ -22,6 +22,7 @@ import projects from './projects'
 import accountants from './accountants'
 import accountant from './accountant'
 import things from './things'
+import tokens from './tokens'
 import tvls from './tvls'
 import allocator from './allocator'
 import newSplitterLogs from './splitter'
@@ -56,6 +57,7 @@ const resolvers = {
     accountant,
     allocator,
     things,
+    tokens,
     newSplitterLogs,
     newYieldSplitterLogs,
     vestingEscrowCreatedLogs

--- a/packages/web/app/api/gql/resolvers/tokens.ts
+++ b/packages/web/app/api/gql/resolvers/tokens.ts
@@ -1,0 +1,31 @@
+import db from '@/app/api/db'
+
+const tokens = async (_: object, args: { chainId?: number }) => {
+  const { chainId } = args
+
+  try {
+    const result = await db.query(`
+    SELECT defaults FROM thing WHERE label = 'erc20';`)
+
+    return result.rows
+      .map(row => row.defaults)
+      .filter(defaults => !chainId || defaults.chainId === chainId)
+      .sort((a, b) => {
+        if (a.chainId !== b.chainId) return a.chainId - b.chainId
+        return (a.name || '').localeCompare(b.name || '')
+      })
+      .map(defaults => ({
+        chainId: defaults.chainId,
+        address: defaults.address,
+        name: defaults.name,
+        symbol: defaults.symbol,
+        decimals: defaults.decimals
+      }))
+
+  } catch (error) {
+    console.error(error)
+    throw new Error('!tokens')
+  }
+}
+
+export default tokens

--- a/packages/web/app/api/gql/typeDefs/index.ts
+++ b/packages/web/app/api/gql/typeDefs/index.ts
@@ -61,6 +61,7 @@ const query = gql`
     accountants(chainId: Int): [Accountant]
     accountant(chainId: Int!, address: String!): Accountant
     things(chainId: Int, labels: [String]!): [Thing]
+    tokens(chainId: Int): [Erc20]
     newSplitterLogs(chainId: Int, address: String, splitter: String, manager: String, managerRecipient: String): [NewSplitterLog]
     newYieldSplitterLogs(chainId: Int, address: String, splitter: String, vault: String, want: String): [NewYieldSplitterLog]
     vestingEscrowCreatedLogs(recipient: String): [VestingEscrowCreatedLog]


### PR DESCRIPTION
Implements new tokens query that returns all ERC20 tokens from the database with chainId, address, name, symbol, and decimals fields. Results are sorted by chainId then name for consistent ordering.

🤖 Generated with [Claude Code](https://claude.ai/code)