### PR TITLE
feat: add isStakingEnabled support for vault metadata

### DIFF
--- a/packages/lib/types.ts
+++ b/packages/lib/types.ts
@@ -254,7 +254,7 @@ export const VaultMetaSchema = z.object({
   kind: z.string(),
   isRetired: z.boolean(),
   isHidden: z.boolean(),
-  isStakingEnabled: z.boolean(),
+  shouldDisableStaking: z.boolean(),
   isAggregator: z.boolean(),
   isBoosted: z.boolean(),
   isAutomated: z.boolean(),

--- a/packages/lib/types.ts
+++ b/packages/lib/types.ts
@@ -254,6 +254,7 @@ export const VaultMetaSchema = z.object({
   kind: z.string(),
   isRetired: z.boolean(),
   isHidden: z.boolean(),
+  isStakingEnabled: z.boolean(),
   isAggregator: z.boolean(),
   isBoosted: z.boolean(),
   isAutomated: z.boolean(),


### PR DESCRIPTION

### Summary
UIs need a metadata flag which through Cms we can serve the staking status, ie: if that's enabled or not seemlesly removing complexity from frontend.

### How to review
- Update cms adding flag for isStakingEnabled = false
- run indexer for that vault
- check snapshot.hook.meta.isStakingEnabled
