### PR TITLE
Add 90-day APY component to historical APY calculation

### DIFF
--- a/packages/ingest/abis/yearn/lib/apy.spec.ts
+++ b/packages/ingest/abis/yearn/lib/apy.spec.ts
@@ -85,6 +85,10 @@ describe('abis/yearn/lib/apy', function() {
     expect(apy.monthlyPricePerShare).to.be.eq(1022834n)
     expect(Number(apy.monthlyBlockNumber)).to.be.closeTo(18130373, 4)
 
+    expect(apy.quarterlyNet).to.be.closeTo(0.015, 1e-2)
+    expect(apy.quarterlyPricePerShare).to.not.be.undefined
+    expect(Number(apy.quarterlyBlockNumber)).to.be.closeTo(17916283, 4)
+
     expect(apy.inceptionNet).to.be.closeTo(0.019352846869146623, 1e-5)
     expect(apy.inceptionPricePerShare).to.be.eq(1000000n)
     expect(Number(apy.inceptionBlockNumber)).to.be.closeTo(15243268, 4)
@@ -124,6 +128,10 @@ describe('abis/yearn/lib/apy', function() {
     expect(apy.monthlyNet).to.be.closeTo(0.008496634004203418, 1e-5)
     expect(apy.monthlyPricePerShare).to.be.eq(1001147n)
     expect(Number(apy.monthlyBlockNumber)).to.be.closeTo(15656324, 4)
+
+    expect(apy.quarterlyNet).to.be.undefined
+    expect(apy.quarterlyPricePerShare).to.be.undefined
+    expect(Number(apy.quarterlyBlockNumber)).to.be.closeTo(15227815, 4)
 
     expect(apy.inceptionNet).to.be.closeTo(0.007697361270727177, 1e-5)
     expect(apy.inceptionPricePerShare).to.be.eq(1000000n)
@@ -185,6 +193,10 @@ describe('abis/yearn/lib/apy', function() {
     expect(apy.monthlyNet).to.be.closeTo(0.293880331621855, 1e-5)
     expect(apy.monthlyPricePerShare).to.be.eq(1005328n)
     expect(Number(apy.monthlyBlockNumber)).to.be.closeTo(50876142, 4)
+
+    expect(apy.quarterlyNet).to.be.closeTo(0.17, 1e-2)
+    expect(apy.quarterlyPricePerShare).to.not.be.undefined
+    expect(Number(apy.quarterlyBlockNumber)).to.be.closeTo(49609196, 4)
 
     expect(apy.inceptionNet).to.be.closeTo(0.13935788133629456, 1e-5)
     expect(apy.inceptionPricePerShare).to.be.eq(1000000n)

--- a/packages/web/app/api/gql/typeDefs/vault.ts
+++ b/packages/web/app/api/gql/typeDefs/vault.ts
@@ -90,6 +90,8 @@ type Apy {
   weeklyPricePerShare: BigInt
   monthlyNet: Float
   monthlyPricePerShare: BigInt
+  quarterlyNet: Float
+  quarterlyPricePerShare: BigInt
   inceptionNet: Float
   grossApr: Float
   blockNumber: String!
@@ -124,6 +126,7 @@ type Historical {
   net: Float
   weeklyNet: Float
   monthlyNet: Float
+  quarterlyNet: Float
   inceptionNet: Float
 }
 

--- a/packages/web/app/api/rest/list/db.ts
+++ b/packages/web/app/api/rest/list/db.ts
@@ -36,6 +36,7 @@ export const VaultListItemSchema = z.object({
       net: CoerceNumber,
       weeklyNet: CoerceNumber,
       monthlyNet: CoerceNumber,
+      quarterlyNet: CoerceNumber,
       inceptionNet: CoerceNumber,
     }).nullish(),
     estimated: z.object({


### PR DESCRIPTION
### Summary
Adds a 90-day (quarterly) APY component to the historical APY calculation system, providing users with a medium-term performance view alongside the existing weekly, monthly, and inception metrics. This fills the gap between monthly (30-day) and inception timeframes for better vault performance analysis.

Closes #259

### How to review
1. **Start with the calculation logic**: Review `packages/ingest/abis/yearn/lib/apy.ts` to see how quarterly APY follows the same pattern as weekly/monthly
2. **Check the schema changes**: Verify the Zod schema includes `quarterlyNet`, `quarterlyPricePerShare`, and `quarterlyBlockNumber`
3. **Review API exposure**: Check GraphQL (`packages/web/app/api/gql/typeDefs/vault.ts`) and REST API (`packages/web/app/api/rest/list/db.ts`) schema updates
4. **Verify test coverage**: Look at `packages/ingest/abis/yearn/lib/apy.spec.ts` for test assertions including edge case handling

The changes are purely additive — no existing functionality is modified.

### Test plan
- [x] **Automated**: All existing tests updated with quarterly APY assertions
  - Run: \`bun --filter ingest test\`
  - Tests verify calculation correctness and edge case (vault age < 90 days returns undefined)
- [x] **Manual**: Verified with production data from vault 0xdA816459F1AB5631232FE5e97a05BBBb94970c95 (yvDAI)
  - Query: \`SELECT component, value FROM output WHERE chain_id = 1 AND address = '0xdA816459F1AB5631232FE5e97a05BBBb94970c95' AND label = 'apy-bwd-delta-pps' AND component LIKE 'quarterly%'\`
  - Confirmed quarterlyNet, quarterlyPricePerShare, and quarterlyBlockNumber are calculated correctly


```
{
  "data": {
    "vault": {
      "performance": {
        "historical": {
          "quarterlyNet": 0.04043234856505595
        }
      }
    }
  }
}
``` 
through gql

### Risk / impact
**Low risk** — This change follows the exact same pattern as existing weekly and monthly APY calculations:
- Uses the same \`compoundAndAnnualizeDelta\` function for consistency
- Handles edge cases identically (returns undefined when vault age < 90 days)
- Only adds new fields, doesn't modify existing calculations
- No database migrations required (outputs stored in existing \`output\` table)

**Rollback**: If issues arise, the quarterly fields can be safely ignored by clients — existing weekly/monthly/inception APY remain unchanged.