### PR TITLE
feat: add apr-oracle to timeseries rest api

### DIFF
--- a/.github/workflows/timeseries-refresh.yml
+++ b/.github/workflows/timeseries-refresh.yml
@@ -21,5 +21,6 @@ jobs:
           POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
           POSTGRES_PORT: ${{ secrets.POSTGRES_PORT }}
           POSTGRES_SSL: ${{ secrets.POSTGRES_SSL }}
+          POSTGRES_POOL_MAX: ${{ vars.POSTGRES_POOL_MAX }}
           REST_CACHE_REDIS_URL: ${{ secrets.REST_CACHE_REDIS_URL }}
         run: bun packages/web/app/api/rest/timeseries/refresh-timeseries.ts

--- a/packages/web/app/api/db/index.ts
+++ b/packages/web/app/api/db/index.ts
@@ -12,7 +12,7 @@ const db = new Pool({
   database: process.env.POSTGRES_DATABASE ?? 'user',
   user: process.env.POSTGRES_USER ?? 'user',
   password: process.env.POSTGRES_PASSWORD ?? 'password',
-  max: 4,
+  max: parseInt(process.env.POSTGRES_POOL_MAX ?? '4', 10),
   idleTimeoutMillis: 60_000,
   connectionTimeoutMillis: 5_000,
 })

--- a/packages/web/app/api/rest/timeseries/labels.ts
+++ b/packages/web/app/api/rest/timeseries/labels.ts
@@ -16,6 +16,11 @@ export const labels: TimeseriesLabel[] = [
     defaultComponent: 'net',
   },
   {
+    label: 'apr-oracle',
+    segment: 'apr-oracle',
+    defaultComponent: 'apr',
+  },
+  {
     label: 'tvl-c',
     segment: 'tvl',
     defaultComponent: 'tvl',


### PR DESCRIPTION
> **Why this exists**
> Clear, minimal context makes reviews fast.
> Tell the reviewer exactly how to validate your work so they can approve it quickly without guesswork.

### Summary
Add support for apr-oracle to timeseries rest api

### How to review
```
cd packages/web

bun app/api/rest/timeseries/refresh-timeseries.ts

curl 'http://localhost:3000/api/rest/timeseries/apr-oracle/1/0x140d0d77eec240f9d3a07c92df37e257cf506081'
```

# Test results
<img width="2518" height="958" alt="CleanShot 2025-12-23 at 17 30 41@2x" src="https://github.com/user-attachments/assets/1aa23bae-1ed9-46b1-bac4-561bba271eac" />
