### PR TITLE
Extend vault list API with new fields and origin filtering

### DIFF
--- a/packages/web/app/api/rest/lists/vaults/[chainId]/route.ts
+++ b/packages/web/app/api/rest/lists/vaults/[chainId]/route.ts
@@ -17,9 +17,12 @@ type RouteParams = {
 }
 
 export async function GET(
-  _request: Request,
+  request: Request,
   context: { params: Promise<RouteParams> },
 ) {
+  const { searchParams } = new URL(request.url)
+  const origin = searchParams.get('origin')
+
   const { chainId: chainIdParam } = (await context.params) ?? {}
   const chainId = parseInt(chainIdParam as string, 10)
 
@@ -47,7 +50,11 @@ export async function GET(
     return new NextResponse('Internal Server Error', { status: 500, headers: corsHeaders })
   }
 
-  return NextResponse.json(vaults, {
+  const filtered = origin
+    ? vaults.filter(v => v.origin === origin)
+    : vaults
+
+  return NextResponse.json(filtered, {
     status: 200,
     headers: {
       'cache-control': 'public, max-age=900, s-maxage=900, stale-while-revalidate=600',

--- a/packages/web/app/api/rest/lists/vaults/route.ts
+++ b/packages/web/app/api/rest/lists/vaults/route.ts
@@ -9,7 +9,10 @@ const corsHeaders = {
   'access-control-allow-methods': 'GET,OPTIONS',
 }
 
-export async function GET() {
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url)
+  const origin = searchParams.get('origin')
+
   const listsKeyv = createListsKeyv('list:vaults')
 
   try {
@@ -30,7 +33,11 @@ export async function GET() {
       }
     }
 
-    return NextResponse.json(allVaults, {
+    const filtered = origin
+      ? allVaults.filter(v => v.origin === origin)
+      : allVaults
+
+    return NextResponse.json(filtered, {
       status: 200,
       headers: {
         'cache-control': 'public, max-age=900, s-maxage=900, stale-while-revalidate=600',


### PR DESCRIPTION
### Summary
Extends the vault list REST API with additional metadata fields and adds filtering capability by origin.

**Schema additions:**
- `estimated` APR object with component breakdown (boost, poolAPY, baseAPR, etc.)
- `inclusion` map for tracking list membership
- `migration` flag for vault migration availability
- `origin` field for vault source tracking

**New query parameter:**
- `?origin=<value>` filter on `/lists/vaults` and `/lists/vaults/[chainId]` endpoints

### How to review
1. Start with `db.ts` for schema and SQL query changes
2. Then review the two route files for the query parameter implementation

### Test plan
- [ ] Configure packages/web to use readonly replica
- [ ] Start redis `docker run --rm -p 6379:6379 redis:latest`
- [ ] Run list refresh `bun packages/web/app/api/lists/refresh.ts`
- [ ] Manual: `GET /api/rest/lists/vaults` returns new fields
- [ ] Manual: `GET /api/rest/lists/vaults?origin=yearn` filters correctly
- [ ] Manual: `GET /api/rest/lists/vaults/1?origin=yearn` filters correctly

### Risk / impact
Low risk. Additive schema changes are backwards compatible. The removed `yearn` boolean flag is replaced by the `inclusion` map.