### PR TITLE
Add MQ job details page and fix erc4626 hook import

### DIFF
--- a/packages/ingest/abis/erc4626/snapshot/hook.ts
+++ b/packages/ingest/abis/erc4626/snapshot/hook.ts
@@ -2,7 +2,8 @@ import { EvmAddressSchema, ThingSchema } from 'lib/types'
 import { z } from 'zod'
 import { fetchOrExtractErc20 } from '../../yearn/lib'
 import { mq } from 'lib'
-import { getLatestApy, getLatestOracleApr, getSparkline } from '../../../db'
+import { getSparkline } from '../../../db'
+import { getLatestApy, getLatestOracleApr } from '../../../helpers/apy-apr'
 
 export default async function process(chainId: number, address: `0x${string}`, data: object) {
   const { asset } = z.object({ asset: EvmAddressSchema }).parse(data)

--- a/packages/web/app/mq/[queue]/[status]/page.tsx
+++ b/packages/web/app/mq/[queue]/[status]/page.tsx
@@ -102,7 +102,11 @@ export default async function JobsList({
 
             return (
               <tr key={job.id}>
-                <td>{job.id}</td>
+                <td>
+                  <Link href={`/mq/${encodeURIComponent(queueName)}/job/${job.id}`} className={styles.jobIdLink}>
+                    {job.id}
+                  </Link>
+                </td>
                 <td>{job.name}</td>
                 <td title={new Date(job.timestamp || 0).toISOString()}>{ageStr} ago</td>
                 <td>{job.attemptsMade}</td>

--- a/packages/web/app/mq/[queue]/job/[jobId]/page.tsx
+++ b/packages/web/app/mq/[queue]/job/[jobId]/page.tsx
@@ -1,0 +1,116 @@
+import { redirect, notFound } from 'next/navigation'
+import Link from 'next/link'
+import { getJobById, queueNames } from '../../../lib'
+import styles from '../../../mq.module.css'
+
+export const dynamic = 'force-dynamic'
+
+type Params = Promise<{ queue: string; jobId: string }>
+
+function formatTimestamp(ts: number | undefined): string {
+  if (!ts) return '-'
+  return new Date(ts).toISOString().replace('T', ' ').slice(0, 19)
+}
+
+function formatDuration(start: number | undefined, end: number | undefined): string {
+  if (!start || !end) return '-'
+  const ms = end - start
+  if (ms < 1000) return `${ms}ms`
+  if (ms < 60000) return `${(ms / 1000).toFixed(2)}s`
+  return `${(ms / 60000).toFixed(2)}m`
+}
+
+export default async function JobDetail({ params }: { params: Params }) {
+  if (process.env.NODE_ENV !== 'development') {
+    redirect('/')
+  }
+
+  const { queue, jobId } = await params
+  const queueName = decodeURIComponent(queue)
+
+  if (!queueNames.includes(queueName)) {
+    notFound()
+  }
+
+  const job = await getJobById(queueName, jobId)
+
+  if (!job) {
+    notFound()
+  }
+
+  const waitTime = formatDuration(job.timestamp, job.processedOn)
+  const runTime = formatDuration(job.processedOn, job.finishedOn)
+
+  return (
+    <div className={styles.container}>
+      <p className={styles.backLink}>
+        <Link href={`/mq/${encodeURIComponent(queueName)}`}>&larr; Back to {queueName}</Link>
+      </p>
+      <h1>Job {job.id}</h1>
+
+      <div className={styles.jobDetail}>
+        <div className={styles.detailRow}>
+          <span className={styles.detailLabel}>Queue</span>
+          <span>{queueName}</span>
+        </div>
+        <div className={styles.detailRow}>
+          <span className={styles.detailLabel}>Name</span>
+          <span>{job.name}</span>
+        </div>
+        <div className={styles.detailRow}>
+          <span className={styles.detailLabel}>Attempts</span>
+          <span>{job.attemptsMade}</span>
+        </div>
+      </div>
+
+      <h2>Timeline</h2>
+      <div className={styles.timeline}>
+        <div className={styles.timelineItem}>
+          <span className={styles.timelineDot}></span>
+          <span className={styles.timelineLabel}>Created</span>
+          <span className={styles.timelineValue}>{formatTimestamp(job.timestamp)}</span>
+        </div>
+        <div className={styles.timelineItem}>
+          <span className={styles.timelineDot}></span>
+          <span className={styles.timelineLabel}>Processed</span>
+          <span className={styles.timelineValue}>
+            {formatTimestamp(job.processedOn)}
+            {job.processedOn && <span className={styles.timelineDuration}>(waited {waitTime})</span>}
+          </span>
+        </div>
+        <div className={styles.timelineItem}>
+          <span className={styles.timelineDot}></span>
+          <span className={styles.timelineLabel}>Finished</span>
+          <span className={styles.timelineValue}>
+            {formatTimestamp(job.finishedOn)}
+            {job.finishedOn && <span className={styles.timelineDuration}>(ran {runTime})</span>}
+          </span>
+        </div>
+      </div>
+
+      <h2>Data</h2>
+      <pre className={styles.fullData}>{JSON.stringify(job.data, null, 2)}</pre>
+
+      {job.returnvalue !== undefined && job.returnvalue !== null && (
+        <>
+          <h2>Return Value</h2>
+          <pre className={styles.fullData}>{JSON.stringify(job.returnvalue, null, 2)}</pre>
+        </>
+      )}
+
+      {job.failedReason && (
+        <>
+          <h2>Error</h2>
+          <p className={styles.errorMessage}>{job.failedReason}</p>
+        </>
+      )}
+
+      {job.stacktrace && job.stacktrace.length > 0 && (
+        <>
+          <h2>Stack Trace</h2>
+          <pre className={styles.stacktrace}>{job.stacktrace.join('\n')}</pre>
+        </>
+      )}
+    </div>
+  )
+}

--- a/packages/web/app/mq/lib.ts
+++ b/packages/web/app/mq/lib.ts
@@ -78,3 +78,21 @@ export async function getQueueJobs(name: string, status: JobStatus, start = 0, e
     returnvalue: job.returnvalue
   }))
 }
+
+export async function getJobById(queueName: string, jobId: string): Promise<JobInfo | null> {
+  const queue = getQueue(queueName)
+  const job = await queue.getJob(jobId)
+  if (!job) return null
+  return {
+    id: job.id,
+    name: job.name,
+    data: job.data,
+    timestamp: job.timestamp,
+    processedOn: job.processedOn,
+    finishedOn: job.finishedOn,
+    attemptsMade: job.attemptsMade,
+    failedReason: job.failedReason,
+    stacktrace: job.stacktrace,
+    returnvalue: job.returnvalue
+  }
+}

--- a/packages/web/app/mq/mq.module.css
+++ b/packages/web/app/mq/mq.module.css
@@ -158,3 +158,116 @@
 .backLink {
   margin-bottom: 15px;
 }
+
+.jobDetail {
+  background: #16213e;
+  padding: 15px;
+  border-radius: 8px;
+  margin: 15px 0;
+}
+
+.detailRow {
+  display: flex;
+  gap: 15px;
+  padding: 8px 0;
+  border-bottom: 1px solid #333;
+}
+
+.detailRow:last-child {
+  border-bottom: none;
+}
+
+.detailLabel {
+  color: #888;
+  min-width: 100px;
+}
+
+.timeline {
+  background: #16213e;
+  padding: 15px;
+  border-radius: 8px;
+  margin: 15px 0;
+}
+
+.timelineItem {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 0;
+  position: relative;
+}
+
+.timelineItem:not(:last-child)::after {
+  content: '';
+  position: absolute;
+  left: 5px;
+  top: 28px;
+  width: 2px;
+  height: calc(100% - 8px);
+  background: #333;
+}
+
+.timelineDot {
+  width: 12px;
+  height: 12px;
+  background: #4da6ff;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.timelineLabel {
+  color: #888;
+  min-width: 80px;
+}
+
+.timelineValue {
+  font-family: monospace;
+}
+
+.timelineDuration {
+  color: #888;
+  margin-left: 10px;
+  font-size: 12px;
+}
+
+.fullData {
+  background: #0d1117;
+  border: 1px solid #333;
+  border-radius: 8px;
+  padding: 15px;
+  overflow-x: auto;
+  font-family: monospace;
+  font-size: 12px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.stacktrace {
+  background: #1a0000;
+  border: 1px solid #5c0000;
+  border-radius: 8px;
+  padding: 15px;
+  overflow-x: auto;
+  font-family: monospace;
+  font-size: 12px;
+  color: #ff6b6b;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.errorMessage {
+  color: #ff6b6b;
+  background: #1a0000;
+  border: 1px solid #5c0000;
+  border-radius: 8px;
+  padding: 15px;
+}
+
+.jobIdLink {
+  color: #4da6ff;
+  text-decoration: none;
+}
+
+.jobIdLink:hover {
+  text-decoration: underline;
+}


### PR DESCRIPTION
## Summary
- Add job details page at `/mq/[queue]/job/[jobId]` to view full job info in the MQ dashboard
- Fix broken import in erc4626 snapshot hook that was causing `getLatestOracleApr is not a function` errors

## Changes
- **Job details page**: Shows full JSON data, timeline (created → processed → finished), attempts, stack traces for failed jobs, and return values
- **Import fix**: `getLatestApy` and `getLatestOracleApr` are in `helpers/apy-apr.ts`, not `db.ts`

## Test plan
- [ ] Verify erc4626 snapshot hooks no longer throw import errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)