### PR TITLE
feat: add snapshot edge api

### DIFF
--- a/.github/workflows/snapshot-refresh.yml
+++ b/.github/workflows/snapshot-refresh.yml
@@ -1,0 +1,26 @@
+name: snapshot-refresh
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v1
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Refresh snapshot cache
+        env:
+          POSTGRES_HOST: ${{ secrets.POSTGRES_HOST }}
+          POSTGRES_DATABASE: ${{ secrets.POSTGRES_DATABASE }}
+          POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+          POSTGRES_PORT: ${{ secrets.POSTGRES_PORT }}
+          POSTGRES_SSL: ${{ secrets.POSTGRES_SSL }}
+          POSTGRES_POOL_MAX: ${{ vars.POSTGRES_POOL_MAX }}
+          REST_CACHE_REDIS_URL: ${{ secrets.REST_CACHE_REDIS_URL }}
+        run: bun packages/web/app/api/rest/snapshot/refresh-snapshot.ts

--- a/packages/lib/subscriptions.ts
+++ b/packages/lib/subscriptions.ts
@@ -16,7 +16,7 @@ export const WebhookSubscriptionSchema = z.object({
   url: z.string().url(),
   abiPath: z.string(),
   type: z.enum(['timeseries']),
-  label: z.string(),
+  labels: z.array(z.string()),
   filter: WebhookFilterSchema.optional()
 })
 

--- a/packages/lib/subscriptions.ts
+++ b/packages/lib/subscriptions.ts
@@ -16,7 +16,7 @@ export const WebhookSubscriptionSchema = z.object({
   url: z.string().url(),
   abiPath: z.string(),
   type: z.enum(['timeseries']),
-  labels: z.array(z.string()),
+  label: z.string(),
   filter: WebhookFilterSchema.optional()
 })
 

--- a/packages/web/app/api/rest/snapshot/[chainId]/[address]/route.ts
+++ b/packages/web/app/api/rest/snapshot/[chainId]/[address]/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createSnapshotKeyv, getSnapshotKey } from '../../redis'
+import type { VaultSnapshot } from '../../db'
+
+export const runtime = 'nodejs'
+
+type RouteParams = {
+  chainId?: string | string[]
+  address?: string | string[]
+}
+
+const corsHeaders = {
+  'access-control-allow-origin': '*',
+  'access-control-allow-methods': 'GET,OPTIONS',
+}
+
+const snapshotKeyv = createSnapshotKeyv()
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<RouteParams> },
+) {
+  const { chainId, address } = (await context.params) ?? {}
+
+  if (
+    typeof chainId !== 'string' ||
+    typeof address !== 'string'
+  ) {
+    return new NextResponse('Invalid params', { status: 400, headers: corsHeaders })
+  }
+
+  const addressLower = address.toLowerCase()
+  const cacheKey = getSnapshotKey(Number(chainId), addressLower)
+  let cached: string | undefined
+  try {
+    cached = await snapshotKeyv.get(cacheKey)
+  } catch (err) {
+    console.error(`Redis read failed for ${cacheKey}:`, err)
+    throw err
+  }
+
+  if (!cached) {
+    return new NextResponse('Not found', { status: 404, headers: corsHeaders })
+  }
+
+  const parsed: VaultSnapshot = JSON.parse(cached as string)
+
+  return NextResponse.json(parsed, {
+    status: 200,
+    headers: {
+      'cache-control': 'public, max-age=900, s-maxage=900, stale-while-revalidate=600',
+      ...corsHeaders,
+    },
+  })
+}
+
+export function OPTIONS() {
+  return new NextResponse(null, { status: 204, headers: corsHeaders })
+}

--- a/packages/web/app/api/rest/snapshot/db.ts
+++ b/packages/web/app/api/rest/snapshot/db.ts
@@ -1,0 +1,74 @@
+import db from '../../db'
+import { getAddress } from 'viem'
+
+export type VaultRow = {
+  chainId: number
+  address: string
+}
+
+export type VaultSnapshot = {
+  chainId: number
+  address: string
+  [key: string]: unknown
+}
+
+/**
+ * Get all vaults
+ * Used by refresh workflow to iterate over all vaults
+ *
+ * @returns All vaults with chainId and address
+ */
+export async function getVaults(): Promise<VaultRow[]> {
+  const result = await db.query(`
+    SELECT DISTINCT
+      chain_id AS "chainId",
+      address
+    FROM thing
+    WHERE label = 'vault'
+    ORDER BY chain_id, address
+  `)
+
+  return result.rows as VaultRow[]
+}
+
+/**
+ * Get vault snapshot (same query as GraphQL vault resolver)
+ * Combines thing.defaults, snapshot.snapshot, and snapshot.hook
+ *
+ * @param chainId - Chain ID
+ * @param address - Vault address
+ * @returns Vault snapshot object or null if not found
+ */
+export async function getVaultSnapshot(
+  chainId: number,
+  address: string
+): Promise<VaultSnapshot | null> {
+  const result = await db.query(`
+    SELECT
+      thing.chain_id AS "chainId",
+      thing.address,
+      thing.defaults,
+      snapshot.snapshot,
+      snapshot.hook
+    FROM thing
+    JOIN snapshot
+      ON thing.chain_id = snapshot.chain_id
+      AND thing.address = snapshot.address
+    WHERE thing.chain_id = $1
+      AND thing.address = $2
+      AND thing.label = $3
+  `, [chainId, getAddress(address as `0x${string}`), 'vault'])
+
+  if (result.rows.length === 0) {
+    return null
+  }
+
+  const row = result.rows[0]
+  return {
+    chainId: row.chainId,
+    address: row.address,
+    ...row.defaults,
+    ...row.snapshot,
+    ...row.hook
+  }
+}

