### PR TITLE
Feat/extend vault murderteeth

### DIFF
--- a/packages/ingest/abis/erc4626/snapshot/hook.ts
+++ b/packages/ingest/abis/erc4626/snapshot/hook.ts
@@ -25,6 +25,16 @@ export default async function process(chainId: number, address: `0x${string}`, d
     sparklines,
     tvl: sparklines.tvl[0],
     apy,
+    performance: {
+      estimated: undefined,
+      oracle: undefined,
+      historical: apy ? {
+        net: apy.net,
+        weeklyNet: apy.weeklyNet,
+        monthlyNet: apy.monthlyNet,
+        inceptionNet: apy.inceptionNet
+      } : undefined
+    },
     pricePerShare: sparklines.pps[0]?.close ?? undefined
   }
 }

--- a/packages/ingest/abis/yearn/2/vault/snapshot/hook.ts
+++ b/packages/ingest/abis/yearn/2/vault/snapshot/hook.ts
@@ -15,7 +15,7 @@ export const CompositionSchema = z.object({
   address: zhexstring,
   name: z.string(),
   status: z.enum(['active', 'inactive', 'unallocated']),
-  netAPR: z.number().nullable(),
+  latestReportApr: z.number().nullish(),
   performanceFee: z.bigint(),
   activation: z.bigint(),
   debtRatio: z.bigint(),
@@ -146,6 +146,7 @@ export default async function process(chainId: number, address: `0x${string}`, d
     apy,
     performance: {
       estimated,
+      oracle: undefined,
       historical: apy ? {
         net: apy.net,
         weeklyNet: apy.weeklyNet,
@@ -307,7 +308,7 @@ async function fetchStrategySnapshots(chainId: number, strategies: `0x${string}`
     SELECT
       address,
       snapshot->>'name' as name,
-      hook->'lastReportDetail'->'apr'->>'net' as "netAPR"
+      hook->'lastReportDetail'->'apr'->>'net' as "latestReportApr"
     FROM snapshot
     WHERE chain_id = $1 AND address = ANY($2)
   `, [chainId, strategies])
@@ -315,7 +316,7 @@ async function fetchStrategySnapshots(chainId: number, strategies: `0x${string}`
   return z.object({
     address: zhexstring,
     name: z.string().nullable(),
-    netAPR: z.string().nullable()
+    latestReportApr: z.string().nullable()
   }).array().parse(result.rows)
 }
 
@@ -342,8 +343,8 @@ export async function extractComposition(
     // Coalesce name: meta.name → snapshot.name → "Unknown"
     const name = meta?.displayName || snapshot?.name || 'Unknown'
 
-    // Parse netAPR
-    const netAPR = snapshot?.netAPR ? parseFloat(snapshot.netAPR) : null
+    // Parse latestReportApr
+    const latestReportApr = snapshot?.latestReportApr ? parseFloat(snapshot.latestReportApr) : null
 
     // Compute status based on debt and withdrawal queue membership
     let status: 'active' | 'inactive' | 'unallocated'
@@ -362,7 +363,7 @@ export async function extractComposition(
       address: strategy,
       name,
       status,
-      netAPR,
+      latestReportApr,
       performanceFee: debt?.performanceFee ?? 0n,
       activation: debt?.activation ?? 0n,
       debtRatio: debt?.debtRatio ?? 0n,

--- a/packages/ingest/abis/yearn/2/vault/snapshot/hook.ts
+++ b/packages/ingest/abis/yearn/2/vault/snapshot/hook.ts
@@ -337,10 +337,10 @@ export async function extractComposition(
 
     // Fetch strategy metadata (try vault meta first for dual-role addresses)
     const vaultMeta = await getVaultMeta(chainId, strategy)
-    const meta = vaultMeta.displayName ? vaultMeta : await getStrategyMeta(chainId, strategy)
+    const meta = vaultMeta?.displayName ? vaultMeta : await getStrategyMeta(chainId, strategy)
 
     // Coalesce name: meta.name → snapshot.name → "Unknown"
-    const name = meta.displayName || snapshot?.name || 'Unknown'
+    const name = meta?.displayName || snapshot?.name || 'Unknown'
 
     // Parse netAPR
     const netAPR = snapshot?.netAPR ? parseFloat(snapshot.netAPR) : null

--- a/packages/ingest/abis/yearn/3/vault/snapshot/hook.ts
+++ b/packages/ingest/abis/yearn/3/vault/snapshot/hook.ts
@@ -363,10 +363,10 @@ export async function extractComposition(
 
     // Fetch strategy metadata (try vault meta first for dual-role addresses)
     const vaultMeta = await getVaultMeta(chainId, strategy)
-    const meta = vaultMeta.displayName ? vaultMeta : await getStrategyMeta(chainId, strategy)
+    const meta = vaultMeta?.displayName ? vaultMeta : await getStrategyMeta(chainId, strategy)
 
     // Coalesce name: meta.name → snapshot.name → "Unknown"
-    const name = meta.displayName || snapshot?.name || 'Unknown'
+    const name = meta?.displayName || snapshot?.name || 'Unknown'
 
     // Parse netAPR
     const netAPR = snapshot?.netAPR ? parseFloat(snapshot.netAPR) : null

--- a/packages/ingest/abis/yearn/3/vault/snapshot/hook.ts
+++ b/packages/ingest/abis/yearn/3/vault/snapshot/hook.ts
@@ -19,7 +19,19 @@ export const CompositionSchema = z.object({
   address: zhexstring,
   name: z.string(),
   status: z.enum(['active', 'inactive', 'unallocated']),
-  netAPR: z.number().nullable(),
+  latestReportApr: z.number().nullish(),
+  performance: z.object({
+    oracle: z.object({
+      apr: z.number().nullish(),
+      apy: z.number().nullish()
+    }).nullish(),
+    historical: z.object({
+      net: z.number().nullish(),
+      weeklyNet: z.number().nullish(),
+      monthlyNet: z.number().nullish(),
+      inceptionNet: z.number().nullish()
+    }).nullish()
+  }).nullish(),
   activation: z.bigint(),
   lastReport: z.bigint(),
   currentDebt: z.bigint(),
@@ -118,6 +130,7 @@ export default async function process(chainId: number, address: `0x${string}`, d
     tvl: sparklines.tvl[0],
     apy,
     performance: {
+      estimated: undefined,
       oracle: {
         apr: oracleApr,
         apy: oracleApy
@@ -319,15 +332,28 @@ async function fetchStrategySnapshots(chainId: number, strategies: `0x${string}`
     SELECT
       address,
       snapshot->>'name' as name,
-      hook->'lastReportDetail'->'apr'->>'net' as "netAPR"
+      hook->'performance' as performance,
+      hook->'lastReportDetail'->'apr'->>'net' as "latestReportApr"
     FROM snapshot
     WHERE chain_id = $1 AND address = ANY($2)
   `, [chainId, strategies])
 
   return z.object({
     address: zhexstring,
-    name: z.string().nullable(),
-    netAPR: z.string().nullable()
+    name: z.string().nullish(),
+    performance: z.object({
+      oracle: z.object({
+        apr: z.number().nullish(),
+        apy: z.number().nullish()
+      }).nullish(),
+      historical: z.object({
+        net: z.number().nullish(),
+        weeklyNet: z.number().nullish(),
+        monthlyNet: z.number().nullish(),
+        inceptionNet: z.number().nullish()
+      }).nullish()
+    }).nullish(),
+    latestReportApr: z.string().nullish()
   }).array().parse(result.rows)
 }
 
@@ -368,8 +394,8 @@ export async function extractComposition(
     // Coalesce name: meta.name → snapshot.name → "Unknown"
     const name = meta?.displayName || snapshot?.name || 'Unknown'
 
-    // Parse netAPR
-    const netAPR = snapshot?.netAPR ? parseFloat(snapshot.netAPR) : null
+    // Parse latestReportApr
+    const latestReportApr = snapshot?.latestReportApr ? parseFloat(snapshot.latestReportApr) : null
 
     // Compute status based on debt and queue membership
     let status: 'active' | 'inactive' | 'unallocated'
@@ -385,7 +411,8 @@ export async function extractComposition(
       address: strategy,
       name,
       status,
-      netAPR,
+      performance: snapshot?.performance ?? undefined,
+      latestReportApr,
       activation: debt?.activation ?? 0n,
       lastReport: debt?.lastReport ?? 0n,
       currentDebt: debt?.currentDebt ?? 0n,


### PR DESCRIPTION
- instead of `netAPR` we should provide both `latestReportApr` and the full `performance` spread in strategy composition snapshots
-- this lets the client chose which performance measure is best
-- only v3 strategies will have `performance` because they are also vaults
- adds a `performance` spread to erc4626 snapshots for consistency

tested by targeting USDC-1 and USDC to USDS Depositor and indexing on a live db fork,

``` abis.local.yaml

  - abiPath: 'erc4626'
    sources: [
      { chainId: 1, address: '0x39c0aEc5738ED939876245224aFc7E09C8480a52', inceptBlock: 22440876 }
    ]

  - abiPath: 'yearn/3/vault'
    sources: [
      { chainId: 1, address: '0xBe53A109B494E5c9f97b9Cd39Fe969BE68BF6204', inceptBlock: 19419991 }
    ]

```