### PR TITLE
feat: enhance vault list edge api

### DIFF
--- a/packages/web/app/api/rest/lists/db.ts
+++ b/packages/web/app/api/rest/lists/db.ts
@@ -82,9 +82,9 @@ export async function getVaultsList(): Promise<VaultListItem[]> {
 
       -- Name with fallback
       COALESCE(
+        thing.defaults->>'name',
         snapshot.snapshot->>'name',
         snapshot.hook->'meta'->>'displayName',
-        thing.defaults->>'name'
       ) AS name,
 
       -- Symbol
@@ -101,8 +101,8 @@ export async function getVaultsList(): Promise<VaultListItem[]> {
 
       -- Decimals
       COALESCE(
+        (thing.defaults->>'decimals')::int,
         (snapshot.snapshot->>'decimals')::int,
-        (thing.defaults->>'decimals')::int
       ) AS decimals,
 
       -- Asset

--- a/packages/web/app/api/rest/lists/db.ts
+++ b/packages/web/app/api/rest/lists/db.ts
@@ -2,35 +2,136 @@ import db from '../../db'
 import { z } from 'zod'
 
 export const VaultListItemSchema = z.object({
+  // Core identification
   chainId: z.number(),
   address: z.string(),
   name: z.string(),
+  symbol: z.string().nullable(),
+  apiVersion: z.string().nullable(),
+  decimals: z.number().nullable(),
+
+  // Asset info
+  asset: z.object({
+    address: z.string(),
+    name: z.string(),
+    symbol: z.string(),
+    decimals: z.number(),
+  }).nullable(),
+
+  // Financial metrics
+  tvl: z.number().nullable(), // USD value
+  apy: z.number().nullable(), // Net APY as decimal
+
+  // Fees (basis points)
+  fees: z.object({
+    management: z.number(),
+    performance: z.number(),
+  }).nullable(),
+
+  // Classification
+  category: z.string().nullable(),
+  type: z.string().nullable(), // 'Yearn Vault', 'Automated', etc
+  kind: z.string().nullable(), // 'Multi Strategy', 'Single Strategy'
+
+  // Flags
+  v3: z.boolean(),
+  yearn: z.boolean(),
+  isRetired: z.boolean(),
+  isHidden: z.boolean(),
+  isBoosted: z.boolean(),
+  isHighlighted: z.boolean(),
+
+  // Strategies
+  strategiesCount: z.number(),
+
+  // Risk
+  riskLevel: z.number().nullable(),
 })
 
 export type VaultListItem = z.infer<typeof VaultListItemSchema>
 
 /**
- * Get all vaults with basic info for listing
+ * Get all vaults with expanded metadata for listing
  * Uses Zod to ensure only specified fields are returned
  *
- * @returns All vaults with chainId, address, and name
+ * @returns All vaults with rich metadata
  */
 export async function getVaultsList(): Promise<VaultListItem[]> {
   const result = await db.query(`
     SELECT DISTINCT
       thing.chain_id AS "chainId",
       thing.address,
+
+      -- Name with fallback
       COALESCE(
+        snapshot.hook->'meta'->>'displayName',
         thing.defaults->>'name',
-        snapshot.snapshot->>'name',
-        snapshot.hook->>'name'
-      ) AS name
+        snapshot.snapshot->>'name'
+      ) AS name,
+
+      -- Symbol
+      COALESCE(
+        snapshot.hook->'meta'->>'displaySymbol',
+        snapshot.snapshot->>'symbol'
+      ) AS symbol,
+
+      -- Version
+      COALESCE(
+        thing.defaults->>'apiVersion',
+        snapshot.snapshot->>'apiVersion'
+      ) AS "apiVersion",
+
+      -- Decimals
+      COALESCE(
+        (thing.defaults->>'decimals')::int,
+        (snapshot.snapshot->>'decimals')::int
+      ) AS decimals,
+
+      -- Asset (as JSON object)
+      jsonb_build_object(
+        'address', snapshot.hook->'asset'->>'address',
+        'name', snapshot.hook->'asset'->>'name',
+        'symbol', snapshot.hook->'asset'->>'symbol',
+        'decimals', (snapshot.hook->'asset'->>'decimals')::int
+      ) AS asset,
+
+      -- TVL (USD)
+      (snapshot.hook->'tvl'->>'close')::numeric AS tvl,
+
+      -- APY (net)
+      (snapshot.hook->'apy'->>'net')::numeric AS apy,
+
+      -- Fees
+      jsonb_build_object(
+        'management', COALESCE((snapshot.hook->'fees'->>'managementFee')::int, 0),
+        'performance', COALESCE((snapshot.hook->'fees'->>'performanceFee')::int, 0)
+      ) AS fees,
+
+      -- Classification
+      snapshot.hook->'meta'->>'category' AS category,
+      snapshot.hook->'meta'->>'type' AS type,
+      snapshot.hook->'meta'->>'kind' AS kind,
+
+      -- Flags
+      COALESCE((thing.defaults->>'v3')::boolean, false) AS v3,
+      COALESCE((thing.defaults->>'yearn')::boolean, false) AS yearn,
+      COALESCE((snapshot.hook->'meta'->>'isRetired')::boolean, false) AS "isRetired",
+      COALESCE((snapshot.hook->'meta'->>'isHidden')::boolean, false) AS "isHidden",
+      COALESCE((snapshot.hook->'meta'->>'isBoosted')::boolean, false) AS "isBoosted",
+      COALESCE((snapshot.hook->'meta'->>'isHighlighted')::boolean, false) AS "isHighlighted",
+
+      -- Strategies count
+      COALESCE(jsonb_array_length(snapshot.hook->'strategies'), 0) AS "strategiesCount",
+
+      -- Risk
+      (snapshot.hook->'risk'->>'riskLevel')::int AS "riskLevel"
+
     FROM thing
     LEFT JOIN snapshot
       ON thing.chain_id = snapshot.chain_id
       AND thing.address = snapshot.address
     WHERE thing.label = 'vault'
-    ORDER BY thing.chain_id, thing.address
+    ORDER BY (snapshot.hook->'tvl'->>'close')::double precision DESC NULLS LAST
   `)
 
   return z.array(VaultListItemSchema).parse(result.rows)

--- a/packages/web/app/api/rest/lists/db.ts
+++ b/packages/web/app/api/rest/lists/db.ts
@@ -82,15 +82,15 @@ export async function getVaultsList(): Promise<VaultListItem[]> {
 
       -- Name with fallback
       COALESCE(
+        snapshot.snapshot->>'name',
         snapshot.hook->'meta'->>'displayName',
-        thing.defaults->>'name',
-        snapshot.snapshot->>'name'
+        thing.defaults->>'name'
       ) AS name,
 
       -- Symbol
       COALESCE(
-        snapshot.hook->'meta'->>'displaySymbol',
-        snapshot.snapshot->>'symbol'
+        snapshot.snapshot->>'symbol',
+        snapshot.hook->'meta'->>'displaySymbol'
       ) AS symbol,
 
       -- Version

--- a/packages/web/app/api/rest/lists/db.ts
+++ b/packages/web/app/api/rest/lists/db.ts
@@ -84,7 +84,7 @@ export async function getVaultsList(): Promise<VaultListItem[]> {
       COALESCE(
         thing.defaults->>'name',
         snapshot.snapshot->>'name',
-        snapshot.hook->'meta'->>'displayName',
+        snapshot.hook->'meta'->>'displayName'
       ) AS name,
 
       -- Symbol
@@ -102,7 +102,7 @@ export async function getVaultsList(): Promise<VaultListItem[]> {
       -- Decimals
       COALESCE(
         (thing.defaults->>'decimals')::int,
-        (snapshot.snapshot->>'decimals')::int,
+        (snapshot.snapshot->>'decimals')::int
       ) AS decimals,
 
       -- Asset

--- a/packages/web/app/api/rest/lists/db.ts
+++ b/packages/web/app/api/rest/lists/db.ts
@@ -1,5 +1,5 @@
-import db from '../../db'
 import { z } from 'zod'
+import db from '../../db'
 
 const CoerceNumber = z.preprocess(
   (val) => (val === null || val === undefined) ? null : Number(val),
@@ -101,8 +101,8 @@ export async function getVaultsList(): Promise<VaultListItem[]> {
 
       -- Decimals
       COALESCE(
-        (thing.defaults->>'decimals')::int,
-        (snapshot.snapshot->>'decimals')::int
+        (snapshot.snapshot->>'decimals')::int,
+        (thing.defaults->>'decimals')::int
       ) AS decimals,
 
       -- Asset

--- a/packages/web/app/api/rest/lists/redis.ts
+++ b/packages/web/app/api/rest/lists/redis.ts
@@ -6,4 +6,3 @@ export function createListsKeyv(namespace?: string) {
     namespace,
   })
 }
-

--- a/packages/web/app/api/rest/lists/vaults/route.ts
+++ b/packages/web/app/api/rest/lists/vaults/route.ts
@@ -10,16 +10,16 @@ const corsHeaders = {
 }
 
 export async function GET() {
-  const keyv = createListsKeyv('list:vaults')
+  const listsKeyv = createListsKeyv('list:vaults')
 
   try {
-    if (!keyv.iterator) {
+    if (!listsKeyv.iterator) {
       return new NextResponse('Iterator not supported', { status: 500, headers: corsHeaders })
     }
 
     const allVaults: VaultListItem[] = []
 
-    for await (const [, value] of keyv.iterator(keyv.namespace)) {
+    for await (const [, value] of listsKeyv.iterator(listsKeyv.namespace)) {
       if (value) {
         try {
           const chainVaults: VaultListItem[] = JSON.parse(value)

--- a/packages/web/app/api/rest/lists/vaults/route.ts
+++ b/packages/web/app/api/rest/lists/vaults/route.ts
@@ -21,8 +21,12 @@ export async function GET() {
 
     for await (const [, value] of keyv.iterator(keyv.namespace)) {
       if (value) {
-        const chainVaults: VaultListItem[] = JSON.parse(value)
-        allVaults.push(...chainVaults)
+        try {
+          const chainVaults: VaultListItem[] = JSON.parse(value)
+          allVaults.push(...chainVaults)
+        } catch (e) {
+          console.error('Failed to parse vault list from Redis:', e)
+        }
       }
     }
 


### PR DESCRIPTION
## Summary                                                                                                                                                     

Enhanced the vault list API to return comprehensive metadata (40+ fields) including asset info, TVL, APY, fees, classification flags, strategies count, and risk levels. 

Previously only returned chainId, address, and name. Also added proper error handling and input validation to route handlers, and changed default sort order to TVL descending.                                                                                                                       
                                                                                                                                                              
## How to review                                                                                                                                               
1. Start with packages/web/app/api/rest/lists/db.ts: Review the expanded schema and SQL query to understand all new fields being returned                   
2. Check route handlers (vaults/route.ts and vaults/[chainId]/route.ts): Verify error handling for JSON parsing and chainId validation                      
3. Test the endpoints:                                                                                                                                      
	- GET /api/rest/lists/vaults - should return all vaults across chains with full metadata                                                                  
    - GET /api/rest/lists/vaults/1 - should return mainnet vaults with full metadata                                                                          
    - GET /api/rest/lists/vaults/invalid - should return 400 with proper error message                                                                        
                                                                                                                                                              
## Test plan                                                                                                                                                   
1. start the web server by running `cd packages/web && bun run dev`.                                                                                                                                                           

2. curl [http://localhost:3001/api/rest/lists/vaults](http://localhost:3001/api/rest/lists/vaults)

3. curl [http://localhost:3001/api/rest/lists/vaults/1](http://localhost:3001/api/rest/lists/vaults/1)



closes #300 