### PR TITLE
fix: cache on gql queries

### DIFF
--- a/packages/web/app/api/gql/route.ts
+++ b/packages/web/app/api/gql/route.ts
@@ -30,7 +30,7 @@ const plugins = [
 if (enableCache) {
   const store = new KeyvRedis(redisUrl)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const cache = new CustomKeyvAdapter(new Keyv<string>(store as any))
+  const cache = new CustomKeyvAdapter(new Keyv<string>({ store: store as any }))
   plugins.push(ApolloServerPluginCacheControl({ defaultMaxAge: defaultCacheMaxAge }))
   plugins.push(responseCachePlugin({ cache }))
 }

--- a/packages/web/app/api/gql/typeDefs/index.ts
+++ b/packages/web/app/api/gql/typeDefs/index.ts
@@ -41,7 +41,7 @@ const query = gql`
     monitor: Monitor @cacheControl(maxAge: 2)
     allocator(chainId: Int!, vault: String!): Allocator
     vaults(chainId: Int, apiVersion: String, erc4626: Boolean, v3: Boolean, yearn: Boolean, origin: String, addresses: [String], vaultType: Int, riskLevel: Int, unratedOnly: Boolean): [Vault]
-    vault(chainId: Int, address: String): Vault
+    vault(chainId: Int, address: String): Vault @cacheControl(maxAge: 3000)
     vaultAccounts(chainId: Int, vault: String): [AccountRole]
     vaultReports(chainId: Int, address: String): [VaultReport]
     vaultStrategies(chainId: Int, vault: String): [Strategy]


### PR DESCRIPTION

### Summary
During changes to infra moving to a new redis provider, we found gql queries were not working.

After further investigation i realized it was not set for the query i was using and the definition of store was wrong given the KEYV constructor.