--- a/packages/web/app/api/rest/snapshot/redis.ts
+++ b/packages/web/app/api/rest/snapshot/redis.ts
@@ -1,0 +1,13 @@
+import { createKeyv } from '@keyv/redis'
+
+export function createSnapshotKeyv() {
+  const redisUrl = process.env.REST_CACHE_REDIS_URL || 'redis://localhost:6379'
+  return createKeyv(redisUrl)
+}
+
+export function getSnapshotKey(
+  chainId: number,
+  address: string,
+): string {
+  return `snapshot:${chainId}:${address.toLowerCase()}`
+}

--- a/packages/web/app/api/rest/snapshot/refresh-snapshot.ts
+++ b/packages/web/app/api/rest/snapshot/refresh-snapshot.ts
@@ -1,0 +1,52 @@
+import { getVaults, getVaultSnapshot } from './db'
+import { createSnapshotKeyv, getSnapshotKey } from './redis'
+
+const BATCH_SIZE = 10
+
+async function refresh(): Promise<void> {
+  console.time('refresh')
+  const keyv = createSnapshotKeyv()
+
+  console.log('Fetching vaults...')
+  const vaults = await getVaults()
+  console.log(`Found ${vaults.length} vaults (batch size: ${BATCH_SIZE})`)
+
+  let processed = 0
+
+  async function processVault(vault: { chainId: number; address: string }) {
+    const addressLower = vault.address.toLowerCase()
+
+    const snapshot = await getVaultSnapshot(vault.chainId, vault.address)
+
+    if (!snapshot) {
+      return
+    }
+
+    const cacheKey = getSnapshotKey(vault.chainId, addressLower)
+    await keyv.set(cacheKey, JSON.stringify(snapshot))
+
+    processed++
+    if (processed % 10 === 0) {
+      console.log(`Processed ${processed}/${vaults.length} vaults`)
+    }
+  }
+
+  for (let i = 0; i < vaults.length; i += BATCH_SIZE) {
+    const batch = vaults.slice(i, i + BATCH_SIZE)
+    await Promise.all(batch.map(processVault))
+  }
+
+  console.log(`✓ Completed: ${processed} vaults processed`)
+  console.timeEnd('refresh')
+}
+
+if (require.main === module) {
+  refresh()
+    .then(() => {
+      process.exit(0)
+    })
+    .catch(err => {
+      console.error(err)
+      process.exit(1)
+    })
+}


### PR DESCRIPTION
### Summary

Adds snapshot edge api, following the timeseries trend where make available much faster snapshot vault information


### Test plan
- Terminal 1 - Start Redis:

```
docker run --rm -p 6379:6379 redis:latest
```

# Leave this running

- Terminal 2 - Configure and start web app:

```
# Configure packages/web/.env.local
# Use kong's webops read replica for postgres (not localhost)
cat > packages/web/.env.local <<EOF
REST_CACHE_REDIS_URL=redis://localhost:6379
POSTGRES_HOST=<webops-read-replica-host>
POSTGRES_DATABASE=<database-name>
POSTGRES_USER=<username>
POSTGRES_PASSWORD=<password>
EOF
```

- Start the web app
```
cd packages/web
bun dev
```

# Leave this running

- Terminal 3 - Run scripts and test:

```
cd packages/web

# Run refresh to populate cache
bun app/api/rest/snapshot/refresh-15min.ts

# Test API endpoint
curl 'http://localhost:3000/api/rest/snapshot/1/0xBe53A109B494E5c9f97b9Cd39Fe969BE68BF6204'

# Test case-insensitive address lookup
curl 'http://localhost:3000/api/rest/snapshot/1/0xbe53a109b494e5c9f97b9cd39fe969be68bf6204'

# Test 404 for non-existent vault
curl 'http://localhost:3000/api/rest/snapshot/1/0x0000000000000000000000000000000000000000'
```


### e2e manual test
<img width="2080" height="888" alt="CleanShot 2026-01-05 at 12 23 18@2x" src="https://github.com/user-attachments/assets/6c4fbb15-b26c-436e-af7d-5f30af5babbd" />
