### PR TITLE
Pin nextjs to 15.3.6 for CVE-2025-66478

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -23,7 +23,7 @@
     "framer-motion": "^10.16.1",
     "graphql": "^16.8.1",
     "graphql-tag": "^2.12.6",
-    "next": "^15.3.2",
+    "next": "15.3.6",
     "pg": "^8.11.3",
     "postcss": "8.4.28",
     "pretty-bytes": "^6.1.1",


### PR DESCRIPTION
https://react.dev/blog/2025/12/03/critical-security-vulnerability-in-react-server-components

