### PR TITLE
Fix vault list endpoint missing chains in production

### DIFF
--- a/packages/web/app/api/rest/lists/refresh.ts
+++ b/packages/web/app/api/rest/lists/refresh.ts
@@ -22,6 +22,8 @@ async function refresh(): Promise<void> {
     await keyv.set(String(chainId), JSON.stringify(chainVaults))
   }
 
+  await keyv.set('all', JSON.stringify(vaults))
+
   console.log(`✓ Completed: ${vaults.length} vaults cached across ${chainIds.length} chains`)
   console.timeEnd('refresh')
 }


### PR DESCRIPTION
### Summary

Fix the `/api/rest/lists/vaults` endpoint returning incomplete results in production (e.g., missing Base chain 8453).

The aggregate endpoint used Keyv's `iterator()` which relies on Redis SCAN. In clustered/proxy Redis setups, SCAN only sees keys from the connected shard, causing partial results. Per-chain endpoints like `/vaults/8453` worked because they use direct GET which properly routes to the correct shard.

The fix stores the complete vault list under an `all` key during refresh, then reads it directly instead of scanning. This is also faster since it requires only one Redis GET instead of iterating all keys.

### How to review

Two small changes:
1. `packages/web/app/api/rest/lists/refresh.ts` - adds one line to store the `all` key
2. `packages/web/app/api/rest/lists/vaults/route.ts` - replaces iterator with direct GET

### Test plan

- [ ] Configure packages/web to use readonly replica
- [ ] Start redis: `docker run --rm -p 6379:6379 redis:latest`
- [ ] Run list refresh: `bun packages/web/app/api/rest/lists/refresh.ts`
- [ ] Verify `/api/rest/lists/vaults` returns all chains including 8453

### Risk / impact

Low risk. The refresh script must run once after deploy to populate the new `all` key, otherwise the endpoint returns 404 until then.