### PR TITLE
Fix monitor resolver to handle empty table gracefully

### DIFF
--- a/packages/web/app/api/gql/resolvers/monitor.ts
+++ b/packages/web/app/api/gql/resolvers/monitor.ts
@@ -4,8 +4,15 @@ const monitor = async () => {
   try {
     const query = 'SELECT latest FROM monitor;'
     const [singleton] = (await db.query(query)).rows
-    return { 
-      ...singleton.latest, 
+
+    // Guard against empty table - return null to let frontend use defaults
+    if (!singleton || !singleton.latest) {
+      console.warn('Monitor table is empty or has no data')
+      return null
+    }
+
+    return {
+      ...singleton.latest,
       indexStatsJson: JSON.stringify(singleton.latest.indexStats)
     }
   } catch (error) {

--- a/packages/web/hooks/useData/index.tsx
+++ b/packages/web/hooks/useData/index.tsx
@@ -78,9 +78,15 @@ export default function DataProvider({ children }: { children: ReactNode }) {
   )
 
   useEffect(() => {
+    // Filter out null values from GraphQL response to preserve defaults
+    const responseData = status?.data || {}
+    const filteredData = Object.fromEntries(
+      Object.entries(responseData).filter(([_, value]) => value !== null)
+    )
+
     const update = DataContextSchema.parse({
       ...DEFAULT_CONTEXT,
-      ...status?.data
+      ...filteredData
     })
     setData(update)
   }, [status, setData])


### PR DESCRIPTION
Adds null guards to prevent crashes when monitor table is empty or unpopulated. The resolver now returns null when no data exists, and the frontend filters out null values to preserve default context values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)