### PR TITLE
Automate manuals extraction in ABI fanout cycle

### DIFF
--- a/docs/manuals.md
+++ b/docs/manuals.md
@@ -1,13 +1,19 @@
-# One time vault initialization
+# Vault initialization via manuals
 
-A manual process is required for indexing a new vault which was added manually through `config/manuals.yaml`.
+Vaults added through `config/manuals.yaml` are now extracted **automatically** as part of the ABI fanout cycle (every 15 minutes). No manual intervention is required after merging.
 
-## Process
+## Automatic flow
 
-- Merge the change onto main
-- Check render dashboard for deployment progress
-- when deployed go to `ingest-v-2` -> `shell`
-- on the attached tty
+1. Merge the change onto main
+2. Wait for deployment (check render dashboard)
+3. On the next ABI fanout cycle, `extract manuals` runs automatically before the ABI source/thing loop
+
+## Manual fallback
+
+If you need to trigger extraction immediately without waiting for the next cycle:
+
+- Go to `ingest-v-2` -> `shell`
+- On the attached tty:
    - `cd packages/terminal`
-   - `bun run (or yarn doesnst matter) production`
-   - trigger `ingest` -> `extract manuals`
+   - `bun run production`
+   - Trigger `ingest` -> `extract manuals`

--- a/packages/ingest/fanout/abis.ts
+++ b/packages/ingest/fanout/abis.ts
@@ -6,6 +6,8 @@ export default class AbisFanout {
   async fanout(data: object) {
     const webhookCollector = new WebhookCollector()
 
+    await mq.add(mq.job.extract.manuals, data)
+
     for (const abi of abisConfig.abis) {
       for (const source of abi.sources) {
         console.info('🤝', 'source', 'abiPath', abi.abiPath, source.chainId, source.address)


### PR DESCRIPTION
### Summary

Adds `extract manuals` to the ABI fanout cycle so vaults defined in `config/manuals.yaml` are automatically picked up every 15 minutes. Previously, adding manual entries required SSHing into the ingest shell and triggering extraction by hand — this removes that operational burden.

### How to review

Two small changes:

1. **`packages/ingest/fanout/abis.ts`** — single line added before the ABI loop to enqueue `mq.job.extract.manuals`. Review that it runs before the source/thing loop (manuals create things that the loop may need).
2. **`docs/manuals.md`** — updated to reflect the new automatic flow, with manual trigger preserved as fallback.

### Test plan

- [ ] Start the dev environment
```
make dev
```

- [ ] Create a `config/manuals.local.yaml` with a test entry (automatically preferred over `manuals.yaml`)
```yaml
manuals:
  - chainId: 1
    address: '0x000000000000000000000000000000000000dEaD'
    label: test manual
    defaults:
      token: '0x000000000000000000000000000000000000dEaD'
      apiVersion: '3.0.0'
      inceptBlock: 20000000
```

- [ ] Trigger `ingest` → `fanout abis` from the terminal UI

- [ ] Verify the test entry was inserted into the database
```sql
SELECT chain_id, address, label, defaults FROM thing
WHERE chain_id = 1 AND address = '0x000000000000000000000000000000000000dEaD';
```
Expected: one row with `label = 'test manual'` and defaults containing `token`, `apiVersion`, `inceptBlock`

- [ ] Trigger `fanout abis` again and verify idempotency — no duplicate rows
```sql
SELECT count(*) FROM thing
WHERE chain_id = 1 AND address = '0x000000000000000000000000000000000000dEaD';
```
Expected: `1`

- [ ] Verify manual fallback still works: trigger `ingest` → `extract manuals` independently from the terminal UI

- [ ] Clean up: `rm config/manuals.local.yaml` and `make down` (or kill the tmux session)

### Risk / impact

Minimal risk. `upsertThing` is idempotent (`ON CONFLICT ... DO UPDATE` with defaults merging), so repeated extraction every 15 minutes is safe. The manual terminal trigger remains available as a fallback. No schema changes, no new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)