### PR TITLE
fix: remove lower to make query significant faster

### DIFF
--- a/packages/ingest/helpers/apy-apr.ts
+++ b/packages/ingest/helpers/apy-apr.ts
@@ -7,10 +7,12 @@ export async function getLatestEstimatedAprV3(chainId: number, address: string) 
   SELECT label, component, value
   FROM output
   WHERE block_time = (
-      SELECT MAX(block_time) FROM output
+      SELECT block_time FROM output
       WHERE chain_id = $1
       AND address = $2
       AND label LIKE '%-estimated-apr'
+      ORDER BY block_time DESC
+      LIMIT 1
     )
     AND chain_id = $1
     AND address = $2

--- a/packages/ingest/helpers/apy-apr.ts
+++ b/packages/ingest/helpers/apy-apr.ts
@@ -9,11 +9,11 @@ export async function getLatestEstimatedAprV3(chainId: number, address: string) 
   WHERE block_time = (
       SELECT MAX(block_time) FROM output
       WHERE chain_id = $1
-      AND LOWER(address) = LOWER($2)
+      AND address = $2
       AND label LIKE '%-estimated-apr'
     )
     AND chain_id = $1
-    AND LOWER(address) = LOWER($2)
+    AND address = $2
     AND label LIKE '%-estimated-apr'
   `, [chainId, address])
 


### PR DESCRIPTION
## Summary

Remove `LOWER()` from the `output` query so the existing `(chain_id, address)` index is used instead of full chunk scans. Despite having a index on the address itself, apparently pg struggled with that more than expected. Removing it makes it much faster. Im going to check other solutions, possibly another index on lower, because this can create mistakes when there's casing issues on vault addresses!

I also moved away from max into a order by with limit, which can leverage timescaledb sortered chunks much better.


## Performance
Old

```
EXPLAIN ANALYZE
SELECT
  label,
  component,
  value
FROM output
WHERE block_time = (
  SELECT MAX(block_time)
  FROM output
  WHERE chain_id = 1
    AND LOWER(address) = LOWER('0x696d02Db93291651ED510704c9b286841d506987')
    AND label LIKE '%-estimated-apr'
)
  AND chain_id = 1
  AND LOWER(address) = ('0x696d02Db93291651ED510704c9b286841d506987')
  AND label LIKE '%-estimated-apr'
```

```
Gather  (cost=595357.04..1150472.79 rows=113 width=30) (actual time=62553.335..62556.923 rows=0 loops=1)
  Workers Planned: 2
  Params Evaluated: $1
  Workers Launched: 2
  InitPlan 1 (returns $1)
    ->  Finalize Aggregate  (cost=587255.52..587255.53 rows=1 width=8) (actual time=62536.361..62538.505 rows=1 loops=1)
          ->  Gather  (cost=9963.79..587254.96 rows=226 width=8) (actual
...
              Filter: ((label ~~ '%-estimated-apr'::text) AND (block_time = $1) AND (chain_id = 1) AND (lower(address) = '0x696d02Db93291651ED510704c9b286841d506987'::text))
Planning Time: 15.012 ms
Execution Time: 62561.273 ms
```


New

```
EXPLAIN ANALYZE SELECT label, component, value
FROM output
WHERE chain_id = 1
  AND address = '0x696d02Db93291651ED510704c9b286841d506987'
  AND label LIKE '%-estimated-apr'
  AND block_time = (
    SELECT block_time
    FROM output
    WHERE chain_id = 1
      AND address = '0x696d02Db93291651ED510704c9b286841d506987'
      AND label LIKE '%-estimated-apr'
    ORDER BY block_time DESC
    LIMIT 1
  );
```

```
Custom Scan (ChunkAppend) on output  (cost=35146.20..70316.09 rows=113 width=30) (actual time=21.822..21.890 rows=0 loops=1)
  Hypertables excluded during runtime: 1
  InitPlan 1 (returns $0)
    ->  Limit  (cost=35145.91..35145.91 rows=1 width=8) (actual time=21.804..21.855 rows=0 loops=1)
          ->  Sort  (cost=35145.91..35146.19 rows=113 width=8) (actual time=21.802..21.854 rows=0 loops=1)
                Sort Key: _hyper_10_27_chunk_1.block_time DESC
                Sort Method: quicksort  Memory: 25kB
      ...
Filter: ((label ~~ '%-estimated-apr'::text) AND (block_time = $0))
Planning Time: 8.351 ms
Execution Time: 11.589 ms
```



