### PR TITLE
feat: add estimated apr from webhook

### DIFF
--- a/packages/ingest/abis/yearn/2/vault/snapshot/hook.ts
+++ b/packages/ingest/abis/yearn/2/vault/snapshot/hook.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 import { parseAbi, toEventSelector, zeroAddress } from 'viem'
 import { rpcs } from '../../../../../rpcs'
 import { ThingSchema, TokenMetaSchema, VaultMetaSchema, zhexstring } from 'lib/types'
-import db, { getLatestApy, getSparkline } from '../../../../../db'
+import db, { getLatestApy, getSparkline, getLatestEstimatedApr } from '../../../../../db'
 import { fetchErc20PriceUsd } from '../../../../../prices'
 import { priced } from 'lib/math'
 import { getRiskScore } from '../../../lib/risk'
@@ -53,6 +53,7 @@ export default async function process(chainId: number, address: `0x${string}`, d
   }
 
   const apy = await getLatestApy(chainId, address)
+  const estimated = await getLatestEstimatedApr(chainId, address)
 
   return {
     asset: erc20,
@@ -63,7 +64,16 @@ export default async function process(chainId: number, address: `0x${string}`, d
     meta: { ...meta, token },
     sparklines,
     tvl: sparklines.tvl[0],
-    apy
+    apy,
+    performance: {
+      estimated,
+      historical: apy ? {
+        net: apy.net,
+        weeklyNet: apy.weeklyNet,
+        monthlyNet: apy.monthlyNet,
+        inceptionNet: apy.inceptionNet
+      } : undefined
+    }
   }
 }
 

--- a/packages/ingest/abis/yearn/2/vault/snapshot/hook.ts
+++ b/packages/ingest/abis/yearn/2/vault/snapshot/hook.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod'
 import { parseAbi, toEventSelector, zeroAddress } from 'viem'
 import { rpcs } from '../../../../../rpcs'
-import { ThingSchema, TokenMetaSchema, VaultMetaSchema, zhexstring } from 'lib/types'
-import db, { getLatestApy, getSparkline, getLatestEstimatedApr } from '../../../../../db'
+import { EstimatedAprSchema, ThingSchema, TokenMetaSchema, VaultMetaSchema, zhexstring } from 'lib/types'
+import db, { getLatestApy, getSparkline, firstRow } from '../../../../../db'
 import { fetchErc20PriceUsd } from '../../../../../prices'
 import { priced } from 'lib/math'
 import { getRiskScore } from '../../../lib/risk'
@@ -31,6 +31,64 @@ export const ResultSchema = z.object({
   })),
   meta: VaultMetaSchema.merge(z.object({ token: TokenMetaSchema }))
 })
