### PR TITLE
Prefer vault metadata over strategy metadata for dual-role addresses

### DIFF
--- a/packages/ingest/abis/yearn/2/strategy/snapshot/hook.ts
+++ b/packages/ingest/abis/yearn/2/strategy/snapshot/hook.ts
@@ -9,7 +9,7 @@ import { mq } from 'lib'
 import { estimateCreationBlock } from 'lib/blocks'
 import { fetchOrExtractErc20, throwOnMulticallError } from '../../../lib'
 import db, { firstRow } from '../../../../../db'
-import { getStrategyMeta } from '../../../lib/meta'
+import { getStrategyMeta, getVaultMeta } from '../../../lib/meta'
 import vaultAbi from '../../vault/abi'
 
 const borkedVaults = [
@@ -52,7 +52,8 @@ export default async function process(chainId: number, address: `0x${string}`, d
   const lenderStatuses = await extractLenderStatuses(chainId, address)
   const lastReportDetail = await fetchLastReportDetail(chainId, address)
   const claims = await computeRewards(chainId, address, snapshot)
-  const meta = await getStrategyMeta(chainId, address)
+  const vaultMeta = await getVaultMeta(chainId, address)
+  const meta = vaultMeta ?? await getStrategyMeta(chainId, address)
   return { totalDebt, totalDebtUsd, lenderStatuses, lastReportDetail, claims, meta }
 }
 

--- a/packages/ingest/abis/yearn/3/strategy/snapshot/hook.ts
+++ b/packages/ingest/abis/yearn/3/strategy/snapshot/hook.ts
@@ -2,12 +2,13 @@ import { z } from 'zod'
 import { zhexstring } from 'lib/types'
 import { firstRow } from '../../../../../db'
 import { fetchOrExtractErc20 } from '../../../lib'
-import { getStrategyMeta } from '../../../lib/meta'
+import { getStrategyMeta, getVaultMeta } from '../../../lib/meta'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default async function process(chainId: number, address: `0x${string}`, data: any) {
   const asset = await fetchOrExtractErc20(chainId, data.asset)
-  const meta = await getStrategyMeta(chainId, address)
+  const vaultMeta = await getVaultMeta(chainId, address)
+  const meta = vaultMeta ?? await getStrategyMeta(chainId, address)
   const lastReportDetail = await fetchLastReportDetail(chainId, address)
   return { asset, meta, lastReportDetail }
 }


### PR DESCRIPTION
Many vaults are also classified as strategies. We have metadata for both vaults and strategies. This creates a conflict where the same snapshot record gets updated twice with potentially conflicting metadata. This update defaults to vault metadata so that it's not overwritten. We don't use strategy metadata in v3 where it's possible for vaults to also be strategies, so this is safe to do.

### How to review
Review the v2 and v3 strategy snapshot hook.

### Test plan
- Create a neondb fork
- Configure dev with the fork
- Configure dev abis.local.yaml with a testcase

```
  - abiPath: 'yearn/3/vault'
    sources: [
      { chainId: 1, address: '0x00C8a649C9837523ebb406Ceb17a6378Ab5C74cF', inceptBlock: 23122553 }
    ]

  - abiPath: 'yearn/3/strategy'
    sources: [
      { chainId: 1, address: '0x00C8a649C9837523ebb406Ceb17a6378Ab5C74cF', inceptBlock: 23122553 }
    ]

 ```
- run the indexer in dev
- confirm vault metadata is not overwritten

### Risk / impact
Some risk that strategy metadata is created for a v3 vault and then doesn't show on the api because it will be overwritten by the vault metadata. We don't use strategy meta for v3 currently, so minimal risk.
