### PR TITLE
Add PoolTogether vault indexing via erc4626 hooks

### DIFF
--- a/config/abis.yaml
+++ b/config/abis.yaml
@@ -15,6 +15,14 @@ abis:
       ]
     }
 
+  - abiPath: 'pooltogether/vault'
+    things: {
+      label: 'vault',
+      filter: [
+        { field: 'origin', op: '=', value: 'pooltogether' }
+      ]
+    }
+
   - abiPath: 'yearn/governance/votingEscrow'
     sources: [
       { chainId: 1, address: '0x200C92Dd85730872Ab6A1e7d5E40A067066257cF', inceptBlock: 18370588 }
@@ -116,7 +124,8 @@ abis:
       label: 'vault',
       filter: [
         { field: 'apiVersion', op: '>=', value: '3.0.0' },
-        { field: 'origin', op: '!=', value: 'ydaemon' }
+        { field: 'origin', op: '!=', value: 'ydaemon' },
+        { field: 'origin', op: '!=', value: 'pooltogether' }
       ]
     }
 

--- a/packages/ingest/abis/pooltogether/vault/abi.ts
+++ b/packages/ingest/abis/pooltogether/vault/abi.ts
@@ -1,0 +1,1 @@
+export { default } from '../../erc4626/abi'

--- a/packages/ingest/abis/pooltogether/vault/snapshot/hook.ts
+++ b/packages/ingest/abis/pooltogether/vault/snapshot/hook.ts
@@ -1,0 +1,1 @@
+export { default } from '../../../erc4626/snapshot/hook'

--- a/packages/ingest/abis/pooltogether/vault/timeseries/apy/hook.ts
+++ b/packages/ingest/abis/pooltogether/vault/timeseries/apy/hook.ts
@@ -1,0 +1,1 @@
+export { outputLabel, default } from '../../../../erc4626/timeseries/apy/hook'

--- a/packages/ingest/abis/pooltogether/vault/timeseries/pps/hook.ts
+++ b/packages/ingest/abis/pooltogether/vault/timeseries/pps/hook.ts
@@ -1,0 +1,1 @@
+export { outputLabel, default } from '../../../../erc4626/timeseries/pps/hook'

--- a/packages/ingest/abis/pooltogether/vault/timeseries/tvl-c/hook.ts
+++ b/packages/ingest/abis/pooltogether/vault/timeseries/tvl-c/hook.ts
@@ -1,0 +1,1 @@
+export { outputLabel, default } from '../../../../erc4626/timeseries/tvl-c/hook'

--- a/packages/ingest/abis/pooltogether/vault/timeseries/tvl/hook.ts
+++ b/packages/ingest/abis/pooltogether/vault/timeseries/tvl/hook.ts
@@ -1,0 +1,1 @@
+export { outputLabel, default } from '../../../../erc4626/timeseries/tvl/hook'


### PR DESCRIPTION
### Summary
Add a dedicated `pooltogether/vault` ABI path so PoolTogether prize vaults get indexed for TVL, APY, and PPS. These vaults (origin=pooltogether) were previously falling through all vault filters — no snapshot enrichment, no timeseries data.

The new hooks re-export from the existing `erc4626` path since PoolTogether vaults are standard ERC-4626. Also excludes `origin=pooltogether` from the `yearn/3/vault` filter to prevent double-matching.

**Vaults:**
- `0x3A49…` (mainnet, USDC)
- `0x4147…` (mainnet, DAI)
- `0x723A…` (arbitrum)
- `0x801c…` (arbitrum)
- `0x482C…` (arbitrum)

### How to review
1. `config/abis.yaml` — new `pooltogether/vault` entry and updated `yearn/3/vault` filter
2. `packages/ingest/abis/pooltogether/vault/` — all files are one-line re-exports from `erc4626`

### Test plan
- [x] Automated: `bun --filter lib test` and `bun --filter ingest test` pass (no new failures)
- [x] Manual: ran ingest locally, confirmed fanout picks up both vaults via `pooltogether/vault`, snapshots produce correct on-chain data (totalAssets, asset info, name/symbol), no double-matching by `yearn/3/vault`
- [ ] Post-deploy: update `origin` to `pooltogether` in prod DB for the 5 vaults, run `fanout abis`, verify output table populates after a few cycles

### Risk / impact
Low risk. Only affects vaults with `origin=pooltogether` (requires manual DB update). No existing vault indexing is changed. Easy rollback: remove the yaml entry.

🤖 Generated with [Claude Code](https://claude.ai/code)