+
+
+async function getLatestEstimatedApr(chainId: number, address: string) {
+  const result = await firstRow(`
+  SELECT
+    chain_id as "chainId",
+    address,
+    label,
+    MAX(CASE WHEN component = 'netAPR' THEN value END) AS apr,
+    MAX(CASE WHEN component = 'netAPY' THEN value END) AS apy,
+    MAX(CASE WHEN component = 'boost' THEN value END) AS boost,
+    MAX(CASE WHEN component = 'poolAPY' THEN value END) AS "poolAPY",
+    MAX(CASE WHEN component = 'boostedAPR' THEN value END) AS "boostedAPR",
+    MAX(CASE WHEN component = 'baseAPR' THEN value END) AS "baseAPR",
+    MAX(CASE WHEN component = 'rewardsAPR' THEN value END) AS "rewardsAPR",
+    MAX(CASE WHEN component = 'rewardsAPY' THEN value END) AS "rewardsAPY",
+    MAX(CASE WHEN component = 'cvxAPR' THEN value END) AS "cvxAPR",
+    MAX(CASE WHEN component = 'keepCRV' THEN value END) AS "keepCRV",
+    MAX(CASE WHEN component = 'keepVelo' THEN value END) AS "keepVelo",
+    block_number as "blockNumber",
+    block_time as "blockTime"
+  FROM output
+  WHERE block_time = (
+      SELECT MAX(block_time) FROM output
+      WHERE chain_id = $1
+      AND LOWER(address) = LOWER($2)
+      AND label IN ('crv-estimated-apr', 'velo-estimated-apr', 'aero-estimated-apr')
+    )
+    AND chain_id = $1
+    AND LOWER(address) = LOWER($2)
+    AND label IN ('crv-estimated-apr', 'velo-estimated-apr', 'aero-estimated-apr')
+  GROUP BY chain_id, address, label, block_number, block_time;
+  `, [chainId, address])
+
+  if (!result) return undefined
+
+  let type = 'unknown'
+  if (result.label === 'crv-estimated-apr') type = 'crv'
+  if (result.label === 'velo-estimated-apr') type = 'velo'
+  if (result.label === 'aero-estimated-apr') type = 'aero'
+
+  return EstimatedAprSchema.parse({
+    apr: result.apr || 0,
+    apy: result.apy || 0,
+    type,
+    components: {
+      boost: result.boost,
+      poolAPY: result.poolAPY,
+      boostedAPR: result.boostedAPR,
+      baseAPR: result.baseAPR,
+      rewardsAPR: result.rewardsAPR,
+      rewardsAPY: result.rewardsAPY,
+      cvxAPR: result.cvxAPR,
+      keepCRV: result.keepCRV,
+      keepVelo: result.keepVelo
+    }
+  })
+}
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default async function process(chainId: number, address: `0x${string}`, data: any) {

--- a/packages/ingest/db.ts
+++ b/packages/ingest/db.ts
@@ -2,7 +2,7 @@
 
 import { z } from 'zod'
 import { strings } from 'lib'
-import { StrideSchema } from 'lib/types'
+import { EstimatedAprSchema, StrideSchema } from 'lib/types'
 import { Pool, PoolClient, types as pgTypes } from 'pg'
 import { snakeToCamelCols } from 'lib/strings'
 
@@ -176,6 +176,63 @@ export async function getLatestOracleApr(chainId: number, address: string): Prom
   if (!result) return [0, 0]
 
   return [result.apr || 0, result.apy || 0]
+}
+
+export async function getLatestEstimatedApr(chainId: number, address: string) {
+  const result = await firstRow(`
+  SELECT
+    chain_id as "chainId",
+    address,
+    label,
+    MAX(CASE WHEN component = 'netAPR' THEN value END) AS apr,
+    MAX(CASE WHEN component = 'netAPY' THEN value END) AS apy,
+    MAX(CASE WHEN component = 'boost' THEN value END) AS boost,
+    MAX(CASE WHEN component = 'poolAPY' THEN value END) AS "poolAPY",
+    MAX(CASE WHEN component = 'boostedAPR' THEN value END) AS "boostedAPR",
+    MAX(CASE WHEN component = 'baseAPR' THEN value END) AS "baseAPR",
+    MAX(CASE WHEN component = 'rewardsAPR' THEN value END) AS "rewardsAPR",
+    MAX(CASE WHEN component = 'rewardsAPY' THEN value END) AS "rewardsAPY",
+    MAX(CASE WHEN component = 'cvxAPR' THEN value END) AS "cvxAPR",
+    MAX(CASE WHEN component = 'keepCRV' THEN value END) AS "keepCRV",
+    MAX(CASE WHEN component = 'keepVelo' THEN value END) AS "keepVelo",
+    block_number as "blockNumber",
+    block_time as "blockTime"
+  FROM output
+  WHERE block_time = (
+      SELECT MAX(block_time) FROM output
+      WHERE chain_id = $1
+      AND LOWER(address) = LOWER($2)
+      AND label IN ('crv-estimated-apr', 'velo-estimated-apr', 'aero-estimated-apr')
+    )
+    AND chain_id = $1
+    AND LOWER(address) = LOWER($2)
+    AND label IN ('crv-estimated-apr', 'velo-estimated-apr', 'aero-estimated-apr')
+  GROUP BY chain_id, address, label, block_number, block_time;
+  `, [chainId, address])
+
+  if (!result) return undefined
+
+  let type = 'unknown'
+  if (result.label === 'crv-estimated-apr') type = 'crv'
+  if (result.label === 'velo-estimated-apr') type = 'velo'
+  if (result.label === 'aero-estimated-apr') type = 'aero'
+
+  return EstimatedAprSchema.parse({
+    apr: result.apr || 0,
+    apy: result.apy || 0,
+    type,
+    components: {
+      boost: result.boost,
+      poolAPY: result.poolAPY,
+      boostedAPR: result.boostedAPR,
+      baseAPR: result.baseAPR,
+      rewardsAPR: result.rewardsAPR,
+      rewardsAPY: result.rewardsAPY,
+      cvxAPR: result.cvxAPR,
+      keepCRV: result.keepCRV,
+      keepVelo: result.keepVelo
+    }
+  })
 }
 
 export function toUpsertSql(table: string, pk: string, data: object, where?: string) {

--- a/packages/lib/types.ts
+++ b/packages/lib/types.ts
@@ -445,15 +445,15 @@ export const EstimatedAprSchema = z.object({
   apy: z.number(),
   type: z.string(),
   components: z.object({
-    boost: z.number().optional(),
-    poolAPY: z.number().optional(),
-    boostedAPR: z.number().optional(),
-    baseAPR: z.number().optional(),
-    rewardsAPR: z.number().optional(),
-    rewardsAPY: z.number().optional(),
-    cvxAPR: z.number().optional(),
-    keepCRV: z.number().optional(),
-    keepVelo: z.number().optional()
+    boost: z.number().nullish(),
+    poolAPY: z.number().nullish(),
+    boostedAPR: z.number().nullish(),
+    baseAPR: z.number().nullish(),
+    rewardsAPR: z.number().nullish(),
+    rewardsAPY: z.number().nullish(),
+    cvxAPR: z.number().nullish(),
+    keepCRV: z.number().nullish(),
+    keepVelo: z.number().nullish()
   })
 })
 

--- a/packages/lib/types.ts
+++ b/packages/lib/types.ts
@@ -439,3 +439,22 @@ export const InceptSchema = z.object({
 })
 
 export type Incept = z.infer<typeof InceptSchema>
+
+export const EstimatedAprSchema = z.object({
+  apr: z.number(),
+  apy: z.number(),
+  type: z.string(),
+  components: z.object({
+    boost: z.number().optional(),
+    poolAPY: z.number().optional(),
+    boostedAPR: z.number().optional(),
+    baseAPR: z.number().optional(),
+    rewardsAPR: z.number().optional(),
+    rewardsAPY: z.number().optional(),
+    cvxAPR: z.number().optional(),
+    keepCRV: z.number().optional(),
+    keepVelo: z.number().optional()
+  })
+})
+
+export type EstimatedApr = z.infer<typeof EstimatedAprSchema>

--- a/packages/web/app/api/gql/typeDefs/vault.ts
+++ b/packages/web/app/api/gql/typeDefs/vault.ts
@@ -101,6 +101,25 @@ type Oracle {
   apy: Float
 }
 
+type EstimatedAprComponents {
+  boost: Float
+  poolAPY: Float
+  boostedAPR: Float
+  baseAPR: Float
+  rewardsAPR: Float
+  rewardsAPY: Float
+  cvxAPR: Float
+  keepCRV: Float
+  keepVelo: Float
+}
+
+type EstimatedApr {
+  apr: Float!
+  apy: Float!
+  type: String!
+  components: EstimatedAprComponents!
+}
+
 type Historical {
   net: Float
   weeklyNet: Float
@@ -110,6 +129,7 @@ type Historical {
 
 type Performance {
   oracle: Oracle
+  estimated: EstimatedApr
   historical: Historical
 }
 


### PR DESCRIPTION
### Summary
Integrated estimated forward APR/APY values for V2 vaults (Curve, Convex, Velodrome, Aerodrome) into the V2 vault snapshot hook and GraphQL API. This surfaces the pre-computed APR data from the `v2-estimated-apr-hook` webhook, aligning V2 vaults with the `performance.oracle` pattern used in V3.


### Test plan
- It can either spawn the indexer locally and let it crawl through a manuals.yml subset of contracts.

- then go to `packages/web` run `bun run dev`

- access `localhost:3000/api/gql`

- Run the following query

```
query {
  vault(chainId: 1, address: "0xf165a634296800812B8B0607a75DeDdcD4D3cC88") {
    performance {
      oracle {
        apr
        apy
      }
      historical {
        net
      }
      estimated {
        apr
        apy
        type
        components {
          boost
          poolAPY
          boostedAPR
          baseAPR
          rewardsAPR
          rewardsAPY
          cvxAPR
          keepCRV
          keepVelo
        }
      }
    }
    apy {
      net
    }
  }
}
```

You should see:

```
{
  "data": {
    "vault": {
      "performance": {
        "oracle": null,
        "historical": {
          "net": 0.07766469935380482
        },
        "estimated": {
          "apr": 0,
          "apy": 0.1748318734131193,
          "type": "crv",
          "components": {
            "boost": 2.2637838029699484,
            "poolAPY": 0.0319,
            "boostedAPR": 0.1623576371256881,
            "baseAPR": 0.071719585992569,
            "rewardsAPR": 0,
            "rewardsAPY": 0,
            "cvxAPR": 0,
            "keepCRV": 0,
            "keepVelo": null
          }
        }
      },
      "apy": {
        "net": 0.07766469935380482
      }
    }
  }
}
```
