### PR TITLE
fix: default cms optional prop

### DIFF
--- a/packages/lib/types.ts
+++ b/packages/lib/types.ts
@@ -254,7 +254,7 @@ export const VaultMetaSchema = z.object({
   kind: z.string(),
   isRetired: z.boolean(),
   isHidden: z.boolean(),
-  shouldDisableStaking: z.boolean(),
+  shouldDisableStaking: z.boolean().optional().default(false),
   isAggregator: z.boolean(),
   isBoosted: z.boolean(),
   isAutomated: z.boolean(),


### PR DESCRIPTION
Fix optional on staking metadata