### PR TITLE
Add new fields to vault list endpoint

### DIFF
--- a/packages/web/app/api/rest/list/db.ts
+++ b/packages/web/app/api/rest/list/db.ts
@@ -96,6 +96,9 @@ export const VaultListItemSchema = z.object({
     address: z.string().nullish(),
     available: z.boolean(),
   }).nullable(),
+
+  // Price
+  pricePerShare: CoerceNumber,
 })
 
 export type VaultListItem = z.infer<typeof VaultListItemSchema>
@@ -195,7 +198,10 @@ export async function getVaultsList(): Promise<VaultListItem[]> {
           'address', snapshot.hook->'staking'->>'address',
           'available', (snapshot.hook->'staking'->>'available')::boolean
         )
-      ELSE NULL END AS staking
+      ELSE NULL END AS staking,
+
+      -- Price
+      (snapshot.snapshot->>'pricePerShare')::numeric AS "pricePerShare"
 
     FROM thing
     LEFT JOIN snapshot

--- a/packages/web/app/api/rest/list/db.ts
+++ b/packages/web/app/api/rest/list/db.ts
@@ -86,6 +86,16 @@ export const VaultListItemSchema = z.object({
   migration: z.boolean(),
 
   origin: z.string().nullable(),
+
+  // Inception
+  inceptBlock: CoerceNumber,
+  inceptTime: CoerceNumber,
+
+  // Staking
+  staking: z.object({
+    address: z.string().nullish(),
+    available: z.boolean(),
+  }).nullable(),
 })
 
 export type VaultListItem = z.infer<typeof VaultListItemSchema>
@@ -173,7 +183,19 @@ export async function getVaultsList(): Promise<VaultListItem[]> {
       COALESCE((snapshot.hook->'meta'->'migration'->>'available')::boolean, false) AS "migration",
 
       -- Origin
-      thing.defaults->>'origin' AS origin
+      thing.defaults->>'origin' AS origin,
+
+      -- Inception
+      (thing.defaults->>'inceptBlock')::bigint AS "inceptBlock",
+      (thing.defaults->>'inceptTime')::bigint AS "inceptTime",
+
+      -- Staking
+      CASE WHEN snapshot.hook->'staking' IS NOT NULL THEN
+        jsonb_build_object(
+          'address', snapshot.hook->'staking'->>'address',
+          'available', (snapshot.hook->'staking'->>'available')::boolean
+        )
+      ELSE NULL END AS staking
 
     FROM thing
     LEFT JOIN snapshot


### PR DESCRIPTION
### Summary
Add `inceptBlock`, `inceptTime`, `staking`, and `pricePerShare` fields to the vault list REST endpoint. These fields provide additional vault metadata needed by consumers.

### How to review
Single file change in `packages/web/app/api/rest/list/db.ts`:
- Schema additions at the top
- SQL query additions at the bottom

### Test plan
- [ ] Manual:
  - configure webops read replica db
  - start redis `docker run --rm -p 6379:6379 redis:latest`
  - refresh list cache `bun packages/web/app/api/rest/list/refresh.ts`
  - run web server `cd packages/web && bun dev`
  - verify new fields
  ```
  curl http://localhost:3000/api/rest/list/vaults?origin=yearn \
  | jq '.[] | select(.address == "0x182863131F9a4630fF9E27830d945B1413e347E8") | { chainId, address, pricePerShare, inceptTime, inceptBlock, staking }'
  ```

### Risk / impact
Low risk - additive changes only, no existing fields modified.