### PR TITLE
fix: use Redis MSET instead of Keyv setMany for cache writes

### DIFF
--- a/packages/web/app/api/rest/cache.ts
+++ b/packages/web/app/api/rest/cache.ts
@@ -1,8 +1,11 @@
 import { createKeyv } from '@keyv/redis'
+import { createClient } from '@redis/client'
+
+const writeClient = createClient({ url: process.env.REST_CACHE_REDIS_URL || 'redis://localhost:6379' })
 
 const keyv = createKeyv(process.env.REST_CACHE_REDIS_URL || 'redis://localhost:6379')
 
-export function createKeyvClient() {
+export function getKeyvClient() {
   return keyv
 }
 
@@ -10,14 +13,14 @@ export function createKeyvClient() {
  * Batch write using Redis MSET (1 command) instead of Keyv's
  * setMany which uses MULTI + N SETs + EXEC (N+2 commands).
  */
+
 export async function cacheMSet(pairs: Array<[string, string]>): Promise<void> {
   if (pairs.length === 0) return
-  const store = keyv.store as { client: { mSet: (pairs: Array<[string, string]>, options?: unknown) => Promise<unknown>; isOpen: boolean; connect: () => Promise<unknown> } }
-  const client = store.client
-  if (!client.isOpen) await client.connect()
-  await client.mSet(pairs)
+  if (!writeClient.isOpen) await writeClient.connect()
+  await writeClient.mSet(pairs)
 }
 
 export async function disconnect(): Promise<void> {
+  await writeClient.disconnect()
   await keyv.disconnect()
 }

--- a/packages/web/app/api/rest/cache.ts
+++ b/packages/web/app/api/rest/cache.ts
@@ -1,7 +1,23 @@
 import { createKeyv } from '@keyv/redis'
 
+const keyv = createKeyv(process.env.REST_CACHE_REDIS_URL || 'redis://localhost:6379')
+
 export function createKeyvClient() {
-  const redisUrl = process.env.REST_CACHE_REDIS_URL || 'redis://localhost:6379'
-  return createKeyv(redisUrl)
+  return keyv
 }
 
+/**
+ * Batch write using Redis MSET (1 command) instead of Keyv's
+ * setMany which uses MULTI + N SETs + EXEC (N+2 commands).
+ */
+export async function cacheMSet(pairs: Array<[string, string]>): Promise<void> {
+  if (pairs.length === 0) return
+  const store = keyv.store as { client: { mSet: (pairs: Array<[string, string]>, options?: unknown) => Promise<unknown>; isOpen: boolean; connect: () => Promise<unknown> } }
+  const client = store.client
+  if (!client.isOpen) await client.connect()
+  await client.mSet(pairs)
+}
+
+export async function disconnect(): Promise<void> {
+  await keyv.disconnect()
+}

--- a/packages/web/app/api/rest/list/refresh.ts
+++ b/packages/web/app/api/rest/list/refresh.ts
@@ -1,7 +1,5 @@
-import { createKeyvClient } from '../cache'
+import { cacheMSet, disconnect } from '../cache'
 import { getVaultsList } from './db'
-
-const keyv = createKeyvClient()
 
 async function refresh(): Promise<void> {
   console.time('refresh list:vaults')
@@ -17,14 +15,14 @@ async function refresh(): Promise<void> {
   }, {} as Record<number, typeof vaults>)
 
   const chainIds = Object.keys(vaultsByChain).map(Number)
-  const entries = chainIds.map((chainId) => ({
-    key: `rest:list:vaults:${chainId}`,
-    value: vaultsByChain[chainId],
-  }))
+  const pairs: Array<[string, string]> = chainIds.map((chainId) => [
+    `rest:list:vaults:${chainId}`,
+    JSON.stringify({ value: vaultsByChain[chainId] }),
+  ])
 
-  entries.push({ key: 'rest:list:vaults:all', value: vaults })
+  pairs.push(['rest:list:vaults:all', JSON.stringify({ value: vaults })])
 
-  await keyv.setMany(entries)
+  await cacheMSet(pairs)
 
   console.log(`✓ Completed: ${vaults.length} vaults cached across ${chainIds.length} chains`)
   console.timeEnd('refresh list:vaults')
@@ -33,12 +31,12 @@ async function refresh(): Promise<void> {
 if (require.main === module) {
   refresh()
     .then(async () => {
-      await keyv.disconnect()
+      await disconnect()
       process.exit(0)
     })
     .catch(async (err) => {
       console.error(err)
-      await keyv.disconnect()
+      await disconnect()
       process.exit(1)
     })
 }

--- a/packages/web/app/api/rest/list/vaults/[chainId]/route.ts
+++ b/packages/web/app/api/rest/list/vaults/[chainId]/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server'
-import { createKeyvClient } from '../../../cache'
+import { getKeyvClient } from '../../../cache'
 import type { VaultListItem } from '../../db'
 
-const keyv = createKeyvClient()
+const keyv = getKeyvClient()
 
 export const runtime = 'nodejs'
 

--- a/packages/web/app/api/rest/list/vaults/route.ts
+++ b/packages/web/app/api/rest/list/vaults/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server'
-import { createKeyvClient } from '../../cache'
+import { getKeyvClient } from '../../cache'
 import type { VaultListItem } from '../db'
 
-const keyv = createKeyvClient()
+const keyv = getKeyvClient()
 
 export const runtime = 'nodejs'
 

--- a/packages/web/app/api/rest/reports/[chainId]/[address]/route.ts
+++ b/packages/web/app/api/rest/reports/[chainId]/[address]/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createKeyvClient } from '../../../cache'
+import { getKeyvClient } from '../../../cache'
 import { VaultReport } from '../../db'
 import { getReportKey } from '../../redis'
 
-const keyv = createKeyvClient()
+const keyv = getKeyvClient()
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',

--- a/packages/web/app/api/rest/reports/refresh.ts
+++ b/packages/web/app/api/rest/reports/refresh.ts
@@ -1,9 +1,7 @@
 import 'lib/global'
-import { createKeyvClient } from '../cache'
+import { cacheMSet, disconnect } from '../cache'
 import { getStrategyReports, getVaults } from './db'
 import { getReportKey } from './redis'
-
-const keyv = createKeyvClient()
 
 const BATCH_SIZE = parseInt(process.env.REFRESH_BATCH_SIZE || '10', 10)
 
@@ -18,21 +16,20 @@ async function refreshReports(): Promise<void> {
 
   for (let i = 0; i < vaults.length; i += BATCH_SIZE) {
     const batch = vaults.slice(i, i + BATCH_SIZE)
-    const results = await Promise.all(batch.map(async (vault) => {
+    const pairs: Array<[string, string]> = []
+
+    await Promise.all(batch.map(async (vault) => {
       const reports = await getStrategyReports(vault.chainId, vault.address)
-      if (!reports || reports.length === 0) return null
-      return {
-        key: getReportKey(vault.chainId, vault.address.toLowerCase()),
-        value: reports,
-      }
+      if (!reports || reports.length === 0) return
+      pairs.push([
+        getReportKey(vault.chainId, vault.address.toLowerCase()),
+        JSON.stringify({ value: reports }),
+      ])
     }))
 
-    const entries = results.filter((r): r is NonNullable<typeof r> => r !== null)
-    if (entries.length > 0) {
-      await keyv.setMany(entries)
-    }
+    await cacheMSet(pairs)
 
-    processed += entries.length
+    processed += pairs.length
     if (processed % 10 === 0) {
       console.log(`Processed ${processed}/${vaults.length} vaults`)
     }
@@ -45,12 +42,12 @@ async function refreshReports(): Promise<void> {
 if (require.main === module) {
   refreshReports()
     .then(async () => {
-      await keyv.disconnect()
+      await disconnect()
       process.exit(0)
     })
     .catch(async (err) => {
       console.error(err)
-      await keyv.disconnect()
+      await disconnect()
       process.exit(1)
     })
 }

--- a/packages/web/app/api/rest/snapshot/[chainId]/[address]/route.ts
+++ b/packages/web/app/api/rest/snapshot/[chainId]/[address]/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createKeyvClient } from '../../../cache'
+import { getKeyvClient } from '../../../cache'
 import type { VaultSnapshot } from '../../db'
 import { getSnapshotKey } from '../../redis'
 
-const keyv = createKeyvClient()
+const keyv = getKeyvClient()
 
 export const runtime = 'nodejs'
 

--- a/packages/web/app/api/rest/snapshot/refresh-snapshot.ts
+++ b/packages/web/app/api/rest/snapshot/refresh-snapshot.ts
@@ -1,8 +1,6 @@
-import { createKeyvClient } from '../cache'
+import { cacheMSet, disconnect } from '../cache'
 import { getVaults, getVaultSnapshot } from './db'
 import { getSnapshotKey } from './redis'
-
-const keyv = createKeyvClient()
 
 const BATCH_SIZE = 10
 
@@ -17,21 +15,20 @@ async function refresh(): Promise<void> {
 
   for (let i = 0; i < vaults.length; i += BATCH_SIZE) {
     const batch = vaults.slice(i, i + BATCH_SIZE)
-    const snapshots = await Promise.all(batch.map(async (vault) => {
+    const pairs: Array<[string, string]> = []
+
+    await Promise.all(batch.map(async (vault) => {
       const snapshot = await getVaultSnapshot(vault.chainId, vault.address)
-      if (!snapshot) return null
-      return {
-        key: getSnapshotKey(vault.chainId, vault.address.toLowerCase()),
-        value: snapshot,
-      }
+      if (!snapshot) return
+      pairs.push([
+        getSnapshotKey(vault.chainId, vault.address.toLowerCase()),
+        JSON.stringify({ value: snapshot }),
+      ])
     }))
 
-    const entries = snapshots.filter((s): s is NonNullable<typeof s> => s !== null)
-    if (entries.length > 0) {
-      await keyv.setMany(entries)
-    }
+    await cacheMSet(pairs)
 
-    processed += entries.length
+    processed += pairs.length
     if (processed % 10 === 0) {
       console.log(`Processed ${processed}/${vaults.length} vaults`)
     }
@@ -44,12 +41,12 @@ async function refresh(): Promise<void> {
 if (require.main === module) {
   refresh()
     .then(async () => {
-      await keyv.disconnect()
+      await disconnect()
       process.exit(0)
     })
     .catch(async (err) => {
       console.error(err)
-      await keyv.disconnect()
+      await disconnect()
       process.exit(1)
     })
 }

--- a/packages/web/app/api/rest/timeseries/[segment]/[chainId]/[address]/route.ts
+++ b/packages/web/app/api/rest/timeseries/[segment]/[chainId]/[address]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createKeyvClient } from '../../../../cache'
+import { getKeyvClient } from '../../../../cache'
 import { labels } from '../../../labels'
 import { getTimeseriesKey } from '../../../redis'
 
@@ -16,7 +16,7 @@ const corsHeaders = {
   'access-control-allow-methods': 'GET,OPTIONS',
 }
 
-const timeseriesKeyv = createKeyvClient()
+const timeseriesKeyv = getKeyvClient()
 
 export async function GET(
   request: NextRequest,

--- a/packages/web/app/api/rest/timeseries/refresh-timeseries.ts
+++ b/packages/web/app/api/rest/timeseries/refresh-timeseries.ts
@@ -1,9 +1,7 @@
-import { createKeyvClient } from '../cache'
+import { cacheMSet, disconnect } from '../cache'
 import { getFullTimeseries, getVaults, TimeseriesRow } from './db'
 import { labels } from './labels'
 import { getTimeseriesKey } from './redis'
-
-const keyv = createKeyvClient()
 
 const BATCH_SIZE = 10
 
@@ -18,7 +16,7 @@ async function refresh24hr(): Promise<void> {
 
   for (let i = 0; i < vaults.length; i += BATCH_SIZE) {
     const batch = vaults.slice(i, i + BATCH_SIZE)
-    const entries: Array<{ key: string; value: unknown }> = []
+    const pairs: Array<[string, string]> = []
 
     await Promise.all(batch.map(async (vault) => {
       const addressLower = vault.address.toLowerCase()
@@ -36,14 +34,14 @@ async function refresh24hr(): Promise<void> {
           value: row.value,
         }))
 
-        entries.push({
-          key: getTimeseriesKey(label, vault.chainId, addressLower),
-          value: minimal,
-        })
+        pairs.push([
+          getTimeseriesKey(label, vault.chainId, addressLower),
+          JSON.stringify({ value: minimal }),
+        ])
       }))
     }))
 
-    await keyv.setMany(entries)
+    await cacheMSet(pairs)
 
     processed += batch.length
     if (processed % 10 === 0) {
@@ -58,12 +56,12 @@ async function refresh24hr(): Promise<void> {
 if (require.main === module) {
   refresh24hr()
     .then(async () => {
-      await keyv.disconnect()
+      await disconnect()
       process.exit(0)
     })
     .catch(async (err) => {
       console.error(err)
-      await keyv.disconnect()
+      await disconnect()
       process.exit(1)
     })
 }


### PR DESCRIPTION
## Summary
- keyv had outdated info when #343  was implemented, implying `setMany` was using mset or any more efficient command under the hood, which after another lookup again today, it's not there anymore, and through source code check, it does multiple sets. Which goes against what we want.
- Replace Keyv's `setMany()` (MULTI + N SETs + EXEC = N+2 commands) with Redis `MSET` (1 command) for all REST cache refresh scripts
- Access the underlying `@redis/client` from Keyv's store to call `mSet()` directly
- Values are serialized as `JSON.stringify({ value })` to stay compatible with `keyv.get()` reads in route handlers (which extract `.value` from deserialized data)
- No changes to route handlers — reads still go through `keyv.get()`

### Why

On Upstash pay-as-you-go, each command in a MULTI/EXEC transaction is billed individually. Keyv's `setMany(N)` produces N+2 billed commands (MULTI + N SETs + EXEC). `MSET` is a single Redis command regardless of how many keys it sets — billed as **1 command** on Upstash.

### Risks

- None — key count didn't change
- Value format didn't change (`JSON.stringify({ value })` matches Keyv's internal serialization)

<img width="1394" height="764" alt="image" src="https://github.com/user-attachments/assets/7e2c28ac-2952-4901-a8ec-93c39a905eb8" />


## Test plan

- [ ] Start Redis
```
docker compose up -d redis
```

- [ ] Set up `packages/web/.env` with local Redis + read-only Postgres
```env
REST_CACHE_REDIS_URL=redis://localhost:6379
POSTGRES_HOST=ep-raspy-art-a5g9bur0-pooler.us-east-2.aws.neon.tech
POSTGRES_DATABASE=neondb
POSTGRES_USER=dev
POSTGRES_PASSWORD=<password>
POSTGRES_SSL=true
POSTGRES_PORT=5432
```

- [ ] Run all refresh scripts to populate the cache
```
cd packages/web && source .env && bun run app/api/rest/list/refresh.ts
```
Expected: `✓ Completed: 2049 vaults cached across 11 chains`

```
cd packages/web && source .env && bun run app/api/rest/snapshot/refresh-snapshot.ts
```
Expected: `✓ Completed: <N> vaults processed`

```
cd packages/web && source .env && bun run app/api/rest/reports/refresh.ts
```
Expected: `✓ Completed: <N> vaults processed`

```
cd packages/web && source .env && bun run app/api/rest/timeseries/refresh-timeseries.ts
```
Expected: `✓ Completed: <N> vaults processed`

- [ ] Start the web server
```
cd packages/web && source .env && bun run dev
```

- [ ] Verify list endpoints
```
curl -s http://localhost:3000/api/rest/list/vaults | jq 'length'
```
Expected: `2049`

```
curl -s http://localhost:3000/api/rest/list/vaults/1 | jq 'length'
```
Expected: `1210`

- [ ] Verify snapshot endpoint
```
curl -s http://localhost:3000/api/rest/snapshot/1/0xa3931d71877C0E7a3148CB7Eb4463524FEc27fbD | jq 'keys'
```
Expected:
```json
["address","apy","asset","blockNumber","blockTime","chainId","decimals","erc4626","inceptBlock","inceptTime","name","performance","pricePerShare","sparklines","symbol","totalAssets","totalSupply","tvl"]
```

- [ ] Verify timeseries endpoint
```
curl -s http://localhost:3000/api/rest/timeseries/tvl/1/0xa3931d71877C0E7a3148CB7Eb4463524FEc27fbD | jq '.[0:2]'
```
Expected:
```json
[
  {"time": 1725408000, "component": "tvl", "value": "0"},
  {"time": 1725494400, "component": "tvl", "value": "0"}
]
```

- [ ] Cleanup
```
docker compose down redis
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)