### PR TITLE
Replace confusing fail queue with per-queue error overlay

### DIFF
--- a/packages/web/components/AsciiMeter.tsx
+++ b/packages/web/components/AsciiMeter.tsx
@@ -16,7 +16,9 @@ export default function AsciiMeter(
     leftLabel = '',
     rightLabel = '',
     panels = 24,
-    className = ''
+    className = '',
+    errorCount,
+    errorMax
   } : {
     current: number,
     current2?: number,
@@ -24,7 +26,9 @@ export default function AsciiMeter(
     leftLabel?: string,
     rightLabel?: string,
     panels?: number,
-    className?: string
+    className?: string,
+    errorCount?: number,
+    errorMax?: number
   }
 ) {
   const meterRef = useRef<HTMLDivElement>(null)
@@ -46,9 +50,11 @@ export default function AsciiMeter(
   }, [panels])
 
   const hasTwo = current2 !== undefined
+  const hasError = errorCount !== undefined && errorMax !== undefined
   const maxPanels = useMemo(() => Math.round((max / max) * panels), [max, panels])
   const filledPanels = useMemo(() => Math.round((current / max) * panels), [current, max, panels])
   const filledPanels2 = useMemo(() => hasTwo ? Math.round((current2 / max) * panels) : 0, [hasTwo, current2, max, panels])
