### PR TITLE
fix: dont override meta on invalidation

### DIFF
--- a/packages/ingest/abis/yearn/lib/meta.ts
+++ b/packages/ingest/abis/yearn/lib/meta.ts
@@ -10,12 +10,7 @@ export async function getVaultMeta(chainId: number, address: `0x${string}`) {
     return (await getMetas<VaultMeta>(VaultMetaSchema, chainId, 'vaults'))[getAddress(address)]
   } catch(error) {
     console.log('🤬', '!meta', chainId, address)
-    return {
-      displayName: '',
-      displaySymbol: '',
-      description: '',
-      protocols: []
-    }
+    return undefined
   }
 }
 
@@ -24,11 +19,7 @@ export async function getStrategyMeta(chainId: number, address: `0x${string}`) {
     return (await getMetas<StrategyMeta>(StrategyMetaSchema, chainId, 'strategies'))[getAddress(address)]
   } catch(error) {
     console.log('🤬', '!meta', chainId, address)
-    return {
-      displayName: '',
-      description: '',
-      protocols: []
-    }
+    return undefined
   }
 }
 
@@ -37,12 +28,7 @@ export async function getTokenMeta(chainId: number, address: `0x${string}`) {
     return (await getMetas<TokenMeta>(TokenMetaSchema, chainId, 'tokens'))[getAddress(address)]
   } catch(error) {
     console.log('🤬', '!meta', chainId, address)
-    return {
-      displayName: '',
-      displaySymbol: '',
-      description: '',
-      protocols: []
-    }
+    return undefined
   }
 }
 

--- a/packages/ingest/abis/yearn/lib/meta.ts
+++ b/packages/ingest/abis/yearn/lib/meta.ts
@@ -59,7 +59,12 @@ async function extractMetas<T>(schema: z.ZodType<T>, chainId: number, type: 'tok
 
   const results: { [address: `0x${string}`]: T } = {}
   for (const item of json) {
-    results[getAddress(item.address)] = schema.parse(item)
+    try {
+      const parsedItem = schema.parse(item)
+      results[getAddress(item.address)] = parsedItem
+    } catch(error) {
+      console.log('🤬', '!meta', chainId, item.address)
+    }
   }
 
   return results

--- a/packages/ingest/load/index.ts
+++ b/packages/ingest/load/index.ts
@@ -108,7 +108,11 @@ export async function upsertSnapshot(data: object) {
 
     const filteredHook = filterNullMeta(snapshot.hook)
 
-    snapshot.hook = { ...currentHook, ...filteredHook }
+    snapshot.hook = {
+      ...currentHook,
+      ...filteredHook,
+      meta: { ...currentHook.meta, ...filteredHook.meta }
+    }
     await upsert(snapshot, 'snapshot', 'chain_id, address', undefined, client)
 
     await client.query('COMMIT')

--- a/packages/ingest/load/index.ts
+++ b/packages/ingest/load/index.ts
@@ -87,7 +87,9 @@ export async function upsertEvmLog(data: object) {
 }
 
 function filterNullMeta(hook: Record<string, any>) {
-  return Object.fromEntries(Object.entries(hook).filter(([, v]) => v != null))
+  const meta = hook.meta
+  hook.meta = Object.fromEntries(Object.entries(meta).filter(([, v]) => v != null))
+  return hook
 }
 
 export async function upsertSnapshot(data: object) {

--- a/packages/ingest/load/index.ts
+++ b/packages/ingest/load/index.ts
@@ -104,7 +104,7 @@ export async function upsertSnapshot(data: object) {
     snapshot.hook = {
       ...currentHook,
       ...snapshot.hook,
-      meta: snapshot.hook.meta ? { ...currentHook.meta, ...snapshot.hook.meta } : currentHook.meta
+      meta: snapshot.hook.meta ? { ...currentHook.meta, ...JSON.parse(JSON.stringify(snapshot.hook.meta)) } : currentHook.meta
     }
     await upsert(snapshot, 'snapshot', 'chain_id, address', undefined, client)
 

--- a/packages/ingest/load/index.ts
+++ b/packages/ingest/load/index.ts
@@ -86,11 +86,6 @@ export async function upsertEvmLog(data: object) {
   }
 }
 
-function filterNullMeta(hook: Record<string, any>) {
-  const meta = hook.meta
-  hook.meta = Object.fromEntries(Object.entries(meta).filter(([, v]) => v != null))
-  return hook
-}
 
 export async function upsertSnapshot(data: object) {
   const snapshot = SnapshotSchema.parse(data)
@@ -106,12 +101,10 @@ export async function upsertSnapshot(data: object) {
 
     snapshot.snapshot = { ...currentSnapshot, ...snapshot.snapshot }
 
-    const filteredHook = filterNullMeta(snapshot.hook)
-
     snapshot.hook = {
       ...currentHook,
-      ...filteredHook,
-      meta: { ...currentHook.meta, ...filteredHook.meta }
+      ...snapshot.hook,
+      meta: snapshot.hook.meta ? { ...currentHook.meta, ...snapshot.hook.meta } : currentHook.meta
     }
     await upsert(snapshot, 'snapshot', 'chain_id, address', undefined, client)
 

--- a/packages/ingest/load/index.ts
+++ b/packages/ingest/load/index.ts
@@ -86,6 +86,10 @@ export async function upsertEvmLog(data: object) {
   }
 }
 
+function filterNullMeta(hook: Record<string, any>) {
+  return Object.fromEntries(Object.entries(hook).filter(([, v]) => v != null))
+}
+
 export async function upsertSnapshot(data: object) {
   const snapshot = SnapshotSchema.parse(data)
   const client = await db.connect()
@@ -99,7 +103,10 @@ export async function upsertSnapshot(data: object) {
     )) ?? { snapshot: {}, hook: {} }
 
     snapshot.snapshot = { ...currentSnapshot, ...snapshot.snapshot }
-    snapshot.hook = { ...currentHook, ...snapshot.hook }
+
+    const filteredHook = filterNullMeta(snapshot.hook)
+
+    snapshot.hook = { ...currentHook, ...filteredHook }
     await upsert(snapshot, 'snapshot', 'chain_id, address', undefined, client)
 
     await client.query('COMMIT')


### PR DESCRIPTION
### Summary
This PR improves the robustness of metadata fetching and ingestion. It modifies metadata fetching functions in `meta.ts` to return `undefined` instead of blank objects on failure, avoiding valid data override with empty strings. It also updates the snapshot ingestion loader to filter out `undefined` meta values, preserving existing database records when transient errors occur.

### How to review
Start with `packages/ingest/abis/yearn/lib/meta.ts` to see the logic change (returning `undefined` on catch).
Then check `packages/ingest/load/index.ts` to see how `upsertSnapshot` filters `undefined` values from `snapshot.hook` before merging.
Review `packages/ingest/abis/yearn/lib/meta.spec.ts` and `packages/ingest/abis/yearn/2/strategy/snapshot/hook.spec.ts` for test coverage.
Ignore local config changes if present.

### Test plan
- [x] Automated: `npx mocha abis/yearn/2/strategy/snapshot/hook.spec.ts` verify hook process handles validation failure gracefully.
- [x] Manual: Ingestion of valid/invalid vaults to ensure no data loss (verified via unit/integration tests).
