### PR TITLE
fix: force refresh-lists workflow scheduler re-registration

### DIFF
--- a/.github/workflows/refresh-lists.yml
+++ b/.github/workflows/refresh-lists.yml
@@ -1,5 +1,6 @@
 name: refresh-lists
 
+# Trigger scheduler re-registration
 on:
   schedule:
     - cron: '*/15 * * * *'


### PR DESCRIPTION
Add comment to trigger GitHub Actions to re-parse workflow and register cron schedule


ps: some people around internet says it works, ill give it a try