### PR TITLE
fix: add 7-day freshness filter to estimated APR queries

### DIFF
--- a/packages/ingest/helpers/apy-apr.ts
+++ b/packages/ingest/helpers/apy-apr.ts
@@ -11,6 +11,7 @@ export async function getLatestEstimatedAprV3(chainId: number, address: string) 
       WHERE chain_id = $1
       AND address = $2
       AND label LIKE '%-estimated-apr'
+      AND block_time > NOW() - INTERVAL '7 days'
       ORDER BY block_time DESC
       LIMIT 1
     )
@@ -59,6 +60,7 @@ export async function getLatestEstimatedApr(chainId: number, address: string) {
       WHERE chain_id = $1
       AND LOWER(address) = LOWER($2)
       AND label IN ('crv-estimated-apr', 'velo-estimated-apr', 'aero-estimated-apr')
+      AND block_time > NOW() - INTERVAL '7 days'
     )
     AND chain_id = $1
     AND LOWER(address) = LOWER($2)


### PR DESCRIPTION
## Summary

- Adds `AND block_time > NOW() - INTERVAL '7 days'` to the inner subqueries in both `getLatestEstimatedAprV3` and `getLatestEstimatedApr`
- Estimated APR data older than 7 days is now treated as stale and ignored, causing the functions to return `undefined`

## Context

Vault `0x468C76f16B7735303f7215b3839D270d058b3d7a` (Curve eUSD-FRAXBP Factory yVault) was showing estimated APR/APY of `3.26e+31`. The Curve gauge was killed, so the webhook stopped producing new estimated APR data — but the last (absurd) value persisted in the `output` table and was served indefinitely.

This is the Kong-side companion to [yearn/v2-estimated-apr-hook#18](https://github.com/yearn/v2-estimated-apr-hook/pull/18), which fixes the webhook to skip killed gauges and guard against zero working supply.

## Changes

### `packages/ingest/helpers/apy-apr.ts`

1. **`getLatestEstimatedAprV3`**: Added 7-day freshness constraint to the block_time subquery
2. **`getLatestEstimatedApr`**: Added 7-day freshness constraint to the block_time subquery

When no data exists within the 7-day window, the subquery returns NULL, the outer query returns no rows, and the function returns `undefined` — so stale estimated APR is no longer displayed.

## Test plan

- [ ] After deploy: `GET /api/rest/snapshot/1/0x468C76f16B7735303f7215b3839D270d058b3d7a` should show `performance.estimated` as `null` (stale data filtered)
- [ ] Vaults with active webhooks producing fresh data continue to show estimated APR normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)