### PR TITLE
fix: add oracle addresses for Gnosis, Sonic, Berachain, and Katana

### DIFF
--- a/packages/ingest/abis/yearn/3/vault/timeseries/apr-oracle/constants.ts
+++ b/packages/ingest/abis/yearn/3/vault/timeseries/apr-oracle/constants.ts
@@ -16,9 +16,17 @@ export const ORACLE_ADDRESSES: Record<number, OracleConfig> = {
     address: '0x1981AD9F44F2EA9aDd2dC4AD7D075c102C70aF92',
     inceptBlock: 126847323,
   },
+  100: {
+    address: '0x1981AD9F44F2EA9aDd2dC4AD7D075c102C70aF92',
+    inceptBlock: 36654351,
+  },
   137: {
     address: '0x1981AD9F44F2EA9aDd2dC4AD7D075c102C70aF92',
     inceptBlock: 63167152,
+  },
+  146: {
+    address: '0x1981AD9F44F2EA9aDd2dC4AD7D075c102C70aF92',
+    inceptBlock:307797,
   },
   8453: {
     address: '0x1981AD9F44F2EA9aDd2dC4AD7D075c102C70aF92',
@@ -28,6 +36,14 @@ export const ORACLE_ADDRESSES: Record<number, OracleConfig> = {
     address: '0x1981AD9F44F2EA9aDd2dC4AD7D075c102C70aF92',
     inceptBlock: 265347717,
   },
+  80094: {
+    address: '0x1981AD9F44F2EA9aDd2dC4AD7D075c102C70aF92',
+    inceptBlock: 827653,
+  },
+  747474: {
+    address: '0x1981AD9F44F2EA9aDd2dC4AD7D075c102C70aF92',
+    inceptBlock: 2237016
+  }
 }
 
 export function getOracleConfig(chainId: number): OracleConfig | undefined {

--- a/packages/ingest/abis/yearn/3/vault/timeseries/apr-oracle/hook.ts
+++ b/packages/ingest/abis/yearn/3/vault/timeseries/apr-oracle/hook.ts
@@ -4,7 +4,6 @@ import { rpcs } from 'lib/rpcs'
 import { Data } from '../../../../../../extract/timeseries'
 import { V3_ORACLE_ABI } from './abi'
 import { getOracleConfig } from './constants'
-import console from 'console'
 
 export const outputLabel = 'apr-oracle'
 


### PR DESCRIPTION
## Summary
- Added APR oracle addresses and inception blocks for chains 100 (Gnosis), 146 (Sonic), 80094 (Berachain), and 747474 (katana)
- Removed unused console import from hook.ts

## Test plan

### Setup
- Ensure RPC endpoints are configured in `.env` for chains 100, 146, 80094, and 747474
- Verify oracle address `0x1981AD9F44F2EA9aDd2dC4AD7D075c102C70aF92` is correct for each chain

### Start Indexer
- Run `make dev` to start the development environment (tmux, redis, postgres, all services)
- Navigate tmux panes with `ctrl+b` + arrow keys to monitor services
- Access terminal UI and select `ingest` → `fanout abis`
- Run fanout multiple times if needed for full initialization
- Monitor indexing progress in tmux panes for errors on new chains

### Verify Data Ingestion
- Check `evmlog` table for APR oracle events from new chains:
  ```sql
  SELECT chain_id, COUNT(*) FROM evmlog 
  WHERE chain_id IN (100, 146, 80094, 747474)
  GROUP BY chain_id;
  ```
- Verify `snapshot` table contains oracle state from inception blocks
- Check `output` table for APR oracle timeseries data on new chains

### Test Timeseries Hook
- Run `fanout replays` to replay APR oracle hooks
- Verify APR data is generated correctly for vaults on new chains
- Use GraphQL explorer at http://localhost:3001/api/gql to query APR data:
  ```graphql
  query {
    vaults(chainIds: [100, 146, 80084, 747474]) {
      address
      chainId
      aprOracle
    }
  }
  ```

### Regression Testing
- Verify no errors on existing chains (1, 10, 137, 8453, 42161)
- Confirm existing APR oracle data is unaffected
- Check `evmlog_strides` for proper block coverage tracking on all chains

🤖 Generated with [Claude Code](https://claude.com/claude-code)