### PR TITLE
Only include netAPR and netAPY in estimated APR response when present

### DIFF
--- a/packages/ingest/helpers/apy-apr.ts
+++ b/packages/ingest/helpers/apy-apr.ts
@@ -27,11 +27,13 @@ export async function getLatestEstimatedAprV3(chainId: number, address: string) 
     if (row.value != null) components[row.component] = row.value
   }
 
+  const { netAPR, netAPY, ...componentsNonAprAPY } = components
+
   return {
     type: result.rows[0].label,
-    apr: components.netAPR ?? 0,
-    apy: components.netAPY ?? 0,
-    components
+    ...(netAPR != null ? { apr: netAPR } : {}),
+    ...(netAPY != null ? { apy: netAPY } : {}),
+    components: componentsNonAprAPY
   }
 }
 

--- a/packages/ingest/helpers/apy-apr.ts
+++ b/packages/ingest/helpers/apy-apr.ts
@@ -27,13 +27,13 @@ export async function getLatestEstimatedAprV3(chainId: number, address: string) 
     if (row.value != null) components[row.component] = row.value
   }
 
-  const { netAPR, netAPY, ...componentsNonAprAPY } = components
+  const { netAPR, netAPY, ...rest } = components
 
   return {
     type: result.rows[0].label,
     ...(netAPR != null ? { apr: netAPR } : {}),
     ...(netAPY != null ? { apy: netAPY } : {}),
-    components: componentsNonAprAPY
+    components: rest
   }
 }
 

--- a/packages/lib/types.ts
+++ b/packages/lib/types.ts
@@ -442,8 +442,8 @@ export const InceptSchema = z.object({
 export type Incept = z.infer<typeof InceptSchema>
 
 export const EstimatedAprSchema = z.object({
-  apr: z.number(),
-  apy: z.number(),
+  apr: z.number().optional(),
+  apy: z.number().optional(),
   type: z.string(),
   components: z.object({
     boost: z.number().nullish(),

--- a/packages/web/app/api/gql/typeDefs/vault.ts
+++ b/packages/web/app/api/gql/typeDefs/vault.ts
@@ -121,8 +121,8 @@ type EstimatedAprComponents {
 }
 
 type EstimatedApr {
-  apr: Float!
-  apy: Float!
+  apr: Float
+  apy: Float
   type: String!
   components: EstimatedAprComponents!
 }

--- a/packages/web/app/api/rest/list/db.ts
+++ b/packages/web/app/api/rest/list/db.ts
@@ -39,8 +39,8 @@ export const VaultListItemSchema = z.object({
       inceptionNet: CoerceNumber,
     }).nullish(),
     estimated: z.object({
-      apr: z.number(),
-      apy: z.number(),
+      apr: z.number().optional(),
+      apy: z.number().optional(),
       type: z.string(),
       components: z.record(z.string(), z.union([z.number(), z.string()]).nullable()).optional(),
     }).nullish(),


### PR DESCRIPTION
### Summary

When `netAPR` or `netAPY` components are missing from the `output` table, the V3 estimated APR helper (`getLatestEstimatedAprV3`) was returning `apr: 0` and `apy: 0` via the `?? 0` fallback. This is misleading — a missing value is not the same as zero. Now `apr` and `apy` are only included in the response when the corresponding component actually exists in the data.

Additionally, `netAPR` and `netAPY` are removed from the `components` bag to avoid duplication, since they are already promoted to top-level `apr`/`apy` fields.

Downstream schemas are updated to accept optional `apr`/`apy`:
- **GraphQL**: `Float!` → `Float` (nullable)
- **REST Zod**: `z.number()` → `z.number().optional()`
- **Lib types**: `z.number()` → `z.number().optional()`

### How to review

1. `packages/ingest/helpers/apy-apr.ts` — core fix: destructuring + conditional spread
2. `packages/web/app/api/gql/typeDefs/vault.ts` — GraphQL nullability change
3. `packages/web/app/api/rest/list/db.ts` — REST schema change
4. `packages/lib/types.ts` — shared type change

### Test plan

- [ ] Start the dev environment
```bash
make dev
```

- [ ] In the terminal UI, select `ingest` → `fanout abis` to trigger indexing

- [ ] Find a vault that has netAPR/netAPY components in the output table
```sql
SELECT DISTINCT chain_id, address, label
FROM output
WHERE component IN ('netAPR', 'netAPY')
  AND label LIKE '%-estimated-apr'
  AND block_time > NOW() - INTERVAL '7 days'
LIMIT 5;
```

- [ ] Check the snapshot hook result for that vault — `apr`/`apy` should be present with numeric values
```sql
SELECT chain_id, address, hook->'estimatedApr' AS estimated_apr
FROM snapshot
WHERE chain_id = <chain_id> AND address = '<address>';
```
Expected: `{"type":"...","apr":<number>,"apy":<number>,"components":{...}}` — `apr`/`apy` present, and `netAPR`/`netAPY` NOT in `components`

- [ ] Find a vault that does NOT have netAPR/netAPY
```sql
SELECT DISTINCT s.chain_id, s.address
FROM snapshot s
LEFT JOIN output o
  ON s.chain_id = o.chain_id AND s.address = o.address
  AND o.component IN ('netAPR', 'netAPY')
  AND o.label LIKE '%-estimated-apr'
  AND o.block_time > NOW() - INTERVAL '7 days'
WHERE o.address IS NULL
  AND s.hook->'estimatedApr' IS NOT NULL
LIMIT 5;
```

- [ ] Check its snapshot — `apr`/`apy` keys should be absent (not zero)
```sql
SELECT chain_id, address, hook->'estimatedApr' AS estimated_apr
FROM snapshot
WHERE chain_id = <chain_id> AND address = '<address>';
```
Expected: `{"type":"...","components":{...}}` — no `apr` or `apy` keys

- [ ] Shut down
```bash
make down
```

### Risk / impact

Low risk. Only affects the V3 estimated APR path (`getLatestEstimatedAprV3`). Consumers that rely on `apr`/`apy` always being present will now need to handle the optional case — but this is the correct behavior since a missing value should not masquerade as zero. GraphQL clients selecting `apr`/`apy` will now get `null` instead of `0` when the data is absent.