### PR TITLE
fix: add vault address to strategy resolvers

### DIFF
--- a/packages/web/app/api/gql/resolvers/strategies.ts
+++ b/packages/web/app/api/gql/resolvers/strategies.ts
@@ -11,18 +11,30 @@ const strategies = async (_: object, args: { chainId?: number, apiVersion?: stri
       thing.address,
       thing.defaults,
       snapshot.snapshot,
-      snapshot.hook
+      snapshot.hook,
+      (
+        SELECT vault_snapshot.address
+        FROM snapshot AS vault_snapshot
+        JOIN thing AS vault_thing
+          ON vault_thing.chain_id = vault_snapshot.chain_id
+          AND vault_thing.address = vault_snapshot.address
+        WHERE vault_thing.label = 'vault'
+          AND vault_thing.chain_id = thing.chain_id
+          AND vault_snapshot.snapshot->'get_default_queue' @> jsonb_build_array(thing.address)
+        LIMIT 1
+      ) AS vault
     FROM thing
     JOIN snapshot
       ON thing.chain_id = snapshot.chain_id
       AND thing.address = snapshot.address
     WHERE thing.label = $1 AND (thing.chain_id = $2 OR $2 IS NULL)
-    ORDER BY snapshot.hook->>'totalDebtUsd' DESC`,
+    ORDER BY snapshot.hook->>'totalDebtUsd' DESC NULLS LAST`,
     ['strategy', chainId])
 
     let rows = result.rows.map(row => ({
       chainId: row.chain_id,
       address: row.address,
+      vault: row.vault,
       ...row.defaults,
       ...row.snapshot,
       ...row.hook
@@ -43,8 +55,8 @@ const strategies = async (_: object, args: { chainId?: number, apiVersion?: stri
     return rows
 
   } catch (error) {
-    console.error(error)
-    throw new Error('!strategies')
+    console.error('Strategies query error:', error)
+    throw error
   }
 }
 


### PR DESCRIPTION
> **Why this exists**

### Summary

During ydaemon integration of kong i've found out that during strategies query the vault field wasn't being populated correctly leading to unexpected behaviors.

<img width="1280" height="384" alt="image" src="https://github.com/user-attachments/assets/b50c5803-986b-4a58-b753-a423129e2c14" />


### How to review

1. run graphql api against any populated db
2. run:
```
query Strategies($chainId: Int) {
  strategies(chainId: $chainId) {
    vault
    name
  }
}
```

you should see: 
<img width="1592" height="1549" alt="image" src="https://github.com/user-attachments/assets/ebbc75d1-08d4-4ba6-95f7-e1af45930733" />


### Test plan
- [ ] Manual: <steps, special cases, environment, etc>
- [ ] Automated (when applicable): <tests run / commands>

### Risk / impact
<Any risky areas (funds, auth, migrations, rate limits)?
Any feature flags, kill switches, or easy rollback steps?>