+  const errorPanels = useMemo(() => hasError ? Math.round((errorCount / errorMax) * panels) : 0, [hasError, errorCount, errorMax, panels])
 
   const title = useMemo(() => {
     return `${leftLabel} ${rightLabel}`
@@ -64,6 +70,11 @@ export default function AsciiMeter(
       <div className="text-emerald-950">
         {'░'.repeat(panels)}
       </div>
+      {hasError && errorPanels > 0 && (
+        <div className="absolute z-5 inset-0 text-red-500">
+          {'░'.repeat(Math.min(errorPanels, maxPanels))}
+        </div>
+      )}
       <div className="absolute z-10 inset-0 text-yellow-600">
         {'▒'.repeat(Math.min(filledPanels2, maxPanels))}
       </div>

--- a/packages/web/components/Evmlogs.tsx
+++ b/packages/web/components/Evmlogs.tsx
@@ -28,7 +28,7 @@ export default function Evmlogs() {
 
   return <div className={'w-full flex flex-col items-start'}>
     <div className="w-full flex items-center justify-between">
-      <div className="font-bold text-lg">Evmlogs</div>
+      <div id="evmlogs" className="font-bold text-lg">Evmlogs</div>
       <Frosty _key={`thing_total-${indexStats.evmlog_total}`} disabled={indexStats.evmlog_total < 1}>{formatLineItemValue(indexStats.evmlog_total)}</Frosty>
     </div>
 

--- a/packages/web/components/LatestBlocks.tsx
+++ b/packages/web/components/LatestBlocks.tsx
@@ -12,7 +12,7 @@ export default function LatestBlocks() {
     return data.latestBlocks.find(block => block.chainId === chainId)?.blockNumber.toString() || '--------'
   }, [data])
   return <div className={'w-full flex flex-col items-start'}>
-    <div className="font-bold text-xl">Latest Blocks</div>
+    <div id="latest-blocks" className="font-bold text-xl">Latest Blocks</div>
     {chains.map((chain, index) => <div key={chain.id} className="w-full flex items-center justify-between">
       <div className="text-yellow-700 whitespace-nowrap">{chain.name.toLowerCase()}</div>
       <Frosty _key={latestBlock(chain.id) as string}>{formatLineItemValue(Number(latestBlock(chain.id)))}</Frosty>

--- a/packages/web/components/MessageQueue.tsx
+++ b/packages/web/components/MessageQueue.tsx
@@ -1,9 +1,8 @@
 'use client'
 
 import { useData } from '@/hooks/useData'
-import { useMemo } from 'react'
+import { useSearchParams } from 'next/navigation'
 import AsciiMeter from './AsciiMeter'
-import { fPercent } from '@/lib/format'
 
 function formatNumber(value: number) {
   if (value < 1000) return String(value).padStart(3, '0')
@@ -14,28 +13,21 @@ function formatNumber(value: number) {
 
 export default function MessageQueue() {
   const { monitor } = useData()
-
-  const fails = useMemo(() => {
-    const max = 100 * monitor.queues.length
-    const current = monitor.queues.flatMap(queue => queue.failed).reduce((acc, curr) => acc + curr, 0)
-    return { max, current }
-  }, [monitor.queues])
+  const searchParams = useSearchParams()
+  const showErrors = searchParams.get('errors') === 'true'
 
   return <div className={'w-full flex flex-col gap-2'}>
     <div className="font-bold text-xl">Message Queue</div>
     <div className="flex flex-col gap-4">
-      {monitor.queues.filter(queue => queue.name !== 'extract').map((queue, index) => <AsciiMeter
+      {monitor.queues.filter(queue => queue.name !== 'extract').map((queue) => <AsciiMeter
         key={queue.name}
         current={queue.active}
         current2={queue.waiting}
         max={(queue.name.includes('-')) ? 50 : 400}
         leftLabel={queue.name}
-        rightLabel={`w ${formatNumber(queue.waiting)} / a ${formatNumber(queue.active)}`} />)}
-      <AsciiMeter
-        current={fails.current}
-        max={fails.max}
-        leftLabel='fail queue'
-        rightLabel={fPercent(fails.current / fails.max)} />
+        rightLabel={`w ${formatNumber(queue.waiting)} / a ${formatNumber(queue.active)}`}
+        errorCount={showErrors ? queue.failed : undefined}
+        errorMax={showErrors ? 100 : undefined} />)}
     </div>
   </div>
 }

--- a/packages/web/components/MessageQueue.tsx
+++ b/packages/web/components/MessageQueue.tsx
@@ -2,6 +2,7 @@
 
 import { useData } from '@/hooks/useData'
 import { useSearchParams } from 'next/navigation'
+import { Suspense } from 'react'
 import AsciiMeter from './AsciiMeter'
 
 function formatNumber(value: number) {
@@ -11,23 +12,29 @@ function formatNumber(value: number) {
   return String(Math.floor(value / 1e9)).padStart(3, '0') + 'B'
 }
 
-export default function MessageQueue() {
+function MessageQueueContent() {
   const { monitor } = useData()
   const searchParams = useSearchParams()
   const showErrors = searchParams.get('errors') === 'true'
 
+  return <div className="flex flex-col gap-4">
+    {monitor.queues.filter(queue => queue.name !== 'extract').map((queue) => <AsciiMeter
+      key={queue.name}
+      current={queue.active}
+      current2={queue.waiting}
+      max={(queue.name.includes('-')) ? 50 : 400}
+      leftLabel={queue.name}
+      rightLabel={`w ${formatNumber(queue.waiting)} / a ${formatNumber(queue.active)}`}
+      errorCount={showErrors ? queue.failed : undefined}
+      errorMax={showErrors ? 100 : undefined} />)}
+  </div>
+}
+
+export default function MessageQueue() {
   return <div className={'w-full flex flex-col gap-2'}>
     <div className="font-bold text-xl">Message Queue</div>
-    <div className="flex flex-col gap-4">
-      {monitor.queues.filter(queue => queue.name !== 'extract').map((queue) => <AsciiMeter
-        key={queue.name}
-        current={queue.active}
-        current2={queue.waiting}
-        max={(queue.name.includes('-')) ? 50 : 400}
-        leftLabel={queue.name}
-        rightLabel={`w ${formatNumber(queue.waiting)} / a ${formatNumber(queue.active)}`}
-        errorCount={showErrors ? queue.failed : undefined}
-        errorMax={showErrors ? 100 : undefined} />)}
-    </div>
+    <Suspense fallback={<div className="flex flex-col gap-4" />}>
+      <MessageQueueContent />
+    </Suspense>
   </div>
 }

--- a/packages/web/components/MessageQueue.tsx
+++ b/packages/web/components/MessageQueue.tsx
@@ -32,7 +32,7 @@ function MessageQueueContent() {
 
 export default function MessageQueue() {
   return <div className={'w-full flex flex-col gap-2'}>
-    <div className="font-bold text-xl">Message Queue</div>
+    <div id="message-queue" className="font-bold text-xl">Message Queue</div>
     <Suspense fallback={<div className="flex flex-col gap-4" />}>
       <MessageQueueContent />
     </Suspense>

--- a/packages/web/components/MessageQueueRedis.tsx
+++ b/packages/web/components/MessageQueueRedis.tsx
@@ -7,7 +7,7 @@ import prettyBytes from 'pretty-bytes'
 export default function MessageQueueRedis() {
   const { monitor } = useData()
   return <div className="w-full flex flex-col gap-2">
-    <div className="font-bold text-xl">Redis</div>
+    <div id="redis" className="font-bold text-xl">Redis</div>
     <div className="w-full flex flex-col justify-between gap-4">
       <AsciiMeter
         current={monitor.redis.memory.used}

--- a/packages/web/components/Outputs.tsx
+++ b/packages/web/components/Outputs.tsx
@@ -28,7 +28,7 @@ export default function Outputs() {
 
   return <div className={'w-full flex flex-col items-start'}>
     <div className="w-full flex items-center justify-between">
-      <div className="font-bold text-lg">Outputs</div>
+      <div id="outputs" className="font-bold text-lg">Outputs</div>
       <Frosty _key={`thing_total-${indexStats.output_total}`} disabled={indexStats.output_total < 1}>{formatLineItemValue(indexStats.output_total)}</Frosty>
     </div>
   </div>

--- a/packages/web/components/Postgres.tsx
+++ b/packages/web/components/Postgres.tsx
@@ -8,7 +8,7 @@ import { fPercent } from '@/lib/format'
 export default function Postgres() {
   const { monitor } = useData()
   return <div className="w-full flex flex-col gap-2">
-    <div className="font-bold text-xl">Postgres</div>
+    <div id="postgres" className="font-bold text-xl">Postgres</div>
     <div className="w-full flex flex-col justify-between gap-4">
       <AsciiMeter
         current={monitor.db.databaseSize}

--- a/packages/web/components/Things.tsx
+++ b/packages/web/components/Things.tsx
@@ -43,7 +43,7 @@ export default function Things() {
 
   return <div className={'w-full flex flex-col items-start'}>
     <div className="w-full flex items-center justify-between">
-      <div className="font-bold text-lg">Things</div>
+      <div id="things" className="font-bold text-lg">Things</div>
       <Frosty _key={`thing_total-${indexStats.things_total}`} disabled={indexStats.things_total < 1}>{formatLineItemValue(indexStats.things_total)}</Frosty>
     </div>
     {lineItems.map(({ label, value }) => (


### PR DESCRIPTION
### Summary
Remove the aggregate "fail queue" meter from the dashboard and replace it with an optional per-queue error overlay. The fail queue was confusing users because it showed a combined percentage across all queues without clear context. Now each queue can display its own error count as a red base layer when `?errors=true` is added to the URL.

### How to review
- Start with `MessageQueue.tsx` to see the simplified logic and URL param handling
- Then check `AsciiMeter.tsx` for the new `errorCount`/`errorMax` props and red overlay layer
- Test by visiting the dashboard with and without `?errors=true`

### Test plan
- [x] Manual: Visit dashboard at `/` — fail queue should no longer appear
- [x] Manual: Visit dashboard at `/?errors=true` — queues with failed jobs should show red base layer

### Risk / impact
Low risk, UI-only change. No data or backend changes. Easy rollback by reverting the commit.