### PR TITLE
Make max db pool configurable, increase default max db pool

### DIFF
--- a/packages/web/app/api/db/index.ts
+++ b/packages/web/app/api/db/index.ts
@@ -12,7 +12,7 @@ const db = new Pool({
   database: process.env.POSTGRES_DATABASE ?? 'user',
   user: process.env.POSTGRES_USER ?? 'user',
   password: process.env.POSTGRES_PASSWORD ?? 'password',
-  max: 4,
+  max: parseInt(process.env.POSTGRES_POOL_MAX ?? '4', 10),
   idleTimeoutMillis: 60_000,
   connectionTimeoutMillis: 5_000,
 })


### PR DESCRIPTION
### Summary
Max db pool size was hardcoded to 4. This was causing timeouts under load. Our current db host supports 10k concurrent connections. This makes max pool size configurable and doubles the default size to 8. In production we'll use something higher.

Error:
```
~/git/kong/packages/web bun app/api/rest/timeseries/refresh-timeseries.ts
Fetching vaults...
Found 1971 vaults (batch size: 10)
40 |     res = resolve
41 |     rej = reject
42 |   }).catch((err) => {
43 |     // replace the stack trace that leads to `TCP.onStreamRead` with one that leads back to the
44 |     // application that created the query
45 |     Error.captureStackTrace(err)
               ^
error: timeout exceeded when trying to connect
      at <anonymous> (/home/murdertxxth/git/kong/node_modules/pg-pool/index.js:45:11) 
```

### How to review

```
docker run --rm -p 6379:6379 redis:latest
```

```
cd packages/web
bun app/api/rest/timeseries/refresh-timeseries.ts
```

```
curl 'http://localhost:3000/api/rest/timeseries/apr-oracle/1/0x140d0d77eec240f9d3a07c92df37e257cf506081'
```

### Risk / impact
This will create higher amplitude spikes in read load on the db. Should not be a problem.
