### PR TITLE
feat: compound v3 APY using on-chain profitMaxUnlockTime

### DIFF
--- a/packages/ingest/abis/yearn/lib/apy.ts
+++ b/packages/ingest/abis/yearn/lib/apy.ts
@@ -189,8 +189,11 @@ export async function _compute(vault: Thing, strategies: `0x${string}`[], blockN
 
   result.net = candidates.find(apy => apy !== undefined) ?? (() => { throw new Error('!candidates') })()
 
-  const annualCompoundingPeriods = 52
-  const fees = compare(vault.defaults.apiVersion, '3.0.0', '>=')
+  const isV3 = compare(vault.defaults.apiVersion, '3.0.0', '>=')
+  const annualCompoundingPeriods = isV3
+    ? await getCompoundingPeriods(chainId, address, blockNumber)
+    : 52
+  const fees = isV3
     ? await extractFees__v3(chainId, address, strategies, blockNumber)
     : await extractFees__v2(chainId, address, strategies, blockNumber)
 
@@ -372,6 +375,24 @@ async function extractAccountant(chainId: number, address: `0x${string}`, blockN
     })
   } catch(error) {
     return undefined
+  }
+}
+
+const SECONDS_PER_YEAR = 31_556_952 // 365.2425 days
+
+async function getCompoundingPeriods(chainId: number, address: `0x${string}`, blockNumber: bigint): Promise<number> {
+  try {
+    const profitMaxUnlockTime = await rpcs.next(chainId, blockNumber).readContract({
+      address,
+      abi: parseAbi(['function profitMaxUnlockTime() view returns (uint256)']),
+      functionName: 'profitMaxUnlockTime',
+      blockNumber
+    }) as bigint
+    if (profitMaxUnlockTime === 0n) return 365
+    return SECONDS_PER_YEAR / Number(profitMaxUnlockTime)
+  } catch(error) {
+    console.warn('🚨', 'getCompoundingPeriods', 'readContract fail', chainId, address, blockNumber)
+    return 365
   }
 }
 


### PR DESCRIPTION
## Summary

- V3 vault APY-to-APR decompounding now uses `profitMaxUnlockTime` read on-chain instead of a hardcoded 52 weekly periods
- Compounding periods: `n = 31,556,952 / profitMaxUnlockTime` (e.g., ~52 for 7-day unlock windows)
- Falls back to 365 (daily compounding) if `profitMaxUnlockTime` is 0 or the RPC call fails
- V2 vaults remain unchanged at 52 periods

## Context

Per feedback from juniordevbot: the compounding periods should reflect the vault's actual `profitMaxUnlockTime` rather than assuming weekly (52). Most v3 vaults use ~7 day unlock periods, but this varies per vault.

## Changed files

- `packages/ingest/abis/yearn/lib/apy.ts` — added `getCompoundingPeriods()` function, v3 path uses it instead of hardcoded 52

## Test plan

- [ ] Start the dev environment
```bash
make dev
```

- [ ] Configure `abis.local.yaml` to index a v3 vault:
```yaml
cron:
  name: AbiFanout
  queue: fanout
  job: abis
  schedule: '*/15 * * * *'
  start: false

abis:
  - abiPath: 'yearn/3/vault'
    sources: [
      { chainId: 1, address: '0xBe53A109B494E5c9f97b9Cd39Fe969BE68BF6204', inceptBlock: 19419991 }
    ]
```

- [ ] Configure `manuals.local.yaml` so the vault is created as a thing:
```yaml
manuals:
  - chainId: 1
    address: '0xBe53A109B494E5c9f97b9Cd39Fe969BE68BF6204'
    label: 'vault'
    defaults: {
      erc4626: true,
      v3: true,
      yearn: true,
      apiVersion: '3.0.2',
      origin: "yearn",
      inceptBlock: 19419991
    }
```

- [ ] In the terminal UI (pane 2), select `Ingest` → `fanout abis` to trigger indexing. Run it multiple times for full initialization.

- [ ] Trigger APY recalculation via `Ingest` → `fanout replays` in the terminal UI

- [ ] Watch the ingest pane for APY processing logs — look for `🧮 apy-bwd-delta-pps` entries. If `profitMaxUnlockTime` read fails, you'll see:
```
🚨 getCompoundingPeriods readContract fail <chainId> <address> <blockNumber>
```

- [ ] Query v3 vault APY outputs from the psql pane (pane 3):
```sql
SELECT o.chain_id, o.address, o.component, o.value, o.block_number
FROM output o
JOIN thing t ON o.chain_id = t.chain_id AND o.address = t.address
WHERE t.label = 'vault'
  AND t.defaults->>'apiVersion' >= '3.0.0'
  AND o.label = 'apy-bwd-delta-pps'
  AND o.component IN ('net', 'grossApr')
ORDER BY o.block_time DESC
LIMIT 20;
```
Expected: `grossApr` values should be present and reasonable. For vaults with ~7 day `profitMaxUnlockTime`, values should be very close to the previous 52-period calculation.

- [ ] Spot-check the vault's `profitMaxUnlockTime` on-chain:
```bash
cast call 0xBe53A109B494E5c9f97b9Cd39Fe969BE68BF6204 "profitMaxUnlockTime()(uint256)" --rpc-url $RPC_1
```
Expected: e.g., `604800` (7 days) → `31556952 / 604800 ≈ 52.18` periods/year

- [ ] Shutdown
```bash
make down
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)