### PR TITLE
Extend vault snapshot strategies with name, APR, and status

### DIFF
--- a/packages/ingest/abis/erc4626/snapshot/hook.ts
+++ b/packages/ingest/abis/erc4626/snapshot/hook.ts
@@ -25,6 +25,16 @@ export default async function process(chainId: number, address: `0x${string}`, d
     sparklines,
     tvl: sparklines.tvl[0],
     apy,
+    performance: {
+      estimated: undefined,
+      oracle: undefined,
+      historical: apy ? {
+        net: apy.net,
+        weeklyNet: apy.weeklyNet,
+        monthlyNet: apy.monthlyNet,
+        inceptionNet: apy.inceptionNet
+      } : undefined
+    },
     pricePerShare: sparklines.pps[0]?.close ?? undefined
   }
 }

--- a/packages/ingest/abis/yearn/2/vault/snapshot/hook.ts
+++ b/packages/ingest/abis/yearn/2/vault/snapshot/hook.ts
@@ -6,10 +6,29 @@ import db, { getLatestApy, getSparkline, firstRow } from '../../../../../db'
 import { fetchErc20PriceUsd } from '../../../../../prices'
 import { priced } from 'lib/math'
 import { getRiskScore } from '../../../lib/risk'
-import { getTokenMeta, getVaultMeta } from '../../../lib/meta'
+import { getTokenMeta, getVaultMeta, getStrategyMeta } from '../../../lib/meta'
 import { fetchOrExtractErc20, throwOnMulticallError } from '../../../lib'
 import { mq } from 'lib'
 import { compare } from 'compare-versions'
+
+export const CompositionSchema = z.object({
+  address: zhexstring,
+  name: z.string(),
+  status: z.enum(['active', 'inactive', 'unallocated']),
+  netAPR: z.number().nullable(),
+  performanceFee: z.bigint(),
+  activation: z.bigint(),
+  debtRatio: z.bigint(),
+  minDebtPerHarvest: z.bigint(),
+  maxDebtPerHarvest: z.bigint(),
+  lastReport: z.bigint(),
+  totalDebt: z.bigint(),
+  totalDebtUsd: z.number(),
+  totalGain: z.bigint(),
+  totalGainUsd: z.number(),
+  totalLoss: z.bigint(),
+  totalLossUsd: z.number()
+})
 
 export const ResultSchema = z.object({
   strategies: z.array(zhexstring),
@@ -29,9 +48,9 @@ export const ResultSchema = z.object({
     totalLoss: z.bigint(),
     totalLossUsd: z.number()
   })),
+  composition: CompositionSchema.array(),
   meta: VaultMetaSchema.merge(z.object({ token: TokenMetaSchema }))
 })
