### PR TITLE
Add safe normalization for tvl-c asset components

### DIFF
--- a/packages/ingest/abis/yearn/lib/tvl.ts
+++ b/packages/ingest/abis/yearn/lib/tvl.ts
@@ -4,7 +4,7 @@ import { fetchErc20PriceUsd } from '../../../prices'
 import { rpcs } from '../../../rpcs'
 import { parseAbi } from 'viem'
 import { compare } from 'compare-versions'
-import { priced } from 'lib/math'
+import { normalize, priced } from 'lib/math'
 import { extractWithdrawalQueue } from '../2/vault/snapshot/hook'
 import { Data } from '../../../extract/timeseries'
 import { estimateHeight, getBlock } from 'lib/blocks'
@@ -42,10 +42,10 @@ export default async function _process(chainId: number, address: `0x${string}`, 
       component: 'delegated', value: delegatedTvl
     }, {
       chainId, address, blockNumber, blockTime: data.blockTime, label: data.outputLabel,
-      component: 'totalAssets', value: totalAssets
+      component: 'totalAssets', value: normalize(totalAssets, vault.defaults.decimals) || 0
     }, {
       chainId, address, blockNumber, blockTime: data.blockTime, label: data.outputLabel,
-      component: 'delegatedAssets', value: delegatedAssets
+      component: 'delegatedAssets', value: normalize(delegatedAssets, vault.defaults.decimals) || 0
     }, {
       chainId, address, blockNumber, blockTime: data.blockTime, label: data.outputLabel,
       component: 'priceUsd', value: priceUsd

--- a/packages/lib/math.ts
+++ b/packages/lib/math.ts
@@ -22,6 +22,11 @@ export function max(...args: bigint[]): bigint {
   return args.reduce((a, b) => (a > b ? a : b))
 }
 
+export function normalize(value: bigint | undefined, decimals: number | undefined, precision: number = 18): number | undefined {
+  if (value === undefined || decimals === undefined) { return undefined }
+  return scaleDown(value, decimals, precision)
+}
+
 export function scaleDown(value: bigint, decimals: number, precision: number = 18): number {
   const factor = BigInt(10 ** precision)
   return Number(value * factor / BigInt(10 ** decimals)) / Number(factor)


### PR DESCRIPTION
### Summary
Fixe bug where totalAssets and delegatedAssets components were always saved as 0. Output values should be normalized to decimal numbers before storage. Adds normalize() helper that safely handles undefined values during conversion.

### How to review
Verify that tvl-c assets output values are correctly stored and retrieved.

### Test plan
- [ ] load the DAI testcase (copypaste `config/testcases/dai.manuals.yaml` to `config/manuals.local.yaml` and `config/testcases/dai.abis.yaml` to `config/abis.local.yaml`)
- [ ] set config/chains.local.yaml to only mainnet
- [ ] run indexer, `make dev`
- [ ] in kong terminal: Ingest, extract manuals (instant)
- [ ] in kong terminal: Ingest, fanout abis
- [ ] wait for all jobs to finish (seconds)
- [ ] browse localhost:3001/api/gql
- [ ] verify DAI's tvl-c series has assets > 0

```

{
  timeseries(
    label: "tvl-c"
    chainId: 1
    address: "0xdA816459F1AB5631232FE5e97a05BBBb94970c95"
    limit: 1000
    component: "totalAssets"
  ) {
    chainId
    address
    label
    component
    time
    value
  }
}

```

### Risk / impact
Minimal
