### PR TITLE
Fix duplicated extract jobs on repeated fanout runs

### DIFF
--- a/packages/ingest/fanout/events.ts
+++ b/packages/ingest/fanout/events.ts
@@ -37,10 +37,9 @@ export default class EventsFanout {
     for (const stride of StrideSchema.array().parse(nextStrides)) {
       console.log('📤', 'stride', chainId, address, stride.from, stride.to)
       await walklog({...stride, logStride: getLogStride(chainId)}, async (from, to) => {
-        const jobId = `evmlog-${chainId}-${address}-${from}-${to}`
         await mq.add(mq.job.extract.evmlog, {
           abiPath, chainId, address, from, to, replay: replay?.enabled
-        }, { jobId })
+        })
       })
     }
   }

--- a/packages/ingest/fanout/events.ts
+++ b/packages/ingest/fanout/events.ts
@@ -37,9 +37,10 @@ export default class EventsFanout {
     for (const stride of StrideSchema.array().parse(nextStrides)) {
       console.log('📤', 'stride', chainId, address, stride.from, stride.to)
       await walklog({...stride, logStride: getLogStride(chainId)}, async (from, to) => {
+        const jobId = `evmlog-${chainId}-${address}-${from}-${to}`
         await mq.add(mq.job.extract.evmlog, {
           abiPath, chainId, address, from, to, replay: replay?.enabled
-        })
+        }, { jobId })
       })
     }
   }

--- a/packages/ingest/fanout/timeseries.ts
+++ b/packages/ingest/fanout/timeseries.ts
@@ -41,9 +41,10 @@ export default class TimeseriesFanout {
       }
 
       for (const blockTime of missing) {
+        const jobId = `timeseries-${chainId}-${address}-${outputLabel}-${blockTime}`
         await mq.add(mq.job.extract.timeseries, {
           abiPath, chainId, address, outputLabel, blockTime
-        })
+        }, { jobId })
       }
     }
   }

--- a/packages/ingest/fanout/timeseries.ts
+++ b/packages/ingest/fanout/timeseries.ts
@@ -41,10 +41,9 @@ export default class TimeseriesFanout {
       }
 
       for (const blockTime of missing) {
-        const jobId = `timeseries-${chainId}-${address}-${outputLabel}-${blockTime}`
         await mq.add(mq.job.extract.timeseries, {
           abiPath, chainId, address, outputLabel, blockTime
-        }, { jobId })
+        })
       }
     }
   }

--- a/packages/lib/mq.ts
+++ b/packages/lib/mq.ts
@@ -94,14 +94,8 @@ export async function add(job: Job, data: any, options?: any) {
       }
     })
   }
-
-  const jobId = options?.jobId ?? `${job.name}-${data.chainId}-${data.address}-${data.from}-${data.to}-${data.blockTime}`
-
   if (!queues[queue]) { queues[queue] = connect(queue) }
-  return await queues[queue].add(job.name, data, {
-    priority: DEFAULT_PRIORITY, attempts: 1, ...options,
-    jobId,
-  })
+  return await queues[queue].add(job.name, data, { priority: DEFAULT_PRIORITY, attempts: 1, ...options })
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/lib/mq.ts
+++ b/packages/lib/mq.ts
@@ -94,8 +94,14 @@ export async function add(job: Job, data: any, options?: any) {
       }
     })
   }
+
+  const jobId = options?.jobId ?? `${job.name}-${data.chainId}-${data.address}-${data.from}-${data.to}-${data.blockTime}`
+
   if (!queues[queue]) { queues[queue] = connect(queue) }
-  return await queues[queue].add(job.name, data, { priority: DEFAULT_PRIORITY, attempts: 1, ...options })
+  return await queues[queue].add(job.name, data, {
+    priority: DEFAULT_PRIORITY, attempts: 1, ...options,
+    jobId,
+  })
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
### Summary

Extract jobs (evmlog and timeseries) were being duplicated every fanout cycle because `mq.add()` used auto-generated BullMQ job IDs. When fanout runs before previous extract jobs complete and update strides/outputs, it sees the same gaps and enqueues identical work. This adds deterministic `jobId`s based on the job's unique key (chainId + address + block range or blockTime), so BullMQ skips adding a job if one with the same ID is already in the queue.

https://docs.bullmq.io/guide/jobs/job-ids - showcases how and when to use it.

### How to review

Two small changes in `packages/ingest/fanout/`:
1. **`events.ts`** — adds `jobId: evmlog-{chainId}-{address}-{from}-{to}` to `extract.evmlog` jobs
2. **`timeseries.ts`** — adds `jobId: timeseries-{chainId}-{address}-{outputLabel}-{blockTime}` to `extract.timeseries` jobs

Key design decision: parent fanout jobs in `abis.ts` intentionally do **not** get jobIds — they must re-run each cycle to discover new work. Only leaf extract jobs are deduplicated.

BullMQ behavior: when a job with the same `jobId` exists in any state (waiting/active/completed/failed), `add()` returns the existing job without creating a duplicate. Jobs are cleaned up via `removeOnComplete: { count: 100, age: 3600 }`.

### Test plan

- [ ] Run ingest lint
```
bun --filter ingest lint
```
Expected: 0 errors (warnings are pre-existing)

- [ ] Start dev environment
```
make dev
```

- [ ] Trigger fanout from terminal UI
```
Ingest → fanout abis → Confirm
```
Expected: jobs dispatched without errors

- [ ] Trigger fanout again immediately (before first run completes)
```
Ingest → fanout abis → Confirm
```
Expected: second run should NOT create duplicate extract jobs for the same block ranges. Verify via Sentry metrics dashboard — `mq.job_added` counts should not double for identical `abiPath:chainId:address:fromBlock:toBlock` tuples.

- [ ] Verify Sentry metrics after ~1 hour of operation
```
https://sentry.io/organizations/yearn-ed/explore/metrics/ → mq.job_added
```
Expected: no more duplicated entries with same abi:chain_id:address:block across consecutive fanout runs

### Risk / impact

- **Low risk**: Only adds an optional `jobId` parameter to existing `mq.add()` calls. No changes to job data, processing logic, or queue configuration.
- **Rollback**: Revert the commit — BullMQ falls back to auto-generated IDs (previous behavior).
- **Edge case**: If a completed extract job is retained (up to 1h by `removeOnComplete`) and the same block range is somehow re-planned, it will be silently skipped. This is safe because strides/outputs update on successful load, so the range won't be re-planned.