-
 
 async function getLatestEstimatedApr(chainId: number, address: string) {
   const result = await firstRow(`
@@ -96,6 +115,7 @@ export default async function process(chainId: number, address: `0x${string}`, d
   const strategies = await projectStrategies(chainId, address)
   const withdrawalQueue = await extractWithdrawalQueue(chainId, address)
   const debts = oldold ? [] : await extractDebts(chainId, address)
+  const composition = oldold ? [] : await extractComposition(chainId, address, strategies, withdrawalQueue, debts)
   const risk = await getRiskScore(chainId, address)
   const meta = await getVaultMeta(chainId, address)
   const token = await getTokenMeta(chainId, data.token)
@@ -118,6 +138,7 @@ export default async function process(chainId: number, address: `0x${string}`, d
     strategies,
     withdrawalQueue,
     debts,
+    composition,
     risk,
     meta: { ...meta, token },
     sparklines,
@@ -277,4 +298,85 @@ export async function extractWithdrawalQueue(chainId: number, address: `0x${stri
 
   return multicall.filter(result => result.status === 'success' && result.result && result.result !== zeroAddress)
     .map(result => result.result as `0x${string}`)
+}
+
+async function fetchStrategySnapshots(chainId: number, strategies: `0x${string}`[]) {
+  if (strategies.length === 0) return []
+
+  const result = await db.query(`
+    SELECT
+      address,
+      snapshot->>'name' as name,
+      hook->'lastReportDetail'->'apr'->>'net' as "netAPR"
+    FROM snapshot
+    WHERE chain_id = $1 AND address = ANY($2)
+  `, [chainId, strategies])
+
+  return z.object({
+    address: zhexstring,
+    name: z.string().nullable(),
+    netAPR: z.string().nullable()
+  }).array().parse(result.rows)
+}
+
+export async function extractComposition(
+  chainId: number,
+  vault: `0x${string}`,
+  strategies: `0x${string}`[],
+  withdrawalQueue: `0x${string}`[],
+  debts: Awaited<ReturnType<typeof extractDebts>>
+) {
+  // Batch-fetch strategy snapshots for name and APR
+  const strategySnapshots = await fetchStrategySnapshots(chainId, strategies)
+
+  const composition: z.infer<typeof CompositionSchema>[] = []
+
+  for (const strategy of strategies) {
+    const debt = debts.find(d => d.strategy === strategy)
+    const snapshot = strategySnapshots.find(s => s.address.toLowerCase() === strategy.toLowerCase())
+
+    // Fetch strategy metadata (try vault meta first for dual-role addresses)
+    const vaultMeta = await getVaultMeta(chainId, strategy)
+    const meta = vaultMeta.displayName ? vaultMeta : await getStrategyMeta(chainId, strategy)
+
+    // Coalesce name: meta.name → snapshot.name → "Unknown"
+    const name = meta.displayName || snapshot?.name || 'Unknown'
+
+    // Parse netAPR
+    const netAPR = snapshot?.netAPR ? parseFloat(snapshot.netAPR) : null
+
+    // Compute status based on debt and withdrawal queue membership
+    let status: 'active' | 'inactive' | 'unallocated'
+    const isInQueue = withdrawalQueue.some(addr => addr.toLowerCase() === strategy.toLowerCase())
+    const hasDebt = debt && debt.totalDebt > 0n && debt.debtRatio > 0n
+
+    if (hasDebt) {
+      status = 'active'
+    } else if (isInQueue) {
+      status = 'inactive'
+    } else {
+      status = 'unallocated'
+    }
+
+    composition.push({
+      address: strategy,
+      name,
+      status,
+      netAPR,
+      performanceFee: debt?.performanceFee ?? 0n,
+      activation: debt?.activation ?? 0n,
+      debtRatio: debt?.debtRatio ?? 0n,
+      minDebtPerHarvest: debt?.minDebtPerHarvest ?? 0n,
+      maxDebtPerHarvest: debt?.maxDebtPerHarvest ?? 0n,
+      lastReport: debt?.lastReport ?? 0n,
+      totalDebt: debt?.totalDebt ?? 0n,
+      totalDebtUsd: debt?.totalDebtUsd ?? 0,
+      totalGain: debt?.totalGain ?? 0n,
+      totalGainUsd: debt?.totalGainUsd ?? 0,
+      totalLoss: debt?.totalLoss ?? 0n,
+      totalLossUsd: debt?.totalLossUsd ?? 0
+    })
+  }
+
+  return CompositionSchema.array().parse(composition)
 }

--- a/packages/ingest/abis/yearn/3/vault/snapshot/hook.ts
+++ b/packages/ingest/abis/yearn/3/vault/snapshot/hook.ts
@@ -8,25 +8,53 @@ import db, { getLatestApy, getLatestOracleApr, getSparkline } from '../../../../
 import { fetchErc20PriceUsd } from '../../../../../prices'
 import { priced } from 'lib/math'
 import { getRiskScore } from '../../../lib/risk'
-import { getTokenMeta, getVaultMeta } from '../../../lib/meta'
+import { getTokenMeta, getVaultMeta, getStrategyMeta } from '../../../lib/meta'
 import { snakeToCamelCols } from 'lib/strings'
 import { fetchOrExtractErc20 } from '../../../lib'
 import { Roles } from '../../../lib/types'
 import accountantAbi from '../../accountant/abi'
 import * as things from '../../../../../things'
 
+export const CompositionSchema = z.object({
+  address: zhexstring,
+  name: z.string(),
+  status: z.enum(['active', 'inactive', 'unallocated']),
+  netAPR: z.number().nullable(),
+  activation: z.bigint(),
+  lastReport: z.bigint(),
+  currentDebt: z.bigint(),
+  currentDebtUsd: z.number(),
+  maxDebt: z.bigint(),
+  maxDebtUsd: z.number(),
+  performanceFee: z.bigint(),
+  totalGain: z.bigint(),
+  totalGainUsd: z.number(),
+  totalLoss: z.bigint(),
+  totalLossUsd: z.number(),
+  targetDebtRatio: z.number().optional(),
+  maxDebtRatio: z.number().optional()
+})
+
 export const ResultSchema = z.object({
   strategies: z.array(zhexstring),
   allocator: zhexstring.optional(),
   debts: z.array(z.object({
     strategy: zhexstring,
+    activation: z.bigint(),
+    lastReport: z.bigint(),
     currentDebt: z.bigint(),
     currentDebtUsd: z.number(),
     maxDebt: z.bigint(),
     maxDebtUsd: z.number(),
+    performanceFee: z.bigint(),
+    totalGain: z.bigint(),
+    totalGainUsd: z.number(),
+    totalLoss: z.bigint(),
+    totalLossUsd: z.number(),
     targetDebtRatio: z.number().optional(),
     maxDebtRatio: z.number().optional()
   })),
+  composition: CompositionSchema.array(),
   fees: z.object({
     managementFee: z.number(),
     performanceFee: z.number()
@@ -53,6 +81,7 @@ export default async function process(chainId: number, address: `0x${string}`, d
   const allocator = await projectDebtAllocator(chainId, address)
 
   const debts = await extractDebts(chainId, address, strategies, allocator)
+  const composition = await extractComposition(chainId, address, strategies, debts)
   const fees = await extractFeesBps(chainId, address, snapshot)
   const risk = await getRiskScore(chainId, address)
   const meta = await getVaultMeta(chainId, address)
@@ -83,7 +112,7 @@ export default async function process(chainId: number, address: `0x${string}`, d
   const [oracleApr, oracleApy] = await getLatestOracleApr(chainId, address)
 
   return {
-    asset, strategies, allocator, roles, debts, fees,
+    asset, strategies, allocator, roles, debts, composition, fees,
     risk, meta: { ...meta, token },
     sparklines,
     tvl: sparklines.tvl[0],
@@ -182,10 +211,17 @@ function appendRoleManagerPseudoRole(
 export async function extractDebts(chainId: number, vault: `0x${string}`, strategies: `0x${string}`[], allocator: `0x${string}` | undefined) {
   const results: {
     strategy: `0x${string}`,
+    activation: bigint,
+    lastReport: bigint,
     currentDebt: bigint,
     currentDebtUsd: number,
     maxDebt: bigint,
     maxDebtUsd: number,
+    performanceFee: bigint,
+    totalGain: bigint,
+    totalGainUsd: number,
+    totalLoss: bigint,
+    totalLossUsd: number,
     targetDebtRatio: number | undefined,
     maxDebtRatio: number | undefined
   }[] = []
@@ -206,10 +242,16 @@ export async function extractDebts(chainId: number, vault: `0x${string}`, strate
 
   if (asset && decimals && strategies) {
     for (const strategy of strategies) {
-      const contracts: any[] = [{
-        address: vault, functionName: 'strategies', args: [strategy],
-        abi: parseAbi(['function strategies(address) view returns (uint256, uint256, uint256, uint256)'])
-      }]
+      const contracts: any[] = [
+        {
+          address: vault, functionName: 'strategies', args: [strategy],
+          abi: parseAbi(['function strategies(address) view returns (uint256, uint256, uint256, uint256)'])
+        },
+        {
+          address: strategy, functionName: 'performanceFee',
+          abi: parseAbi(['function performanceFee() view returns (uint16)'])
+        }
+      ]
 
       if (allocator) {
         contracts.push(
@@ -230,22 +272,37 @@ export async function extractDebts(chainId: number, vault: `0x${string}`, strate
         ? multicall[0].result! as [bigint, bigint, bigint, bigint]
         : [0n, 0n, 0n, 0n] as [bigint, bigint, bigint, bigint]
 
-      const targetDebtRatio = multicall[1]?.result
-        ? Number(multicall[1].result)
+      const performanceFee = multicall[1]?.result
+        ? BigInt(multicall[1].result as number)
+        : 0n
+
+      const targetDebtRatio = multicall[2]?.result
+        ? Number(multicall[2].result)
         : undefined
 
-      const maxDebtRatio = multicall[2]?.result
-        ? Number(multicall[2].result)
+      const maxDebtRatio = multicall[3]?.result
+        ? Number(multicall[3].result)
         : undefined
 
       const price = await fetchErc20PriceUsd(chainId, asset)
 
+      // V3 contracts don't track totalGain and totalLoss at the strategy level
+      const totalGain = 0n
+      const totalLoss = 0n
+
       results.push({
         strategy,
+        activation,
+        lastReport,
         currentDebt,
         currentDebtUsd: priced(currentDebt, decimals, price.priceUsd),
         maxDebt,
         maxDebtUsd: priced(maxDebt, decimals, price.priceUsd),
+        performanceFee,
+        totalGain,
+        totalGainUsd: 0,
+        totalLoss,
+        totalLossUsd: 0,
         targetDebtRatio,
         maxDebtRatio
       })
@@ -253,6 +310,99 @@ export async function extractDebts(chainId: number, vault: `0x${string}`, strate
   }
 
   return results
+}
+
+async function fetchStrategySnapshots(chainId: number, strategies: `0x${string}`[]) {
+  if (strategies.length === 0) return []
+
+  const result = await db.query(`
+    SELECT
+      address,
+      snapshot->>'name' as name,
+      hook->'lastReportDetail'->'apr'->>'net' as "netAPR"
+    FROM snapshot
+    WHERE chain_id = $1 AND address = ANY($2)
+  `, [chainId, strategies])
+
+  return z.object({
+    address: zhexstring,
+    name: z.string().nullable(),
+    netAPR: z.string().nullable()
+  }).array().parse(result.rows)
+}
+
+export async function extractComposition(
+  chainId: number,
+  vault: `0x${string}`,
+  strategies: `0x${string}`[],
+  debts: Awaited<ReturnType<typeof extractDebts>>
+) {
+  // Fetch vault snapshot data for queue context
+  const vaultSnapshot = await db.query(`
+    SELECT
+      hook->'strategies' as strategies,
+      snapshot->'get_default_queue' as "defaultQueue",
+      snapshot->'use_default_queue' as "useDefaultQueue"
+    FROM snapshot
+    WHERE chain_id = $1 AND address = $2
+  `, [chainId, vault])
+
+  const { defaultQueue } = z.object({
+    strategies: z.array(zhexstring).nullable(),
+    defaultQueue: z.array(zhexstring).nullable()
+  }).parse(vaultSnapshot.rows[0] || {})
+
+  // Batch-fetch strategy snapshots for name and APR
+  const strategySnapshots = await fetchStrategySnapshots(chainId, strategies)
+
+  const composition: z.infer<typeof CompositionSchema>[] = []
+
+  for (const strategy of strategies) {
+    const debt = debts.find(d => d.strategy === strategy)
+    const snapshot = strategySnapshots.find(s => s.address.toLowerCase() === strategy.toLowerCase())
+
+    // Fetch strategy metadata (try vault meta first for dual-role addresses)
+    const vaultMeta = await getVaultMeta(chainId, strategy)
+    const meta = vaultMeta.displayName ? vaultMeta : await getStrategyMeta(chainId, strategy)
+
+    // Coalesce name: meta.name → snapshot.name → "Unknown"
+    const name = meta.displayName || snapshot?.name || 'Unknown'
+
+    // Parse netAPR
+    const netAPR = snapshot?.netAPR ? parseFloat(snapshot.netAPR) : null
+
+    // Compute status based on debt and queue membership
+    let status: 'active' | 'inactive' | 'unallocated'
+    if (debt && debt.currentDebt > 0n) {
+      status = 'active'
+    } else if (defaultQueue?.includes(strategy)) {
+      status = 'inactive'
+    } else {
+      status = 'unallocated'
+    }
+
+    composition.push({
+      address: strategy,
+      name,
+      status,
+      netAPR,
+      activation: debt?.activation ?? 0n,
+      lastReport: debt?.lastReport ?? 0n,
+      currentDebt: debt?.currentDebt ?? 0n,
+      currentDebtUsd: debt?.currentDebtUsd ?? 0,
+      maxDebt: debt?.maxDebt ?? 0n,
+      maxDebtUsd: debt?.maxDebtUsd ?? 0,
+      performanceFee: debt?.performanceFee ?? 0n,
+      totalGain: debt?.totalGain ?? 0n,
+      totalGainUsd: debt?.totalGainUsd ?? 0,
+      totalLoss: debt?.totalLoss ?? 0n,
+      totalLossUsd: debt?.totalLossUsd ?? 0,
+      targetDebtRatio: debt?.targetDebtRatio,
+      maxDebtRatio: debt?.maxDebtRatio
+    })
+  }
+
+  return CompositionSchema.array().parse(composition)
 }
 
 export async function extractFeesBps(chainId: number, address: `0x${string}`, snapshot: Snapshot) {


### PR DESCRIPTION
### Summary

Enhances vault snapshot REST API to include enriched strategy data similar to yDaemon's output format. Adds a new `composition` field that merges debt information with strategy metadata (name, netAPR, status) while preserving existing `strategies` and `debts` fields for backward compatibility. Also aligns V3 debt fields with yDaemon expectations by adding previously missing fields.

Closes #314

### How to review

1. **Schema changes first**: Review `CompositionSchema` definitions in both V2 and V3 vault snapshot hooks
2. **V3 debt alignment**: Check the new fields added to V3 debts (activation, lastReport, performanceFee, totalGain/Loss) in `packages/ingest/abis/yearn/3/vault/snapshot/hook.ts`
3. **Composition logic**: Review `extractComposition()` implementation in both hooks, focusing on:
   - Name coalescing logic (metadata → snapshot → "Unknown")
   - Status computation using debt and queue context
   - Batch query helper for strategy snapshots
4. **Backward compatibility**: Verify existing fields remain unchanged

### Test plan

- [x] Manual: Tested with V3 vault Dusfer USDC on chain 1
  - Request: `curl http://localhost:3001/api/rest/snapshot/1/0xAC64c681102E23f4114bC6fC873499267aeb9eA8`
  - Verified composition field contains enriched strategy data
  - Strategy name: "Morpho Gauntlet USDC Prime Compounder" (fetched from metadata)
  - Status correctly computed as "active" (currentDebt: 508677 > 0)
  - netAPR field present and null (no harvest data yet)
  - All debt fields properly included (activation, lastReport, performanceFee, totalGain/Loss)
  
  **Response excerpt:**
  ```json
  {
    "address": "0xAC64c681102E23f4114bC6fC873499267aeb9eA8",
    "name": "Dusfer USDC",
    "strategies": ["0x694E47AFD14A64661a04eee674FB331bCDEF3737"],
    "debts": [{
      "strategy": "0x694E47AFD14A64661a04eee674FB331bCDEF3737",
      "activation": "1747897187",
      "lastReport": "1753333739",
      "currentDebt": "508677",
      "currentDebtUsd": 0.5086,
      "performanceFee": "500",
      "totalGain": "0",
      "totalLoss": "0"
    }],
    "composition": [{
      "address": "0x694E47AFD14A64661a04eee674FB331bCDEF3737",
      "name": "Morpho Gauntlet USDC Prime Compounder",
      "status": "active",
      "netAPR": null,
      "activation": "1747897187",
      "lastReport": "1753333739",
      "currentDebt": "508677",
      "currentDebtUsd": 0.5086,
      "maxDebt": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
      "maxDebtUsd": 1.157920892373162e+71,
      "performanceFee": "500",
      "totalGain": "0",
      "totalGainUsd": 0,
      "totalLoss": "0",
      "totalLossUsd": 0
    }]
  }
  ```