### PR TITLE
Add rollback function for stride management

### DIFF
--- a/packages/lib/strider.spec.ts
+++ b/packages/lib/strider.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai'
-import { add, contains, plan, remove } from './strider'
+import { add, contains, plan, remove, rollback } from './strider'
 
 describe.only('strider', function() {
   it('plans new strides', async function() {
@@ -47,5 +47,13 @@ describe.only('strider', function() {
     expect(contains({ from: 0n, to: 10n }, { from: 2n, to: 9n })).to.be.true
     expect(contains({ from: 0n, to: 10n }, { from: 11n, to: 12n })).to.be.false
     expect(contains({ from: 0n, to: 10n }, { from: 0n, to: 12n })).to.be.false
+  })
+
+  it.only('rolls back ending blocks', async function() {
+    expect(rollback([], 9n)).to.deep.equal([])
+    expect(rollback([{ from: 0n, to: 10n }], 9n)).to.deep.equal([{ from: 0n, to: 9n }])
+    expect(rollback([{ from: 0n, to: 4n }, { from: 6n, to: 10n }], 9n)).to.deep.equal([{ from: 0n, to: 4n }, { from: 6n, to: 9n }])
+    expect(rollback([{ from: 0n, to: 10n }], 11n)).to.deep.equal([{ from: 0n, to: 10n }])
+    expect(rollback([{ from: 0n, to: 4n }, { from: 6n, to: 10n }], 11n)).to.deep.equal([{ from: 0n, to: 4n }, { from: 6n, to: 10n }])
   })
 })

--- a/packages/lib/strider.ts
+++ b/packages/lib/strider.ts
@@ -105,3 +105,22 @@ export function remove(stride: Stride, strides: Stride[] | undefined): Stride[] 
 export function contains(a: Stride, b: Stride) {
   return a.from <= b.from && a.to >= b.to
 }
+
+export function rollback(strides: Stride[], endBlock: bigint): Stride[] {
+  if (!strides || strides.length === 0) return []
+
+  // Find the last stride
+  const sorted = [...strides].sort((a, b) => Number(a.from - b.from))
+  const lastStride = sorted[sorted.length - 1]
+
+  // If the last stride ends after endBlock, truncate it
+  if (lastStride.to > endBlock) {
+    return [
+      ...sorted.slice(0, -1),
+      { from: lastStride.from, to: endBlock }
+    ]
+  }
+
+  // Otherwise return strides as-is
+  return sorted
+}

--- a/packages/scripts/src/rollback-strides-5a88a2a.ts
+++ b/packages/scripts/src/rollback-strides-5a88a2a.ts
@@ -1,0 +1,140 @@
+/**
+ * Rollback evmlog_strides to commit 5a88a2a (2025-10-25 18:12:11 -0400)
+ *
+ * This script rolls back the indexed block ranges to a specific point in time.
+ * Block numbers were obtained from DeFiLlama API for the target timestamp: 1761430331
+ *
+ */
+
+import 'lib/global'
+import { Pool } from 'pg'
+import { rollback } from 'lib/strider'
+
+// Target blocks for each chain at the rollback timestamp
+const ROLLBACK_TARGETS = {
+  1: 23657375n,      // mainnet
+  10: 142915777n,    // optimism
+  100: 42812735n,    // gnosis
+  137: 78162752n,    // polygon
+  146: 51872687n,    // sonic
+  250: 117399886n,   // fantom
+  8453: 37320492n,   // base
+  42161: 393385831n, // arbitrum
+  80094: 12260847n,  // bera
+} as const
+
+type ChainId = keyof typeof ROLLBACK_TARGETS
+
+const CHAIN_NAMES: Record<ChainId, string> = {
+  1: 'mainnet',
+  10: 'optimism',
+  100: 'gnosis',
+  137: 'polygon',
+  146: 'sonic',
+  250: 'fantom',
+  8453: 'base',
+  42161: 'arbitrum',
+  80094: 'bera',
+}
+
+interface StrideRow {
+  chain_id: number
+  address: string
+  strides: string
+}
+
+interface Stride {
+  from: bigint
+  to: bigint
+}
+
+async function main() {
+  const pool = new Pool({
+    host: process.env.POSTGRES_HOST ?? 'localhost',
+    port: (process.env.POSTGRES_PORT ?? 5432) as number,
+    ssl: (process.env.POSTGRES_SSL ?? false)
+      ? (process.env.POSTGRES_SSL_REJECT_UNAUTHORIZED ?? true)
+        ? true
+        : { rejectUnauthorized: false }
+      : false,
+    database: process.env.POSTGRES_DATABASE ?? 'user',
+    user: process.env.POSTGRES_USER ?? 'user',
+    password: process.env.POSTGRES_PASSWORD ?? 'password',
+  })
+
+  console.log('🔍 Checking which addresses will be affected...\n')
+
+  // Compute affected addresses for all chains
+  const affectedByChain = new Map<ChainId, Array<{ address: string, strides: Stride[], rolledback: Stride[] }>>()
+
+  for (const [chainId, targetBlock] of Object.entries(ROLLBACK_TARGETS)) {
+    const chain = Number(chainId) as ChainId
+    const result = await pool.query<StrideRow>(
+      'SELECT chain_id, address, strides FROM evmlog_strides WHERE chain_id = $1',
+      [chain]
+    )
+
+    const affected: Array<{ address: string, strides: Stride[], rolledback: Stride[] }> = []
+
+    for (const row of result.rows) {
+      const strides: Stride[] = JSON.parse(row.strides)
+      const rolledback = rollback(strides, targetBlock)
+
+      // Only include if rollback changes something
+      if (JSON.stringify(strides) !== JSON.stringify(rolledback)) {
+        affected.push({ address: row.address, strides, rolledback })
+      }
+    }
+
+    affectedByChain.set(chain, affected)
+
+    if (affected.length > 0) {
+      console.log(`📌 ${CHAIN_NAMES[chain]} (${chain}): ${affected.length} addresses will be rolled back to block ${targetBlock}`)
+      console.log(`   First few: ${affected.slice(0, 3).map(a => a.address).join(', ')}${affected.length > 3 ? '...' : ''}`)
+    } else {
+      console.log(`✅ ${CHAIN_NAMES[chain]} (${chain}): No addresses need rollback`)
+    }
+  }
+
+  console.log('\n❓ Do you want to proceed? (Ctrl+C to cancel, Enter to continue)')
+  await new Promise(resolve => {
+    process.stdin.once('data', resolve)
+  })
+
+  console.log('\n🔄 Starting rollback...\n')
+
+  let totalUpdated = 0
+
+  for (const [chainId] of Object.entries(ROLLBACK_TARGETS)) {
+    const chain = Number(chainId) as ChainId
+    const affected = affectedByChain.get(chain) ?? []
+
+    if (affected.length === 0) continue
+
+    for (const { address, strides, rolledback } of affected) {
+      const rolledbackStridesJson = rolledback.map(s => ({
+        from: s.from.toString(),
+        to: s.to.toString()
+      }))
+
+      await pool.query(
+        'UPDATE evmlog_strides SET strides = $1 WHERE chain_id = $2 AND address = $3',
+        [JSON.stringify(rolledbackStridesJson), chain, address]
+      )
+
+      console.log(`  ✓ ${CHAIN_NAMES[chain]}: ${address} (${strides.length} → ${rolledback.length} strides)`)
+    }
+
+    console.log(`\n✅ ${CHAIN_NAMES[chain]}: Updated ${affected.length} addresses\n`)
+    totalUpdated += affected.length
+  }
+
+  console.log(`\n🎉 Rollback complete! Updated ${totalUpdated} total addresses.`)
+
+  await pool.end()
+}
+
+main().catch(err => {
+  console.error('❌ Error:', err)
+  process.exit(1)
+})


### PR DESCRIPTION

Changes

- New function: rollback() in packages/lib/strider.ts - Utility function to truncate stride ranges to a specified end block

- New script: packages/scripts/src/rollback-strides-5a88a2a.ts - Rolls back stride data to block heights corresponding to the timestamp of commit 5a88a2a (maintenance update that introduced am abi filtering bug)

Implementation Details

The rollback() function in the strider library truncates the last stride in a set if it extends beyond a specified block number, enabling precise temporal rollbacks of indexed data.

Use Case

This allows resetting the indexer state to a known good point in time, useful for recovering from indexing errors or testing changes against historical data.