### PR TITLE
Generalize estimated APR components schema to accept dynamic keys

### DIFF
--- a/packages/web/app/api/rest/list/db.ts
+++ b/packages/web/app/api/rest/list/db.ts
@@ -42,17 +42,7 @@ export const VaultListItemSchema = z.object({
       apr: z.number(),
       apy: z.number(),
       type: z.string(),
-      components: z.object({
-        boost: z.number().nullish(),
-        poolAPY: z.number().nullish(),
-        boostedAPR: z.number().nullish(),
-        baseAPR: z.number().nullish(),
-        rewardsAPR: z.number().nullish(),
-        rewardsAPY: z.number().nullish(),
-        cvxAPR: z.number().nullish(),
-        keepCRV: z.number().nullish(),
-        keepVelo: z.number().nullish()
-      })
+      components: z.record(z.string(), z.union([z.number(), z.string()]).nullable()).optional(),
     }).nullish(),
   }).nullish(),
 


### PR DESCRIPTION
### Summary
The `VaultListItemSchema` in the REST list endpoint had a hardcoded Zod object for estimated APR components (`boost`, `poolAPY`, `boostedAPR`, `baseAPR`, `rewardsAPR`, etc.). This breaks validation when vaults return component keys not listed in the schema. Replaced with a generic `z.record()` that accepts any string key with number/string/null values, making the schema forward-compatible with new APR component types.

### How to review
Single file change in `packages/web/app/api/rest/list/db.ts`. Compare the old hardcoded object shape with the new `z.record()` — the rest of the schema is untouched.

### Test plan

- [ ] start redis if not already started
```
docker start redis 2>/dev/null || docker run -d --name redis -p 6379:6379 redis
timeout 1 bash -c '</dev/tcp/127.0.0.1/6379' 2>/dev/null && echo up || echo down
```

- [ ] configure redis cache in `packages/web/.env`
```
REST_CACHE_REDIS_URL=redis://localhost:6379
```

- [ ] configure database read replica in `.env` and `packages/web/.env.local`
```
POSTGRES_HOST=<read-replica-host>
POSTGRES_DATABASE=neondb
POSTGRES_USER=<user>
POSTGRES_PASSWORD=<password>
POSTGRES_SSL=true
POSTGRES_PORT=5432
```

- [ ] start web server
```
(cd packages/web && bun dev)
```

- [ ] run the refresh script to populate the Redis cache
```
bun packages/web/app/api/rest/list/refresh.ts
```
Expected: completes without Zod validation errors, e.g. `✓ Completed: 2021 vaults cached across 11 chains`

- [ ] list length matches script output
```
curl -s http://localhost:3000/api/rest/list/vaults | jq 'length'
```
Expected: `2021` (or matching the number from the refresh output)

- [ ] confirm estimated components with dynamic keys are present in the cached response
```
curl -s 'http://localhost:3000/api/rest/list/vaults' | jq '[.[] | select(.performance?.estimated?.components? != null)][0].performance.estimated'
```
Expected: components object with dynamic keys, e.g.:
```json
{
  "apr": 0.4755801625226109,
  "apy": 0.068,
  "type": "katana-estimated-apr",
  "components": {
    "netAPR": 0.4755801625226109,
    "netAPY": 0.068,
    "katanaBonusAPY": 0.068,
    "katanaNativeYield": 0.027094828234592194,
    "katanaAppRewardsAPR": 0.09848533428801876,
    "steerPointsPerDollar": 0.1934,
    "fixedRateKatanaRewards": 0.35
  }
}
```

- [ ] stop redis if you started it
```
docker stop redis 2>/dev/null || true
timeout 1 bash -c '</dev/tcp/127.0.0.1/6379' 2>/dev/null && echo up || echo down
```
