### PR TITLE
Update label from 'velodrome' to 'velo'

### DIFF
--- a/config/subscriptions.yaml
+++ b/config/subscriptions.yaml
@@ -13,6 +13,6 @@ subscriptions:
     url: 'https://v2-estimated-apr-hook.vercel.app/webhook'
     abiPath: 'yearn/2/vault'
     type: 'timeseries'
-    labels: ['crv-estimated-apr', 'aero-estimated-apr', 'velodrome-estimated-apr']
+    labels: ['crv-estimated-apr', 'aero-estimated-apr', 'velo-estimated-apr']
     filter:
       chainIds: [1, 10, 250, 42161]


### PR DESCRIPTION
Fixes "Unexpected labels. Expected one of: crv-estimated-apr, aero-estimated-apr, velodrome-estimated-apr, Got: velo-estimated-apr, velo-estimated-apr, velo-estimated-apr" errors in log that were preventing velo aprs from flowing in.

### How to review
Match the new label with the labels coming from the estimated apr service.

### Risk / impact
Low. Label is incorrect.