### PR TITLE
Update locked yvUSD address for chainId 1 in manuals.yaml

### DIFF
--- a/config/manuals.yaml
+++ b/config/manuals.yaml
@@ -128,7 +128,7 @@ manuals:
     }
 
   - chainId: 1
-    address: '0xAb9018A699003a777d690c156045DfC4A7ef3A96'
+    address: '0xAaaFEa48472f77563961Cdb53291DEDfB46F9040'
     label: 'vault'
     defaults: {
       erc4626: true,


### PR DESCRIPTION
update locked yvUSD address so kong indexes the most current one. confirmed by Schlag.

### Summary
update locked yvUSD address so kong indexes the most current one

### How to review
confrim this looks right: https://etherscan.io/address/0xaaafea48472f77563961cdb53291dedfb46f9040

### Test plan
- will be tested more as it is integrated into the FE.

### Risk / impact
Not currently
