### PR TITLE
Add yvUSD default data

### DIFF
--- a/config/manuals.yaml
+++ b/config/manuals.yaml
@@ -133,6 +133,7 @@ manuals:
     defaults: {
       erc4626: true,
       v3: true,
+      yearn: true,
       apiVersion: '3.0.4',
       origin: "yearn",
       name: 'yvUSD',
@@ -148,6 +149,7 @@ manuals:
     defaults: {
       erc4626: true,
       v3: true,
+      yearn: true,
       apiVersion: '3.0.4',
       origin: "yearn",
       name: 'Locked yvUSD',

--- a/config/manuals.yaml
+++ b/config/manuals.yaml
@@ -128,12 +128,28 @@ manuals:
     }
 
   - chainId: 1
+    address: '0x696d02Db93291651ED510704c9b286841d506987'
+    label: 'vault'
+    defaults: {
+      erc4626: true,
+      v3: true,
+      apiVersion: '3.0.4',
+      origin: "yearn",
+      name: 'yvUSD',
+      asset: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+      decimals: 6,
+      inceptBlock: 24271831,
+      inceptTime: 1768861991
+    }
+
+  - chainId: 1
     address: '0xAaaFEa48472f77563961Cdb53291DEDfB46F9040'
     label: 'vault'
     defaults: {
       erc4626: true,
       v3: true,
       apiVersion: '3.0.4',
+      origin: "yearn",
       name: 'Locked yvUSD',
       asset: '0x696d02Db93291651ED510704c9b286841d506987',
       decimals: 6,


### PR DESCRIPTION
### Summary
Add manual default data for the new yvUSD vaults on Ethereum mainnet. This sets up two entries in `config/manuals.yaml`:

- **yvUSD** (`0x696d02Db93291651ED510704c9b286841d506987`) — v3.0.4 vault with USDC as the underlying asset
- **Locked yvUSD** (`0xAaaFEa48472f77563961Cdb53291DEDfB46F9040`) — v3.0.4 vault with yvUSD as the underlying asset

Both entries include ERC-4626 and v3 flags, inception block/time, and decimal configuration. Setting `origin: "yearn"` in the defaults will include these vaults in Yearn vault lists and Yearn CMS.

### How to review
Single file change in `config/manuals.yaml` — check the two new entries at the bottom of the file for correct addresses, chain ID, and default values.

### Test plan
- [ ] Manual: Run fanout and verify the yvUSD vaults are picked up with the correct defaults

### Risk / impact
Config-only change. No code changes, no migrations. Low risk.