### PR TITLE
Reduce timeseries and reports cache refresh schedule from every 15m to hourly

### DIFF
--- a/.github/workflows/reports-refresh.yml
+++ b/.github/workflows/reports-refresh.yml
@@ -2,7 +2,7 @@ name: Reports Refresh
 
 on:
   schedule:
-    - cron: '*/15 * * * *'
+    - cron: '0 * * * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/timeseries-refresh.yml
+++ b/.github/workflows/timeseries-refresh.yml
@@ -2,7 +2,7 @@ name: timeseries-refresh
 
 on:
   schedule:
-    - cron: '*/15 * * * *'
+    - cron: '0 * * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- Updates cron schedule for `timeseries-refresh` and `reports-refresh` GitHub Actions workflows from every 15 minutes to every hour to cut some network and usage