### PR TITLE
fix: migrate labels on subscriptions to be array

### DIFF
--- a/config/subscriptions.yaml
+++ b/config/subscriptions.yaml
@@ -3,7 +3,7 @@ subscriptions:
     url: 'https://kong.yearn.farm/api/webhook-healthcheck'
     abiPath: 'yearn/3/vault'
     type: 'timeseries'
-    label: 'webhook-healthcheck'
+    labels: ['webhook-healthcheck']
     filter:
       contracts:
         - chainId: 1
@@ -13,6 +13,6 @@ subscriptions:
     url: 'https://v2-estimated-apr-hook.vercel.app/webhook'
     abiPath: 'yearn/2/vault'
     type: 'timeseries'
-    label: 'crv-estimated-apr'
+    labels: ['crv-estimated-apr']
     filter:
       chains: [1, 10, 250, 42161]

--- a/config/subscriptions.yaml
+++ b/config/subscriptions.yaml
@@ -13,6 +13,6 @@ subscriptions:
     url: 'https://v2-estimated-apr-hook.vercel.app/webhook'
     abiPath: 'yearn/2/vault'
     type: 'timeseries'
-    labels: ['crv-estimated-apr']
+    labels: ['crv-estimated-apr', 'aero-estimated-apr', 'velodrome-estimated-apr']
     filter:
       chains: [1, 10, 250, 42161]

--- a/packages/ingest/extract/webhook.ts
+++ b/packages/ingest/extract/webhook.ts
@@ -61,7 +61,7 @@ export class WebhookExtractor {
     await semaphore.acquire()
 
     try {
-      const label = `🔌 ${mq.job.extract.webhook.name} ${subscription.id} ${subscription.url} ${subscription.label}`
+      const label = `🔌 ${mq.job.extract.webhook.name} ${subscription.id} ${subscription.url} ${subscription.labels.join(', ')}`
       console.time(label)
       const response = await fetchResponse(subscription, data)
       console.timeEnd(label)
@@ -73,8 +73,8 @@ export class WebhookExtractor {
       const body = await response.json()
       const outputs = OutputSchema.array().parse(body)
 
-      if (outputs.some(output => output.label !== subscription.label)) {
-        throw new Error(`Unexpected labels. Expected: ${subscription.label}, Got: ${outputs.map(output => output.label).join(', ')}`)
+      if (outputs.some(output => !subscription.labels.includes(output.label))) {
+        throw new Error(`Unexpected labels. Expected one of: ${subscription.labels.join(', ')}, Got: ${outputs.map(output => output.label).join(', ')}`)
       }
 
       const MAX_OUTPUTS = 20

--- a/packages/lib/subscriptions.ts
+++ b/packages/lib/subscriptions.ts
@@ -16,7 +16,7 @@ export const WebhookSubscriptionSchema = z.object({
   url: z.string().url(),
   abiPath: z.string(),
   type: z.enum(['timeseries']),
-  label: z.string(),
+  labels: z.array(z.string()),
   filter: WebhookFilterSchema.optional()
 })
 


### PR DESCRIPTION
### **Why this exists**
v2-apr service was in the need to provide multiple labels, for the same domain of info.


### Summary
Converts the label array into labels for the hook subscription configuration

### Risk / impact
None, given the requester will send label in singular, of which will be made the checks inside kong.