### PR TITLE
Increase webhook max outputs from 20 to 100

### DIFF
--- a/packages/ingest/extract/webhook.ts
+++ b/packages/ingest/extract/webhook.ts
@@ -77,7 +77,7 @@ export class WebhookExtractor {
         throw new Error(`Unexpected labels. Expected one of: ${subscription.labels.join(', ')}, Got: ${outputs.map(output => output.label).join(', ')}`)
       }
 
-      const MAX_OUTPUTS = 20
+      const MAX_OUTPUTS = 100
       if (outputs.length > MAX_OUTPUTS) {
         throw new Error(`Max outputs exceeded: ${outputs.length} > ${MAX_OUTPUTS}`)
       }


### PR DESCRIPTION
### Summary
Increases the maximum allowed outputs for webhook subscriptions from 20 to 100. This change allows webhooks to handle larger result sets without hitting the artificial limit.


### Test plan
Trigger a webhook subscription that generates between 20-100 outputs and verify it processes successfully