### PR TITLE
Fix subscription filter key from chains to chainIds

### DIFF
--- a/config/subscriptions.yaml
+++ b/config/subscriptions.yaml
@@ -15,4 +15,4 @@ subscriptions:
     type: 'timeseries'
     labels: ['crv-estimated-apr', 'aero-estimated-apr', 'velodrome-estimated-apr']
     filter:
-      chains: [1, 10, 250, 42161]
+      chainIds: [1, 10, 250, 42161]


### PR DESCRIPTION
Fixed typo in subscription filter config: `chains` → `chainIds`. The schema expects `chainIds` but the config used `chains`, causing the filter to be silently ignored and the webhook to fire for all chains instead of just [1, 10, 250, 42161].

### How to review
- `config/subscriptions.yaml:18` - the one-line fix
- `packages/lib/subscriptions.ts:7` - shows the schema expects `chainIds`

### Test plan
- [x ] Manual: Verify webhook only fires for v2 vaults on chains 1, 10, 250, 42161

### Risk / impact
Low risk. Previously the webhook was firing for all chains (unintended). Now it will only fire for the intended chains.