### PR TITLE
feat: add netApr and netApy components to apr-oracle timeseries

### DIFF
--- a/packages/ingest/abis/yearn/3/vault/snapshot/hook.ts
+++ b/packages/ingest/abis/yearn/3/vault/snapshot/hook.ts
@@ -24,6 +24,8 @@ export const CompositionSchema = z.object({
   performance: z.object({
     estimated: EstimatedAprSchema.nullish(),
     oracle: z.object({
+      netAPR: z.number().nullish(),
+      netAPY: z.number().nullish(),
       apr: z.number().nullish(),
       apy: z.number().nullish()
     }).nullish(),

--- a/packages/ingest/abis/yearn/3/vault/snapshot/hook.ts
+++ b/packages/ingest/abis/yearn/3/vault/snapshot/hook.ts
@@ -10,6 +10,7 @@ import { getLatestApy, getLatestEstimatedAprV3, getLatestOracleApr } from '../..
 import { fetchErc20PriceUsd } from '../../../../../prices'
 import { rpcs } from '../../../../../rpcs'
 import * as things from '../../../../../things'
+import { computeApy, computeNetApr } from '../../../lib/apy'
 import { fetchOrExtractErc20 } from '../../../lib'
 import { getStrategyMeta, getTokenMeta, getVaultMeta } from '../../../lib/meta'
 import { getRiskScore } from '../../../lib/risk'
@@ -139,6 +140,10 @@ export default async function process(chainId: number, address: `0x${string}`, d
     LIMIT 1
   `, [chainId, address])
 
+  const oracleNetApr = oracleApr != null
+    ? computeNetApr(oracleApr, { management: fees.managementFee / 10_000, performance: fees.performanceFee / 10_000 })
+    : undefined
+
   return {
     asset, strategies, allocator, roles, debts, composition, fees,
     risk, meta: { ...meta, token },
@@ -149,13 +154,9 @@ export default async function process(chainId: number, address: `0x${string}`, d
       estimated: estimatedApr ?? undefined,
       oracle: {
         apr: oracleApr,
-        netAPR: oracleApr != null
-          ? oracleApr * (1 - fees.performanceFee / 10_000) - fees.managementFee / 10_000
-          : undefined,
+        netAPR: oracleNetApr,
         apy: oracleApy,
-        netAPY: oracleApy != null
-          ? oracleApy * (1 - fees.performanceFee / 10_000) - fees.managementFee / 10_000
-          : undefined,
+        netAPY: oracleNetApr != null ? computeApy(oracleNetApr) : undefined,
       },
       historical: apy ? {
         net: apy.net,

--- a/packages/ingest/abis/yearn/3/vault/snapshot/hook.ts
+++ b/packages/ingest/abis/yearn/3/vault/snapshot/hook.ts
@@ -152,7 +152,10 @@ export default async function process(chainId: number, address: `0x${string}`, d
         netAPR: oracleApr != null
           ? oracleApr * (1 - fees.performanceFee / 10_000) - fees.managementFee / 10_000
           : undefined,
-        apy: oracleApy
+        apy: oracleApy,
+        netAPY: oracleApy != null
+          ? oracleApy * (1 - fees.performanceFee / 10_000) - fees.managementFee / 10_000
+          : undefined,
       },
       historical: apy ? {
         net: apy.net,

--- a/packages/ingest/abis/yearn/3/vault/timeseries/apr-oracle/hook.spec.ts
+++ b/packages/ingest/abis/yearn/3/vault/timeseries/apr-oracle/hook.spec.ts
@@ -1,0 +1,26 @@
+import { expect } from 'chai'
+import { computeNetApr } from './hook'
+
+describe('abis/yearn/3/vault/timeseries/apr-oracle/hook', function() {
+  it('returns gross APR when fees are zero', function() {
+    expect(computeNetApr(0.10, { management: 0, performance: 0 })).to.equal(0.10)
+  })
+
+  it('correctly applies performance and management fees', function() {
+    // grossApr=0.10, management=0.02, performance=0.20
+    // netApr = (0.10 - 0.02) * (1 - 0.20) = 0.08 * 0.80 = 0.064
+    expect(computeNetApr(0.10, { management: 0.02, performance: 0.20 })).to.be.closeTo(0.064, 1e-10)
+  })
+
+  it('returns zero when performance fee is 100%', function() {
+    expect(computeNetApr(0.10, { management: 0, performance: 1.0 })).to.equal(0)
+  })
+
+  it('handles zero gross APR', function() {
+    expect(computeNetApr(0, { management: 0, performance: 0.20 })).to.equal(0)
+  })
+
+  it('handles no strategies (zero fees)', function() {
+    expect(computeNetApr(0.05, { management: 0, performance: 0 })).to.equal(0.05)
+  })
+})

--- a/packages/ingest/abis/yearn/3/vault/timeseries/apr-oracle/hook.spec.ts
+++ b/packages/ingest/abis/yearn/3/vault/timeseries/apr-oracle/hook.spec.ts
@@ -1,26 +1,9 @@
 import { expect } from 'chai'
-import { computeNetApr } from './hook'
+import { computeNetApr } from '../../../../lib/apy'
 
 describe('abis/yearn/3/vault/timeseries/apr-oracle/hook', function() {
-  it('returns gross APR when fees are zero', function() {
-    expect(computeNetApr(0.10, { management: 0, performance: 0 })).to.equal(0.10)
-  })
-
-  it('correctly applies performance and management fees', function() {
-    // grossApr=0.10, management=0.02, performance=0.20
-    // netApr = (0.10 - 0.02) * (1 - 0.20) = 0.08 * 0.80 = 0.064
-    expect(computeNetApr(0.10, { management: 0.02, performance: 0.20 })).to.be.closeTo(0.064, 1e-10)
-  })
-
-  it('returns zero when performance fee is 100%', function() {
-    expect(computeNetApr(0.10, { management: 0, performance: 1.0 })).to.equal(0)
-  })
-
-  it('handles zero gross APR', function() {
-    expect(computeNetApr(0, { management: 0, performance: 0.20 })).to.equal(0)
-  })
-
-  it('handles no strategies (zero fees)', function() {
-    expect(computeNetApr(0.05, { management: 0, performance: 0 })).to.equal(0.05)
+  it('re-exports computeNetApr from lib/apy', async function() {
+    const { computeNetApr: reExported } = await import('./hook')
+    expect(reExported).to.equal(computeNetApr)
   })
 })

--- a/packages/ingest/abis/yearn/3/vault/timeseries/apr-oracle/hook.ts
+++ b/packages/ingest/abis/yearn/3/vault/timeseries/apr-oracle/hook.ts
@@ -57,8 +57,8 @@ export default async function (
   try {
     const strategies = await projectStrategies(chainId, address, blockNumber)
     fees = await extractFees__v3(chainId, address, strategies, blockNumber)
-  } catch {
-    // fall through with zero fees
+  } catch (error) {
+    console.warn('🚨', 'apr-oracle fee fetch failed', chainId, address, String(blockNumber), error)
   }
 
   const netApr = computeNetApr(apr, fees)

--- a/packages/ingest/abis/yearn/3/vault/timeseries/apr-oracle/hook.ts
+++ b/packages/ingest/abis/yearn/3/vault/timeseries/apr-oracle/hook.ts
@@ -2,14 +2,12 @@ import { Output, OutputSchema } from 'lib/types'
 import { estimateHeight, getBlock } from 'lib/blocks'
 import { rpcs } from 'lib/rpcs'
 import { Data } from '../../../../../../extract/timeseries'
-import { extractFees__v3 } from '../../../../lib/apy'
+import { computeApy, computeNetApr, extractFees__v3 } from '../../../../lib/apy'
 import { projectStrategies } from '../../snapshot/hook'
 import { V3_ORACLE_ABI } from './abi'
 import { getOracleConfig } from './constants'
 
-export function computeNetApr(grossApr: number, fees: { management: number; performance: number }): number {
-  return (grossApr - fees.management) * (1 - fees.performance)
-}
+export { computeNetApr } from '../../../../lib/apy'
 
 export const outputLabel = 'apr-oracle'
 
@@ -53,7 +51,7 @@ export default async function (
     apr = 0
   }
 
-  const apy = (1 + apr / 52) ** 52 - 1
+  const apy = computeApy(apr)
 
   let fees = { management: 0, performance: 0 }
   try {
@@ -64,7 +62,7 @@ export default async function (
   }
 
   const netApr = computeNetApr(apr, fees)
-  const netApy = (1 + netApr / 52) ** 52 - 1
+  const netApy = computeApy(netApr)
 
   const outputs: Output[] = [
     {

--- a/packages/ingest/abis/yearn/3/vault/timeseries/apr-oracle/hook.ts
+++ b/packages/ingest/abis/yearn/3/vault/timeseries/apr-oracle/hook.ts
@@ -2,8 +2,14 @@ import { Output, OutputSchema } from 'lib/types'
 import { estimateHeight, getBlock } from 'lib/blocks'
 import { rpcs } from 'lib/rpcs'
 import { Data } from '../../../../../../extract/timeseries'
+import { extractFees__v3 } from '../../../../lib/apy'
+import { projectStrategies } from '../../snapshot/hook'
 import { V3_ORACLE_ABI } from './abi'
 import { getOracleConfig } from './constants'
+
+export function computeNetApr(grossApr: number, fees: { management: number; performance: number }): number {
+  return (grossApr - fees.management) * (1 - fees.performance)
+}
 
 export const outputLabel = 'apr-oracle'
 
@@ -49,6 +55,17 @@ export default async function (
 
   const apy = (1 + apr / 52) ** 52 - 1
 
+  let fees = { management: 0, performance: 0 }
+  try {
+    const strategies = await projectStrategies(chainId, address, blockNumber)
+    fees = await extractFees__v3(chainId, address, strategies, blockNumber)
+  } catch {
+    // fall through with zero fees
+  }
+
+  const netApr = computeNetApr(apr, fees)
+  const netApy = (1 + netApr / 52) ** 52 - 1
+
   const outputs: Output[] = [
     {
       label: outputLabel,
@@ -63,6 +80,24 @@ export default async function (
       label: outputLabel,
       component: 'apy',
       value: apy,
+      chainId,
+      address,
+      blockNumber,
+      blockTime: data.blockTime,
+    },
+    {
+      label: outputLabel,
+      component: 'netApr',
+      value: netApr,
+      chainId,
+      address,
+      blockNumber,
+      blockTime: data.blockTime,
+    },
+    {
+      label: outputLabel,
+      component: 'netApy',
+      value: netApy,
       chainId,
       address,
       blockNumber,

--- a/packages/ingest/abis/yearn/lib/apy.spec.ts
+++ b/packages/ingest/abis/yearn/lib/apy.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai'
 import { addresses } from '../../../test-addresses'
 import { mainnet, polygon } from 'viem/chains'
-import { _compute, extractFees__v2, extractFees__v3, extractLockedProfit__v2, extractLockedProfit__v3 } from './apy'
+import { _compute, computeApy, computeNetApr, extractFees__v2, extractFees__v3, extractLockedProfit__v2, extractLockedProfit__v3 } from './apy'
 import { EvmLogSchema, ThingSchema } from 'lib/types'
 import { upsertBatch } from '../../../load'
 import db from '../../../db'
@@ -189,5 +189,45 @@ describe('abis/yearn/lib/apy', function() {
     expect(apy.inceptionNet).to.be.closeTo(0.13935788133629456, 1e-5)
     expect(apy.inceptionPricePerShare).to.be.eq(1000000n)
     expect(Number(apy.inceptionBlockNumber)).to.be.closeTo(49181585, 4)
+  })
+
+  describe('computeNetApr', function() {
+    it('returns gross APR when fees are zero', function() {
+      expect(computeNetApr(0.10, { management: 0, performance: 0 })).to.equal(0.10)
+    })
+
+    it('correctly applies performance and management fees', function() {
+      // grossApr=0.10, management=0.02, performance=0.20
+      // netApr = (0.10 - 0.02) * (1 - 0.20) = 0.08 * 0.80 = 0.064
+      expect(computeNetApr(0.10, { management: 0.02, performance: 0.20 })).to.be.closeTo(0.064, 1e-10)
+    })
+
+    it('returns zero when performance fee is 100%', function() {
+      expect(computeNetApr(0.10, { management: 0, performance: 1.0 })).to.equal(0)
+    })
+
+    it('handles zero gross APR', function() {
+      expect(computeNetApr(0, { management: 0, performance: 0.20 })).to.equal(0)
+    })
+
+    it('handles no strategies (zero fees)', function() {
+      expect(computeNetApr(0.05, { management: 0, performance: 0 })).to.equal(0.05)
+    })
+  })
+
+  describe('computeApy', function() {
+    it('returns 0 for zero APR', function() {
+      expect(computeApy(0)).to.equal(0)
+    })
+
+    it('compounds weekly (52 periods)', function() {
+      const apr = 0.10
+      const expected = (1 + apr / 52) ** 52 - 1
+      expect(computeApy(apr)).to.be.closeTo(expected, 1e-15)
+    })
+
+    it('returns 0 for Infinity', function() {
+      expect(computeApy(Infinity)).to.equal(0)
+    })
   })
 })

--- a/packages/ingest/abis/yearn/lib/apy.ts
+++ b/packages/ingest/abis/yearn/lib/apy.ts
@@ -452,3 +452,12 @@ export async function extractLockedProfit__v3(chainId: number, address: `0x${str
     return undefined
   }
 }
+
+export function computeNetApr(grossApr: number, fees: { management: number; performance: number }): number {
+  return (grossApr - fees.management) * (1 - fees.performance)
+}
+
+export function computeApy(apr: number): number {
+  const result = (1 + apr / 52) ** 52 - 1
+  return Number.isFinite(result) ? result : 0
+}

--- a/packages/scripts/src/backfill-apr-oracle-netapr.ts
+++ b/packages/scripts/src/backfill-apr-oracle-netapr.ts
@@ -26,6 +26,7 @@ type TimeseriesCandidate = {
 type FeeConfig = { management: number; performance: number }
 type FeeConfigBps = { management: number; performance: number }
 type FeeSegment = { blockNumber: bigint } & FeeConfigBps
+type AccountantSegment = { blockNumber: bigint; accountant: `0x${string}` }
 
 type StrategyChangeEvent = { blockNumber: bigint; strategy: `0x${string}`; type: 'add' | 'revoke' }
 type DebtSnapshot = { blockNumber: bigint; currentDebt: bigint }
@@ -41,6 +42,9 @@ const CUSTOM_FEE_SELECTOR = toEventSelector(
 )
 const REMOVED_CUSTOM_FEE_SELECTOR = toEventSelector(
   'event RemovedCustomFeeConfig(address indexed vault, address indexed strategy)'
+)
+const UPDATE_ACCOUNTANT_SELECTOR = toEventSelector(
+  'event UpdateAccountant(address indexed accountant)'
 )
 
 function parseArgs(argv: string[]): Args {
@@ -125,43 +129,86 @@ async function getTimeseriesCandidates(args: Args): Promise<TimeseriesCandidate[
   }))
 }
 
-/** Get vault→accountant mapping from snapshot table */
-async function getVaultAccountants(candidates: TimeseriesCandidate[]): Promise<Map<string, `0x${string}`>> {
+/** Build vault accountant timelines from UpdateAccountant events, with snapshot fallback when no history exists */
+async function buildVaultAccountantTimelines(
+  candidates: TimeseriesCandidate[]
+): Promise<Map<string, AccountantSegment[]>> {
   const byChain = new Map<number, Set<string>>()
   for (const c of candidates) {
     if (!byChain.has(c.chainId)) byChain.set(c.chainId, new Set())
     byChain.get(c.chainId)!.add(c.address)
   }
 
-  const vaultAccountants = new Map<string, `0x${string}`>()
+  const timelines = new Map<string, AccountantSegment[]>()
 
   for (const [chainId, addresses] of byChain) {
+    const vaults = [...addresses]
+    const history = await db.query(`
+      SELECT chain_id, address, block_number, args
+      FROM evmlog
+      WHERE chain_id = $1 AND address = ANY($2) AND signature = $3
+      ORDER BY block_number ASC, log_index ASC
+    `, [chainId, vaults, UPDATE_ACCOUNTANT_SELECTOR])
+
+    for (const row of history.rows) {
+      const accountant = row.args.accountant ? getAddress(row.args.accountant) as `0x${string}` : zeroAddress
+      if (accountant === zeroAddress) continue
+      const key = `${row.chain_id}:${row.address}`
+      if (!timelines.has(key)) timelines.set(key, [])
+      timelines.get(key)!.push({
+        blockNumber: BigInt(row.block_number),
+        accountant,
+      })
+    }
+
     const result = await db.query(`
       SELECT address, snapshot->>'accountant' AS accountant
       FROM snapshot
       WHERE chain_id = $1 AND address = ANY($2)
         AND snapshot->>'accountant' IS NOT NULL
-    `, [chainId, [...addresses]])
+    `, [chainId, vaults])
 
     for (const row of result.rows) {
-      if (row.accountant && row.accountant !== zeroAddress) {
-        vaultAccountants.set(`${chainId}:${row.address}`, row.accountant)
+      const accountant = row.accountant ? getAddress(row.accountant) as `0x${string}` : zeroAddress
+      if (accountant !== zeroAddress) {
+        const key = `${chainId}:${row.address}`
+        if (!timelines.has(key) || timelines.get(key)!.length === 0) {
+          timelines.set(key, [{ blockNumber: 0n, accountant }])
+        }
       }
     }
   }
 
-  return vaultAccountants
+  return timelines
+}
+
+function lookupAccountantAtBlock(
+  timeline: AccountantSegment[] | undefined,
+  blockNumber: bigint
+): `0x${string}` | undefined {
+  if (!timeline || timeline.length === 0) return undefined
+  let accountant: `0x${string}` | undefined
+  for (const segment of timeline) {
+    if (segment.blockNumber <= blockNumber) {
+      accountant = segment.accountant
+    } else {
+      break
+    }
+  }
+  return accountant
 }
 
 /** Build default fee timelines from UpdateDefaultFeeConfig events in evmlog */
 async function buildDefaultFeeTimelines(
-  vaultAccountants: Map<string, `0x${string}`>
+  vaultAccountants: Map<string, AccountantSegment[]>
 ): Promise<Map<string, FeeSegment[]>> {
   const accountantsByChain = new Map<number, Set<string>>()
-  for (const [key, accountant] of vaultAccountants) {
+  for (const [key, timeline] of vaultAccountants) {
     const chainId = Number(key.split(':')[0])
     if (!accountantsByChain.has(chainId)) accountantsByChain.set(chainId, new Set())
-    accountantsByChain.get(chainId)!.add(accountant)
+    for (const { accountant } of timeline) {
+      accountantsByChain.get(chainId)!.add(accountant)
+    }
   }
 
   const timelines = new Map<string, FeeSegment[]>()
@@ -198,13 +245,15 @@ type CustomFeeEvent = {
 
 /** Build custom fee timelines from UpdateCustomFeeConfig and RemovedCustomFeeConfig events */
 async function buildCustomFeeTimelines(
-  vaultAccountants: Map<string, `0x${string}`>
+  vaultAccountants: Map<string, AccountantSegment[]>
 ): Promise<Map<string, CustomFeeEvent[]>> {
   const accountantsByChain = new Map<number, Set<string>>()
-  for (const [key, accountant] of vaultAccountants) {
+  for (const [key, timeline] of vaultAccountants) {
     const chainId = Number(key.split(':')[0])
     if (!accountantsByChain.has(chainId)) accountantsByChain.set(chainId, new Set())
-    accountantsByChain.get(chainId)!.add(accountant)
+    for (const { accountant } of timeline) {
+      accountantsByChain.get(chainId)!.add(accountant)
+    }
   }
 
   const timelines = new Map<string, CustomFeeEvent[]>()
@@ -335,9 +384,12 @@ function projectStrategiesAtBlock(
   return strategies
 }
 
-/** Build debt timelines from StrategyReported events per (vault, strategy) */
+/** Build debt timelines from debt-changing events per (vault, strategy) */
 const STRATEGY_REPORTED_SELECTOR = toEventSelector(
   'event StrategyReported(address indexed strategy, uint256 gain, uint256 loss, uint256 current_debt, uint256 protocol_fees, uint256 total_fees, uint256 total_refunds)'
+)
+const DEBT_UPDATED_SELECTOR = toEventSelector(
+  'event DebtUpdated(address indexed strategy, uint256 current_debt, uint256 new_debt)'
 )
 
 async function buildDebtTimelines(
@@ -353,19 +405,22 @@ async function buildDebtTimelines(
 
   for (const [chainId, addresses] of byChain) {
     const result = await db.query(`
-      SELECT chain_id, address, block_number, args
+      SELECT chain_id, address, block_number, log_index, signature, args
       FROM evmlog
-      WHERE chain_id = $1 AND address = ANY($2) AND signature = $3
+      WHERE chain_id = $1 AND address = ANY($2) AND signature = ANY($3)
       ORDER BY block_number ASC, log_index ASC
-    `, [chainId, [...addresses], STRATEGY_REPORTED_SELECTOR])
+    `, [chainId, [...addresses], [STRATEGY_REPORTED_SELECTOR, DEBT_UPDATED_SELECTOR]])
 
     for (const row of result.rows) {
       const strategy = getAddress(row.args.strategy) as `0x${string}`
       const key = `${row.chain_id}:${row.address}:${strategy}`
       if (!timelines.has(key)) timelines.set(key, [])
+      const currentDebt = row.signature === DEBT_UPDATED_SELECTOR
+        ? BigInt(row.args.new_debt)
+        : BigInt(row.args.current_debt)
       timelines.get(key)!.push({
         blockNumber: BigInt(row.block_number),
-        currentDebt: BigInt(row.args.current_debt),
+        currentDebt,
       })
     }
   }
@@ -458,18 +513,18 @@ function resolveFees(
 }
 
 async function buildCaches(candidates: TimeseriesCandidate[]): Promise<{
-  vaultAccountants: Map<string, `0x${string}`>
+  vaultAccountantTimelines: Map<string, AccountantSegment[]>
   defaultTimelines: Map<string, FeeSegment[]>
   customTimelines: Map<string, CustomFeeEvent[]>
   strategyTimelines: Map<string, StrategyChangeEvent[]>
   debtTimelines: Map<string, DebtSnapshot[]>
 }> {
-  const vaultAccountants = await getVaultAccountants(candidates)
-  console.log(`found accountants for ${vaultAccountants.size} vaults`)
+  const vaultAccountantTimelines = await buildVaultAccountantTimelines(candidates)
+  console.log(`found accountant timelines for ${vaultAccountantTimelines.size} vaults`)
 
   const [defaultTimelines, customTimelines, strategyTimelines, debtTimelines] = await Promise.all([
-    buildDefaultFeeTimelines(vaultAccountants),
-    buildCustomFeeTimelines(vaultAccountants),
+    buildDefaultFeeTimelines(vaultAccountantTimelines),
+    buildCustomFeeTimelines(vaultAccountantTimelines),
     buildStrategyTimelines(candidates),
     buildDebtTimelines(candidates),
   ])
@@ -480,7 +535,7 @@ async function buildCaches(candidates: TimeseriesCandidate[]): Promise<{
   const totalDebtEvents = [...debtTimelines.values()].reduce((sum, t) => sum + t.length, 0)
   console.log(`loaded ${totalDefaultEvents} default fee events, ${totalCustomEvents} custom fee events, ${totalStrategyEvents} strategy events, ${totalDebtEvents} debt events from evmlog`)
 
-  return { vaultAccountants, defaultTimelines, customTimelines, strategyTimelines, debtTimelines }
+  return { vaultAccountantTimelines, defaultTimelines, customTimelines, strategyTimelines, debtTimelines }
 }
 
 async function backfillTimeseries(args: Args) {
@@ -488,14 +543,14 @@ async function backfillTimeseries(args: Args) {
   console.log(`timeseries candidates: ${candidates.length}`)
   if (candidates.length === 0) return
 
-  const { vaultAccountants, defaultTimelines, customTimelines, strategyTimelines, debtTimelines } = await buildCaches(candidates)
+  const { vaultAccountantTimelines, defaultTimelines, customTimelines, strategyTimelines, debtTimelines } = await buildCaches(candidates)
 
   const outputs: Output[] = []
   let noAccountant = 0
 
   for (const candidate of candidates) {
     const vaultKey = `${candidate.chainId}:${candidate.address}`
-    const accountant = vaultAccountants.get(vaultKey)
+    const accountant = lookupAccountantAtBlock(vaultAccountantTimelines.get(vaultKey), candidate.blockNumber)
 
     let fees: FeeConfig
     if (!accountant) {

--- a/packages/scripts/src/backfill-apr-oracle-netapr.ts
+++ b/packages/scripts/src/backfill-apr-oracle-netapr.ts
@@ -1,10 +1,9 @@
 import 'lib/global'
 
-import { projectStrategies } from 'ingest/abis/yearn/3/vault/snapshot/hook'
 import { computeApy, computeNetApr } from 'ingest/abis/yearn/lib/apy'
 import db from 'ingest/db'
 import { upsertBatchOutput } from 'ingest/load'
-import { mq } from 'lib'
+import { math, mq } from 'lib'
 import type { Output } from 'lib/types'
 import { getAddress, toEventSelector, zeroAddress } from 'viem'
 
@@ -26,6 +25,9 @@ type TimeseriesCandidate = {
 
 type FeeConfig = { management: number; performance: number }
 type FeeSegment = { blockNumber: bigint } & FeeConfig
+
+type StrategyChangeEvent = { blockNumber: bigint; strategy: `0x${string}`; type: 'add' | 'revoke' }
+type DebtSnapshot = { blockNumber: bigint; currentDebt: bigint }
 
 const WRITE_BATCH_SIZE = 1000
 const WRITE_CONCURRENCY = 10
@@ -271,7 +273,120 @@ function lookupCustomAtBlock(timeline: CustomFeeEvent[] | undefined, blockNumber
   return result
 }
 
-/** Resolve fees for a vault at a given block using evmlog-based fee timelines */
+/** Build strategy change timelines from StrategyChanged events per vault */
+const STRATEGY_CHANGED_SELECTOR = toEventSelector(
+  'event StrategyChanged(address indexed strategy, uint256 change_type)'
+)
+
+async function buildStrategyTimelines(
+  candidates: TimeseriesCandidate[]
+): Promise<Map<string, StrategyChangeEvent[]>> {
+  const byChain = new Map<number, Set<string>>()
+  for (const c of candidates) {
+    if (!byChain.has(c.chainId)) byChain.set(c.chainId, new Set())
+    byChain.get(c.chainId)!.add(c.address)
+  }
+
+  const timelines = new Map<string, StrategyChangeEvent[]>()
+
+  for (const [chainId, addresses] of byChain) {
+    const result = await db.query(`
+      SELECT chain_id, address, block_number, args
+      FROM evmlog
+      WHERE chain_id = $1 AND address = ANY($2) AND signature = $3
+      ORDER BY block_number ASC, log_index ASC
+    `, [chainId, [...addresses], STRATEGY_CHANGED_SELECTOR])
+
+    for (const row of result.rows) {
+      const key = `${row.chain_id}:${row.address}`
+      if (!timelines.has(key)) timelines.set(key, [])
+      const changeType: Record<number, 'add' | 'revoke'> = { [2 ** 0]: 'add', [2 ** 1]: 'revoke' }
+      const type = changeType[Number(row.args.change_type)]
+      if (type) {
+        timelines.get(key)!.push({
+          blockNumber: BigInt(row.block_number),
+          strategy: getAddress(row.args.strategy) as `0x${string}`,
+          type,
+        })
+      }
+    }
+  }
+
+  return timelines
+}
+
+/** Project strategy set at a given block by replaying StrategyChanged events */
+function projectStrategiesAtBlock(
+  timeline: StrategyChangeEvent[] | undefined,
+  blockNumber: bigint
+): `0x${string}`[] {
+  if (!timeline) return []
+  const strategies: `0x${string}`[] = []
+  for (const event of timeline) {
+    if (event.blockNumber > blockNumber) break
+    if (event.type === 'add') {
+      if (!strategies.includes(event.strategy)) strategies.push(event.strategy)
+    } else {
+      const idx = strategies.indexOf(event.strategy)
+      if (idx >= 0) strategies.splice(idx, 1)
+    }
+  }
+  return strategies
+}
+
+/** Build debt timelines from StrategyReported events per (vault, strategy) */
+const STRATEGY_REPORTED_SELECTOR = toEventSelector(
+  'event StrategyReported(address indexed strategy, uint256 gain, uint256 loss, uint256 current_debt, uint256 protocol_fees, uint256 total_fees, uint256 total_refunds)'
+)
+
+async function buildDebtTimelines(
+  candidates: TimeseriesCandidate[]
+): Promise<Map<string, DebtSnapshot[]>> {
+  const byChain = new Map<number, Set<string>>()
+  for (const c of candidates) {
+    if (!byChain.has(c.chainId)) byChain.set(c.chainId, new Set())
+    byChain.get(c.chainId)!.add(c.address)
+  }
+
+  const timelines = new Map<string, DebtSnapshot[]>()
+
+  for (const [chainId, addresses] of byChain) {
+    const result = await db.query(`
+      SELECT chain_id, address, block_number, args
+      FROM evmlog
+      WHERE chain_id = $1 AND address = ANY($2) AND signature = $3
+      ORDER BY block_number ASC, log_index ASC
+    `, [chainId, [...addresses], STRATEGY_REPORTED_SELECTOR])
+
+    for (const row of result.rows) {
+      const strategy = getAddress(row.args.strategy) as `0x${string}`
+      const key = `${row.chain_id}:${row.address}:${strategy}`
+      if (!timelines.has(key)) timelines.set(key, [])
+      timelines.get(key)!.push({
+        blockNumber: BigInt(row.block_number),
+        currentDebt: BigInt(row.args.current_debt),
+      })
+    }
+  }
+
+  return timelines
+}
+
+/** Lookup the latest debt snapshot for a strategy at or before blockNumber */
+function lookupDebtAtBlock(timeline: DebtSnapshot[] | undefined, blockNumber: bigint): bigint {
+  if (!timeline || timeline.length === 0) return 0n
+  let result = 0n
+  for (const snapshot of timeline) {
+    if (snapshot.blockNumber <= blockNumber) {
+      result = snapshot.currentDebt
+    } else {
+      break
+    }
+  }
+  return result
+}
+
+/** Resolve fees for a vault at a given block using debt-weighted averaging (matches production extractFees__v3) */
 function resolveFees(
   chainId: number,
   vault: `0x${string}`,
@@ -280,52 +395,86 @@ function resolveFees(
   blockNumber: bigint,
   defaultTimelines: Map<string, FeeSegment[]>,
   customTimelines: Map<string, CustomFeeEvent[]>,
+  debtTimelines: Map<string, DebtSnapshot[]>,
 ): FeeConfig {
   const accountantKey = `${chainId}:${accountant}`
   const defaultFees = lookupDefaultAtBlock(defaultTimelines.get(accountantKey), blockNumber)
 
   if (strategies.length === 0) return defaultFees
 
-  // Check if any strategy has a custom config at this block
-  let totalManagement = 0
-  let totalPerformance = 0
-  for (const strategy of strategies) {
-    const customKey = `${chainId}:${vault}:${strategy}`
-    const custom = lookupCustomAtBlock(customTimelines.get(customKey), blockNumber)
-    if (custom) {
-      totalManagement += custom.management
-      totalPerformance += custom.performance
-    } else {
-      totalManagement += defaultFees.management
-      totalPerformance += defaultFees.performance
+  // Compute debt-weighted fees (matching production extractFees__v3)
+  const debts: bigint[] = strategies.map(strategy => {
+    const debtKey = `${chainId}:${vault}:${strategy}`
+    return lookupDebtAtBlock(debtTimelines.get(debtKey), blockNumber)
+  })
+  const totalDebt = debts.reduce((a, b) => a + b, 0n)
+
+  // If no debt data, fall back to equal weighting
+  if (totalDebt === 0n) {
+    let totalManagement = 0
+    let totalPerformance = 0
+    for (const strategy of strategies) {
+      const customKey = `${chainId}:${vault}:${strategy}`
+      const custom = lookupCustomAtBlock(customTimelines.get(customKey), blockNumber)
+      if (custom) {
+        totalManagement += custom.management
+        totalPerformance += custom.performance
+      } else {
+        totalManagement += defaultFees.management
+        totalPerformance += defaultFees.performance
+      }
+    }
+    return {
+      management: totalManagement / strategies.length,
+      performance: totalPerformance / strategies.length,
     }
   }
 
-  // Equal-weighted average across strategies (approximation without on-chain debt data)
+  let weightedManagement = 0
+  let weightedPerformance = 0
+  for (let i = 0; i < strategies.length; i++) {
+    const debtRatio = math.div(debts[i], totalDebt)
+    const customKey = `${chainId}:${vault}:${strategies[i]}`
+    const custom = lookupCustomAtBlock(customTimelines.get(customKey), blockNumber)
+    if (custom) {
+      weightedManagement += debtRatio * custom.management
+      weightedPerformance += debtRatio * custom.performance
+    } else {
+      weightedManagement += debtRatio * defaultFees.management
+      weightedPerformance += debtRatio * defaultFees.performance
+    }
+  }
+
   return {
-    management: totalManagement / strategies.length,
-    performance: totalPerformance / strategies.length,
+    management: weightedManagement,
+    performance: weightedPerformance,
   }
 }
 
-async function buildFeeCache(candidates: TimeseriesCandidate[]): Promise<{
+async function buildCaches(candidates: TimeseriesCandidate[]): Promise<{
   vaultAccountants: Map<string, `0x${string}`>
   defaultTimelines: Map<string, FeeSegment[]>
   customTimelines: Map<string, CustomFeeEvent[]>
+  strategyTimelines: Map<string, StrategyChangeEvent[]>
+  debtTimelines: Map<string, DebtSnapshot[]>
 }> {
   const vaultAccountants = await getVaultAccountants(candidates)
   console.log(`found accountants for ${vaultAccountants.size} vaults`)
 
-  const [defaultTimelines, customTimelines] = await Promise.all([
+  const [defaultTimelines, customTimelines, strategyTimelines, debtTimelines] = await Promise.all([
     buildDefaultFeeTimelines(vaultAccountants),
     buildCustomFeeTimelines(vaultAccountants),
+    buildStrategyTimelines(candidates),
+    buildDebtTimelines(candidates),
   ])
 
   const totalDefaultEvents = [...defaultTimelines.values()].reduce((sum, t) => sum + t.length, 0)
   const totalCustomEvents = [...customTimelines.values()].reduce((sum, t) => sum + t.length, 0)
-  console.log(`loaded ${totalDefaultEvents} default fee events, ${totalCustomEvents} custom fee events from evmlog`)
+  const totalStrategyEvents = [...strategyTimelines.values()].reduce((sum, t) => sum + t.length, 0)
+  const totalDebtEvents = [...debtTimelines.values()].reduce((sum, t) => sum + t.length, 0)
+  console.log(`loaded ${totalDefaultEvents} default fee events, ${totalCustomEvents} custom fee events, ${totalStrategyEvents} strategy events, ${totalDebtEvents} debt events from evmlog`)
 
-  return { vaultAccountants, defaultTimelines, customTimelines }
+  return { vaultAccountants, defaultTimelines, customTimelines, strategyTimelines, debtTimelines }
 }
 
 async function backfillTimeseries(args: Args) {
@@ -333,36 +482,7 @@ async function backfillTimeseries(args: Args) {
   console.log(`timeseries candidates: ${candidates.length}`)
   if (candidates.length === 0) return
 
-  const { vaultAccountants, defaultTimelines, customTimelines } = await buildFeeCache(candidates)
-
-  // Cache strategies per vault to avoid repeated DB queries
-  const strategyCache = new Map<string, `0x${string}`[]>()
-
-  // Group candidates by vault for strategy caching
-  const vaultCandidates = new Map<string, TimeseriesCandidate[]>()
-  for (const c of candidates) {
-    const key = `${c.chainId}:${c.address}`
-    if (!vaultCandidates.has(key)) vaultCandidates.set(key, [])
-    vaultCandidates.get(key)!.push(c)
-  }
-
-  // Pre-fetch strategies for each vault at each unique block
-  // (projectStrategies is a DB query, not RPC)
-  const STRATEGY_CONCURRENCY = 10
-  const vaultEntries = [...vaultCandidates.entries()]
-  for (let i = 0; i < vaultEntries.length; i += STRATEGY_CONCURRENCY) {
-    const batch = vaultEntries.slice(i, i + STRATEGY_CONCURRENCY)
-    await Promise.all(batch.map(async ([key, vCandidates]) => {
-      const { chainId, address } = vCandidates[0]
-      // Use the latest blockNumber for strategy projection
-      const maxBlock = vCandidates.reduce((max, c) => c.blockNumber > max ? c.blockNumber : max, 0n)
-      const strategies = await projectStrategies(chainId, address, maxBlock)
-      strategyCache.set(key, strategies)
-    }))
-    if ((i + STRATEGY_CONCURRENCY) % 200 === 0 || i + STRATEGY_CONCURRENCY >= vaultEntries.length) {
-      console.log(`fetched strategies ${Math.min(i + STRATEGY_CONCURRENCY, vaultEntries.length)}/${vaultEntries.length}`)
-    }
-  }
+  const { vaultAccountants, defaultTimelines, customTimelines, strategyTimelines, debtTimelines } = await buildCaches(candidates)
 
   const outputs: Output[] = []
   let noAccountant = 0
@@ -376,10 +496,11 @@ async function backfillTimeseries(args: Args) {
       fees = { management: 0, performance: 0 }
       noAccountant++
     } else {
-      const strategies = strategyCache.get(vaultKey) ?? []
+      // Project strategies at this candidate's block (not latest)
+      const strategies = projectStrategiesAtBlock(strategyTimelines.get(vaultKey), candidate.blockNumber)
       fees = resolveFees(
         candidate.chainId, candidate.address, accountant, strategies,
-        candidate.blockNumber, defaultTimelines, customTimelines,
+        candidate.blockNumber, defaultTimelines, customTimelines, debtTimelines,
       )
     }
 

--- a/packages/scripts/src/backfill-apr-oracle-netapr.ts
+++ b/packages/scripts/src/backfill-apr-oracle-netapr.ts
@@ -568,7 +568,7 @@ async function backfillTimeseries(args: Args) {
     const netApr = computeNetApr(candidate.apr, fees)
     const netApy = computeApy(netApr)
 
-    if (!candidate.hasNetApr) {
+    if (!candidate.hasNetApr && netApr !== 0) {
       outputs.push({
         chainId: candidate.chainId,
         address: candidate.address,
@@ -580,7 +580,7 @@ async function backfillTimeseries(args: Args) {
       })
     }
 
-    if (!candidate.hasNetApy) {
+    if (!candidate.hasNetApy && netApy !== 0) {
       outputs.push({
         chainId: candidate.chainId,
         address: candidate.address,

--- a/packages/scripts/src/backfill-apr-oracle-netapr.ts
+++ b/packages/scripts/src/backfill-apr-oracle-netapr.ts
@@ -246,10 +246,10 @@ async function buildCustomFeeTimelines(
   return timelines
 }
 
-/** Find the fee config active at a given block from a sorted timeline */
-function lookupDefaultAtBlock(timeline: FeeSegment[] | undefined, blockNumber: bigint): FeeConfig {
+/** Find the fee config (BPS) active at a given block from a sorted timeline */
+function lookupDefaultAtBlock(timeline: FeeSegment[] | undefined, blockNumber: bigint): FeeConfigBps {
   if (!timeline || timeline.length === 0) return { management: 0, performance: 0 }
-  let result: FeeConfig = { management: 0, performance: 0 }
+  let result: FeeConfigBps = { management: 0, performance: 0 }
   for (const segment of timeline) {
     if (segment.blockNumber <= blockNumber) {
       result = { management: segment.management, performance: segment.performance }
@@ -260,10 +260,10 @@ function lookupDefaultAtBlock(timeline: FeeSegment[] | undefined, blockNumber: b
   return result
 }
 
-/** Find the custom fee config active at a given block, or null if reverted to default */
-function lookupCustomAtBlock(timeline: CustomFeeEvent[] | undefined, blockNumber: bigint): FeeConfig | null {
+/** Find the custom fee config (BPS) active at a given block, or null if reverted to default */
+function lookupCustomAtBlock(timeline: CustomFeeEvent[] | undefined, blockNumber: bigint): FeeConfigBps | null {
   if (!timeline || timeline.length === 0) return null
-  let result: FeeConfig | null = null
+  let result: FeeConfigBps | null = null
   for (const event of timeline) {
     if (event.blockNumber <= blockNumber) {
       result = event.type === 'set' ? { management: event.management, performance: event.performance } : null
@@ -387,7 +387,7 @@ function lookupDebtAtBlock(timeline: DebtSnapshot[] | undefined, blockNumber: bi
   return result
 }
 
-/** Resolve fees for a vault at a given block using debt-weighted averaging (matches production extractFees__v3) */
+/** Resolve fees for a vault at a given block using debt-weighted BPS averaging (matches production extractFees__v3) */
 function resolveFees(
   chainId: number,
   vault: `0x${string}`,
@@ -399,11 +399,16 @@ function resolveFees(
   debtTimelines: Map<string, DebtSnapshot[]>,
 ): FeeConfig {
   const accountantKey = `${chainId}:${accountant}`
-  const defaultFees = lookupDefaultAtBlock(defaultTimelines.get(accountantKey), blockNumber)
+  const defaultFeesBps = lookupDefaultAtBlock(defaultTimelines.get(accountantKey), blockNumber)
 
-  if (strategies.length === 0) return defaultFees
+  if (strategies.length === 0) {
+    return {
+      management: defaultFeesBps.management / 10_000,
+      performance: defaultFeesBps.performance / 10_000,
+    }
+  }
 
-  // Compute debt-weighted fees (matching production extractFees__v3)
+  // Compute debt-weighted fees in BPS (matching production extractFees__v3)
   const debts: bigint[] = strategies.map(strategy => {
     const debtKey = `${chainId}:${vault}:${strategy}`
     return lookupDebtAtBlock(debtTimelines.get(debtKey), blockNumber)
@@ -421,34 +426,34 @@ function resolveFees(
         totalManagement += custom.management
         totalPerformance += custom.performance
       } else {
-        totalManagement += defaultFees.management
-        totalPerformance += defaultFees.performance
+        totalManagement += defaultFeesBps.management
+        totalPerformance += defaultFeesBps.performance
       }
     }
     return {
-      management: totalManagement / strategies.length,
-      performance: totalPerformance / strategies.length,
+      management: (totalManagement / strategies.length) / 10_000,
+      performance: (totalPerformance / strategies.length) / 10_000,
     }
   }
 
-  let weightedManagement = 0
-  let weightedPerformance = 0
+  const feesBps = { management: 0, performance: 0 }
   for (let i = 0; i < strategies.length; i++) {
     const debtRatio = math.div(debts[i], totalDebt)
+    if (Number.isNaN(debtRatio)) continue
     const customKey = `${chainId}:${vault}:${strategies[i]}`
     const custom = lookupCustomAtBlock(customTimelines.get(customKey), blockNumber)
     if (custom) {
-      weightedManagement += debtRatio * custom.management
-      weightedPerformance += debtRatio * custom.performance
+      feesBps.management += debtRatio * custom.management
+      feesBps.performance += debtRatio * custom.performance
     } else {
-      weightedManagement += debtRatio * defaultFees.management
-      weightedPerformance += debtRatio * defaultFees.performance
+      feesBps.management += debtRatio * defaultFeesBps.management
+      feesBps.performance += debtRatio * defaultFeesBps.performance
     }
   }
 
   return {
-    management: weightedManagement,
-    performance: weightedPerformance,
+    management: feesBps.management / 10_000,
+    performance: feesBps.performance / 10_000,
   }
 }
 

--- a/packages/scripts/src/backfill-apr-oracle-netapr.ts
+++ b/packages/scripts/src/backfill-apr-oracle-netapr.ts
@@ -24,7 +24,8 @@ type TimeseriesCandidate = {
 }
 
 type FeeConfig = { management: number; performance: number }
-type FeeSegment = { blockNumber: bigint } & FeeConfig
+type FeeConfigBps = { management: number; performance: number }
+type FeeSegment = { blockNumber: bigint } & FeeConfigBps
 
 type StrategyChangeEvent = { blockNumber: bigint; strategy: `0x${string}`; type: 'add' | 'revoke' }
 type DebtSnapshot = { blockNumber: bigint; currentDebt: bigint }
@@ -179,8 +180,8 @@ async function buildDefaultFeeTimelines(
       const cfg = row.args.defaultFeeConfig ?? row.args
       timelines.get(key)!.push({
         blockNumber: BigInt(row.block_number),
-        management: Number(cfg.managementFee ?? cfg[0] ?? 0) / 10_000,
-        performance: Number(cfg.performanceFee ?? cfg[1] ?? 0) / 10_000,
+        management: Number(cfg.managementFee ?? cfg[0] ?? 0),
+        performance: Number(cfg.performanceFee ?? cfg[1] ?? 0),
       })
     }
   }
@@ -228,8 +229,8 @@ async function buildCustomFeeTimelines(
         timelines.get(key)!.push({
           blockNumber: BigInt(row.block_number),
           type: 'set',
-          management: Number(cfg.managementFee ?? cfg[0] ?? 0) / 10_000,
-          performance: Number(cfg.performanceFee ?? cfg[1] ?? 0) / 10_000,
+          management: Number(cfg.managementFee ?? cfg[0] ?? 0),
+          performance: Number(cfg.performanceFee ?? cfg[1] ?? 0),
         })
       } else {
         timelines.get(key)!.push({

--- a/packages/scripts/src/backfill-apr-oracle-netapr.ts
+++ b/packages/scripts/src/backfill-apr-oracle-netapr.ts
@@ -1,6 +1,7 @@
 import 'lib/global'
 
-import { extractFeesBps } from 'ingest/abis/yearn/3/vault/snapshot/hook'
+import { projectStrategies } from 'ingest/abis/yearn/3/vault/snapshot/hook'
+import { computeApy, computeNetApr, extractFees__v3 } from 'ingest/abis/yearn/lib/apy'
 import db from 'ingest/db'
 import { upsertBatchOutput } from 'ingest/load'
 import { rpcs } from 'ingest/rpcs'
@@ -22,17 +23,6 @@ type TimeseriesCandidate = {
   apr: number
   hasNetApr: boolean
   hasNetApy: boolean
-}
-
-type VaultSnapshotRow = {
-  chainId: number
-  address: `0x${string}`
-  snapshot: Record<string, unknown>
-}
-
-type FeeRates = {
-  management: number
-  performance: number
 }
 
 const WRITE_BATCH_SIZE = 200
@@ -62,16 +52,6 @@ defaults:
     chainId: chainId ? Number(chainId) : undefined,
     address: address ? getAddress(address as `0x${string}`) : undefined,
   }
-}
-
-function computeFeeAdjustedApr(apr: number, fees: FeeRates): number {
-  const next = apr * (1 - fees.performance) - fees.management
-  return Number.isFinite(next) ? next : 0
-}
-
-function computeApy(apr: number): number {
-  const next = (1 + apr / 52) ** 52 - 1
-  return Number.isFinite(next) ? next : 0
 }
 
 async function getTimeseriesCandidates(args: Args): Promise<TimeseriesCandidate[]> {
@@ -129,75 +109,30 @@ async function getTimeseriesCandidates(args: Args): Promise<TimeseriesCandidate[
   }))
 }
 
-async function getV3VaultSnapshots(args: Args): Promise<Map<string, Record<string, unknown>>> {
-  const values: Array<number | string> = []
-  const filters: string[] = []
-
-  if (args.chainId !== undefined) {
-    values.push(args.chainId)
-    filters.push(`s.chain_id = $${values.length}`)
-  }
-
-  if (args.address) {
-    values.push(args.address)
-    filters.push(`s.address = $${values.length}`)
-  }
-
-  const whereClause = filters.length > 0 ? `AND ${filters.join(' AND ')}` : ''
-
-  const result = await db.query(`
-    SELECT
-      s.chain_id AS "chainId",
-      s.address,
-      s.snapshot
-    FROM snapshot s
-    JOIN thing t
-      ON t.chain_id = s.chain_id
-      AND t.address = s.address
-      AND t.label = 'vault'
-      AND COALESCE((t.defaults->>'v3')::boolean, false)
-    WHERE TRUE
-      ${whereClause}
-  `, values)
-
-  const map = new Map<string, Record<string, unknown>>()
-  for (const row of result.rows as VaultSnapshotRow[]) {
-    map.set(`${row.chainId}:${row.address}`, row.snapshot ?? {})
-  }
-
-  return map
-}
-
 async function backfillTimeseries(args: Args) {
   const candidates = await getTimeseriesCandidates(args)
-  console.log(`🕒 timeseries candidates: ${candidates.length}`)
+  console.log(`timeseries candidates: ${candidates.length}`)
   if (candidates.length === 0) return
 
-  const snapshots = await getV3VaultSnapshots(args)
-  const feesByVault = new Map<string, FeeRates>()
+  const feeCache = new Map<string, { management: number; performance: number }>()
   const pending: Output[] = []
   let inserted = 0
 
   for (const [index, candidate] of candidates.entries()) {
-    const vaultKey = `${candidate.chainId}:${candidate.address}`
-    let fees = feesByVault.get(vaultKey)
+    const cacheKey = `${candidate.chainId}:${candidate.address}:${candidate.blockNumber}`
+    let fees = feeCache.get(cacheKey)
 
     if (!fees) {
-      const snapshot = snapshots.get(vaultKey)
-      if (!snapshot) {
-        console.warn(`🚨 missing snapshot for ${vaultKey}, defaulting fees to zero`)
+      try {
+        const strategies = await projectStrategies(candidate.chainId, candidate.address, candidate.blockNumber)
+        fees = await extractFees__v3(candidate.chainId, candidate.address, strategies, candidate.blockNumber)
+      } catch {
         fees = { management: 0, performance: 0 }
-      } else {
-        const feeBps = await extractFeesBps(candidate.chainId, candidate.address, snapshot)
-        fees = {
-          management: feeBps.managementFee / 10_000,
-          performance: feeBps.performanceFee / 10_000,
-        }
       }
-      feesByVault.set(vaultKey, fees)
+      feeCache.set(cacheKey, fees)
     }
 
-    const netApr = computeFeeAdjustedApr(candidate.apr, fees)
+    const netApr = computeNetApr(candidate.apr, fees)
     const netApy = computeApy(netApr)
 
     if (!candidate.hasNetApr) {
@@ -231,7 +166,7 @@ async function backfillTimeseries(args: Args) {
     }
 
     if ((index + 1) % 500 === 0 || index === candidates.length - 1) {
-      console.log(`🕒 processed ${index + 1}/${candidates.length} timeseries rows`)
+      console.log(`processed ${index + 1}/${candidates.length} timeseries rows`)
     }
   }
 
@@ -241,13 +176,13 @@ async function backfillTimeseries(args: Args) {
     inserted += batch.length
   }
 
-  console.log(`${args.apply ? '✅' : '🧪'} timeseries outputs ${args.apply ? 'upserted' : 'prepared'}: ${inserted}`)
+  console.log(`${args.apply ? 'upserted' : 'prepared (dry-run)'}: ${inserted} timeseries outputs`)
 }
 
 async function main() {
   const args = parseArgs(process.argv.slice(2))
 
-  console.log(args.apply ? '⚠️ apply mode' : '🧪 dry-run mode')
+  console.log(args.apply ? 'apply mode' : 'dry-run mode')
   if (args.chainId !== undefined) console.log(`chainId=${args.chainId}`)
   if (args.address) console.log(`address=${args.address}`)
 
@@ -263,6 +198,6 @@ async function main() {
 }
 
 main().catch(error => {
-  console.error('🤬 backfill-apr-oracle-netapr', error)
+  console.error('backfill-apr-oracle-netapr', error)
   process.exit(1)
 })

--- a/packages/scripts/src/backfill-apr-oracle-netapr.ts
+++ b/packages/scripts/src/backfill-apr-oracle-netapr.ts
@@ -1,13 +1,12 @@
 import 'lib/global'
 
 import { projectStrategies } from 'ingest/abis/yearn/3/vault/snapshot/hook'
-import { computeApy, computeNetApr, extractFees__v3 } from 'ingest/abis/yearn/lib/apy'
+import { computeApy, computeNetApr } from 'ingest/abis/yearn/lib/apy'
 import db from 'ingest/db'
 import { upsertBatchOutput } from 'ingest/load'
-import { rpcs } from 'ingest/rpcs'
 import { mq } from 'lib'
 import type { Output } from 'lib/types'
-import { getAddress } from 'viem'
+import { getAddress, toEventSelector, zeroAddress } from 'viem'
 
 type Args = {
   apply: boolean
@@ -25,7 +24,21 @@ type TimeseriesCandidate = {
   hasNetApy: boolean
 }
 
-const WRITE_BATCH_SIZE = 200
+type FeeConfig = { management: number; performance: number }
+type FeeSegment = { blockNumber: bigint } & FeeConfig
+
+const WRITE_BATCH_SIZE = 1000
+const WRITE_CONCURRENCY = 10
+
+const DEFAULT_FEE_SELECTOR = toEventSelector(
+  'event UpdateDefaultFeeConfig((uint16,uint16,uint16,uint16,uint16,uint16) defaultFeeConfig)'
+)
+const CUSTOM_FEE_SELECTOR = toEventSelector(
+  'event UpdateCustomFeeConfig(address indexed vault, address indexed strategy, (uint16,uint16,uint16,uint16,uint16,uint16) custom_config)'
+)
+const REMOVED_CUSTOM_FEE_SELECTOR = toEventSelector(
+  'event RemovedCustomFeeConfig(address indexed vault, address indexed strategy)'
+)
 
 function parseArgs(argv: string[]): Args {
   const getArg = (flag: string) => {
@@ -109,52 +122,267 @@ async function getTimeseriesCandidates(args: Args): Promise<TimeseriesCandidate[
   }))
 }
 
-async function prefetchFees(candidates: TimeseriesCandidate[]): Promise<Map<string, { management: number; performance: number }>> {
-  const vaultMap = new Map<string, { chainId: number; address: `0x${string}`; blockNumber: bigint }>()
+/** Get vault→accountant mapping from snapshot table */
+async function getVaultAccountants(candidates: TimeseriesCandidate[]): Promise<Map<string, `0x${string}`>> {
+  const byChain = new Map<number, Set<string>>()
   for (const c of candidates) {
-    const key = `${c.chainId}:${c.address}`
-    const existing = vaultMap.get(key)
-    if (!existing || c.blockNumber > existing.blockNumber) {
-      vaultMap.set(key, { chainId: c.chainId, address: c.address, blockNumber: c.blockNumber })
-    }
+    if (!byChain.has(c.chainId)) byChain.set(c.chainId, new Set())
+    byChain.get(c.chainId)!.add(c.address)
   }
 
-  console.log(`fetching fees for ${vaultMap.size} unique vaults...`)
-  const feeCache = new Map<string, { management: number; performance: number }>()
+  const vaultAccountants = new Map<string, `0x${string}`>()
 
-  const CONCURRENCY = 10
-  const entries = [...vaultMap.entries()]
-  for (let i = 0; i < entries.length; i += CONCURRENCY) {
-    const batch = entries.slice(i, i + CONCURRENCY)
-    const results = await Promise.all(batch.map(async ([key, vault]) => {
-      try {
-        const strategies = await projectStrategies(vault.chainId, vault.address, vault.blockNumber)
-        return { key, fees: await extractFees__v3(vault.chainId, vault.address, strategies, vault.blockNumber) }
-      } catch {
-        return { key, fees: { management: 0, performance: 0 } }
+  for (const [chainId, addresses] of byChain) {
+    const result = await db.query(`
+      SELECT address, snapshot->>'accountant' AS accountant
+      FROM snapshot
+      WHERE chain_id = $1 AND address = ANY($2)
+        AND snapshot->>'accountant' IS NOT NULL
+    `, [chainId, [...addresses]])
+
+    for (const row of result.rows) {
+      if (row.accountant && row.accountant !== zeroAddress) {
+        vaultAccountants.set(`${chainId}:${row.address}`, row.accountant)
       }
-    }))
-    for (const { key, fees } of results) {
-      feeCache.set(key, fees)
     }
-    console.log(`fetched fees ${Math.min(i + CONCURRENCY, entries.length)}/${entries.length}`)
   }
 
-  return feeCache
+  return vaultAccountants
 }
 
-const WRITE_CONCURRENCY = 5
+/** Build default fee timelines from UpdateDefaultFeeConfig events in evmlog */
+async function buildDefaultFeeTimelines(
+  vaultAccountants: Map<string, `0x${string}`>
+): Promise<Map<string, FeeSegment[]>> {
+  const accountantsByChain = new Map<number, Set<string>>()
+  for (const [key, accountant] of vaultAccountants) {
+    const chainId = Number(key.split(':')[0])
+    if (!accountantsByChain.has(chainId)) accountantsByChain.set(chainId, new Set())
+    accountantsByChain.get(chainId)!.add(accountant)
+  }
+
+  const timelines = new Map<string, FeeSegment[]>()
+
+  for (const [chainId, accountants] of accountantsByChain) {
+    const result = await db.query(`
+      SELECT chain_id, address, block_number, args
+      FROM evmlog
+      WHERE chain_id = $1 AND address = ANY($2) AND signature = $3
+      ORDER BY block_number ASC, log_index ASC
+    `, [chainId, [...accountants], DEFAULT_FEE_SELECTOR])
+
+    for (const row of result.rows) {
+      const key = `${row.chain_id}:${row.address}`
+      if (!timelines.has(key)) timelines.set(key, [])
+      const cfg = row.args.defaultFeeConfig ?? row.args
+      timelines.get(key)!.push({
+        blockNumber: BigInt(row.block_number),
+        management: Number(cfg.managementFee ?? cfg[0] ?? 0) / 10_000,
+        performance: Number(cfg.performanceFee ?? cfg[1] ?? 0) / 10_000,
+      })
+    }
+  }
+
+  return timelines
+}
+
+type CustomFeeEvent = {
+  blockNumber: bigint
+  type: 'set' | 'removed'
+  management: number
+  performance: number
+}
+
+/** Build custom fee timelines from UpdateCustomFeeConfig and RemovedCustomFeeConfig events */
+async function buildCustomFeeTimelines(
+  vaultAccountants: Map<string, `0x${string}`>
+): Promise<Map<string, CustomFeeEvent[]>> {
+  const accountantsByChain = new Map<number, Set<string>>()
+  for (const [key, accountant] of vaultAccountants) {
+    const chainId = Number(key.split(':')[0])
+    if (!accountantsByChain.has(chainId)) accountantsByChain.set(chainId, new Set())
+    accountantsByChain.get(chainId)!.add(accountant)
+  }
+
+  const timelines = new Map<string, CustomFeeEvent[]>()
+
+  for (const [chainId, accountants] of accountantsByChain) {
+    // Query both custom config set and removed events
+    const result = await db.query(`
+      SELECT chain_id, address, block_number, log_index, signature, args
+      FROM evmlog
+      WHERE chain_id = $1 AND address = ANY($2) AND signature = ANY($3)
+      ORDER BY block_number ASC, log_index ASC
+    `, [chainId, [...accountants], [CUSTOM_FEE_SELECTOR, REMOVED_CUSTOM_FEE_SELECTOR]])
+
+    for (const row of result.rows) {
+      const vault = row.args.vault as string
+      const strategy = row.args.strategy as string
+      const key = `${row.chain_id}:${vault}:${strategy}`
+      if (!timelines.has(key)) timelines.set(key, [])
+
+      if (row.signature === CUSTOM_FEE_SELECTOR) {
+        const cfg = row.args.custom_config ?? row.args
+        timelines.get(key)!.push({
+          blockNumber: BigInt(row.block_number),
+          type: 'set',
+          management: Number(cfg.managementFee ?? cfg[0] ?? 0) / 10_000,
+          performance: Number(cfg.performanceFee ?? cfg[1] ?? 0) / 10_000,
+        })
+      } else {
+        timelines.get(key)!.push({
+          blockNumber: BigInt(row.block_number),
+          type: 'removed',
+          management: 0,
+          performance: 0,
+        })
+      }
+    }
+  }
+
+  return timelines
+}
+
+/** Find the fee config active at a given block from a sorted timeline */
+function lookupDefaultAtBlock(timeline: FeeSegment[] | undefined, blockNumber: bigint): FeeConfig {
+  if (!timeline || timeline.length === 0) return { management: 0, performance: 0 }
+  let result: FeeConfig = { management: 0, performance: 0 }
+  for (const segment of timeline) {
+    if (segment.blockNumber <= blockNumber) {
+      result = { management: segment.management, performance: segment.performance }
+    } else {
+      break
+    }
+  }
+  return result
+}
+
+/** Find the custom fee config active at a given block, or null if reverted to default */
+function lookupCustomAtBlock(timeline: CustomFeeEvent[] | undefined, blockNumber: bigint): FeeConfig | null {
+  if (!timeline || timeline.length === 0) return null
+  let result: FeeConfig | null = null
+  for (const event of timeline) {
+    if (event.blockNumber <= blockNumber) {
+      result = event.type === 'set' ? { management: event.management, performance: event.performance } : null
+    } else {
+      break
+    }
+  }
+  return result
+}
+
+/** Resolve fees for a vault at a given block using evmlog-based fee timelines */
+function resolveFees(
+  chainId: number,
+  vault: `0x${string}`,
+  accountant: `0x${string}`,
+  strategies: `0x${string}`[],
+  blockNumber: bigint,
+  defaultTimelines: Map<string, FeeSegment[]>,
+  customTimelines: Map<string, CustomFeeEvent[]>,
+): FeeConfig {
+  const accountantKey = `${chainId}:${accountant}`
+  const defaultFees = lookupDefaultAtBlock(defaultTimelines.get(accountantKey), blockNumber)
+
+  if (strategies.length === 0) return defaultFees
+
+  // Check if any strategy has a custom config at this block
+  let totalManagement = 0
+  let totalPerformance = 0
+  for (const strategy of strategies) {
+    const customKey = `${chainId}:${vault}:${strategy}`
+    const custom = lookupCustomAtBlock(customTimelines.get(customKey), blockNumber)
+    if (custom) {
+      totalManagement += custom.management
+      totalPerformance += custom.performance
+    } else {
+      totalManagement += defaultFees.management
+      totalPerformance += defaultFees.performance
+    }
+  }
+
+  // Equal-weighted average across strategies (approximation without on-chain debt data)
+  return {
+    management: totalManagement / strategies.length,
+    performance: totalPerformance / strategies.length,
+  }
+}
+
+async function buildFeeCache(candidates: TimeseriesCandidate[]): Promise<{
+  vaultAccountants: Map<string, `0x${string}`>
+  defaultTimelines: Map<string, FeeSegment[]>
+  customTimelines: Map<string, CustomFeeEvent[]>
+}> {
+  const vaultAccountants = await getVaultAccountants(candidates)
+  console.log(`found accountants for ${vaultAccountants.size} vaults`)
+
+  const [defaultTimelines, customTimelines] = await Promise.all([
+    buildDefaultFeeTimelines(vaultAccountants),
+    buildCustomFeeTimelines(vaultAccountants),
+  ])
+
+  const totalDefaultEvents = [...defaultTimelines.values()].reduce((sum, t) => sum + t.length, 0)
+  const totalCustomEvents = [...customTimelines.values()].reduce((sum, t) => sum + t.length, 0)
+  console.log(`loaded ${totalDefaultEvents} default fee events, ${totalCustomEvents} custom fee events from evmlog`)
+
+  return { vaultAccountants, defaultTimelines, customTimelines }
+}
 
 async function backfillTimeseries(args: Args) {
   const candidates = await getTimeseriesCandidates(args)
   console.log(`timeseries candidates: ${candidates.length}`)
   if (candidates.length === 0) return
 
-  const feeCache = await prefetchFees(candidates)
+  const { vaultAccountants, defaultTimelines, customTimelines } = await buildFeeCache(candidates)
+
+  // Cache strategies per vault to avoid repeated DB queries
+  const strategyCache = new Map<string, `0x${string}`[]>()
+
+  // Group candidates by vault for strategy caching
+  const vaultCandidates = new Map<string, TimeseriesCandidate[]>()
+  for (const c of candidates) {
+    const key = `${c.chainId}:${c.address}`
+    if (!vaultCandidates.has(key)) vaultCandidates.set(key, [])
+    vaultCandidates.get(key)!.push(c)
+  }
+
+  // Pre-fetch strategies for each vault at each unique block
+  // (projectStrategies is a DB query, not RPC)
+  const STRATEGY_CONCURRENCY = 10
+  const vaultEntries = [...vaultCandidates.entries()]
+  for (let i = 0; i < vaultEntries.length; i += STRATEGY_CONCURRENCY) {
+    const batch = vaultEntries.slice(i, i + STRATEGY_CONCURRENCY)
+    await Promise.all(batch.map(async ([key, vCandidates]) => {
+      const { chainId, address } = vCandidates[0]
+      // Use the latest blockNumber for strategy projection
+      const maxBlock = vCandidates.reduce((max, c) => c.blockNumber > max ? c.blockNumber : max, 0n)
+      const strategies = await projectStrategies(chainId, address, maxBlock)
+      strategyCache.set(key, strategies)
+    }))
+    if ((i + STRATEGY_CONCURRENCY) % 200 === 0 || i + STRATEGY_CONCURRENCY >= vaultEntries.length) {
+      console.log(`fetched strategies ${Math.min(i + STRATEGY_CONCURRENCY, vaultEntries.length)}/${vaultEntries.length}`)
+    }
+  }
+
   const outputs: Output[] = []
+  let noAccountant = 0
 
   for (const candidate of candidates) {
-    const fees = feeCache.get(`${candidate.chainId}:${candidate.address}`) ?? { management: 0, performance: 0 }
+    const vaultKey = `${candidate.chainId}:${candidate.address}`
+    const accountant = vaultAccountants.get(vaultKey)
+
+    let fees: FeeConfig
+    if (!accountant) {
+      fees = { management: 0, performance: 0 }
+      noAccountant++
+    } else {
+      const strategies = strategyCache.get(vaultKey) ?? []
+      fees = resolveFees(
+        candidate.chainId, candidate.address, accountant, strategies,
+        candidate.blockNumber, defaultTimelines, customTimelines,
+      )
+    }
+
     const netApr = computeNetApr(candidate.apr, fees)
     const netApy = computeApy(netApr)
 
@@ -181,6 +409,10 @@ async function backfillTimeseries(args: Args) {
         blockTime: candidate.blockTime,
       })
     }
+  }
+
+  if (noAccountant > 0) {
+    console.warn(`${noAccountant} candidates had no accountant, used zero fees`)
   }
 
   console.log(`computed ${outputs.length} outputs, writing...`)
@@ -210,13 +442,10 @@ async function main() {
   if (args.chainId !== undefined) console.log(`chainId=${args.chainId}`)
   if (args.address) console.log(`address=${args.address}`)
 
-  await rpcs.up()
-
   try {
     await backfillTimeseries(args)
   } finally {
     await mq.down()
-    await rpcs.down()
     await db.end()
   }
 }

--- a/packages/scripts/src/backfill-apr-oracle-netapr.ts
+++ b/packages/scripts/src/backfill-apr-oracle-netapr.ts
@@ -109,34 +109,57 @@ async function getTimeseriesCandidates(args: Args): Promise<TimeseriesCandidate[
   }))
 }
 
+async function prefetchFees(candidates: TimeseriesCandidate[]): Promise<Map<string, { management: number; performance: number }>> {
+  const vaultMap = new Map<string, { chainId: number; address: `0x${string}`; blockNumber: bigint }>()
+  for (const c of candidates) {
+    const key = `${c.chainId}:${c.address}`
+    const existing = vaultMap.get(key)
+    if (!existing || c.blockNumber > existing.blockNumber) {
+      vaultMap.set(key, { chainId: c.chainId, address: c.address, blockNumber: c.blockNumber })
+    }
+  }
+
+  console.log(`fetching fees for ${vaultMap.size} unique vaults...`)
+  const feeCache = new Map<string, { management: number; performance: number }>()
+
+  const CONCURRENCY = 10
+  const entries = [...vaultMap.entries()]
+  for (let i = 0; i < entries.length; i += CONCURRENCY) {
+    const batch = entries.slice(i, i + CONCURRENCY)
+    const results = await Promise.all(batch.map(async ([key, vault]) => {
+      try {
+        const strategies = await projectStrategies(vault.chainId, vault.address, vault.blockNumber)
+        return { key, fees: await extractFees__v3(vault.chainId, vault.address, strategies, vault.blockNumber) }
+      } catch {
+        return { key, fees: { management: 0, performance: 0 } }
+      }
+    }))
+    for (const { key, fees } of results) {
+      feeCache.set(key, fees)
+    }
+    console.log(`fetched fees ${Math.min(i + CONCURRENCY, entries.length)}/${entries.length}`)
+  }
+
+  return feeCache
+}
+
+const WRITE_CONCURRENCY = 5
+
 async function backfillTimeseries(args: Args) {
   const candidates = await getTimeseriesCandidates(args)
   console.log(`timeseries candidates: ${candidates.length}`)
   if (candidates.length === 0) return
 
-  const feeCache = new Map<string, { management: number; performance: number }>()
-  const pending: Output[] = []
-  let inserted = 0
+  const feeCache = await prefetchFees(candidates)
+  const outputs: Output[] = []
 
-  for (const [index, candidate] of candidates.entries()) {
-    const cacheKey = `${candidate.chainId}:${candidate.address}:${candidate.blockNumber}`
-    let fees = feeCache.get(cacheKey)
-
-    if (!fees) {
-      try {
-        const strategies = await projectStrategies(candidate.chainId, candidate.address, candidate.blockNumber)
-        fees = await extractFees__v3(candidate.chainId, candidate.address, strategies, candidate.blockNumber)
-      } catch {
-        fees = { management: 0, performance: 0 }
-      }
-      feeCache.set(cacheKey, fees)
-    }
-
+  for (const candidate of candidates) {
+    const fees = feeCache.get(`${candidate.chainId}:${candidate.address}`) ?? { management: 0, performance: 0 }
     const netApr = computeNetApr(candidate.apr, fees)
     const netApy = computeApy(netApr)
 
     if (!candidate.hasNetApr) {
-      pending.push({
+      outputs.push({
         chainId: candidate.chainId,
         address: candidate.address,
         label: 'apr-oracle',
@@ -148,7 +171,7 @@ async function backfillTimeseries(args: Args) {
     }
 
     if (!candidate.hasNetApy) {
-      pending.push({
+      outputs.push({
         chainId: candidate.chainId,
         address: candidate.address,
         label: 'apr-oracle',
@@ -158,25 +181,26 @@ async function backfillTimeseries(args: Args) {
         blockTime: candidate.blockTime,
       })
     }
-
-    if (pending.length >= WRITE_BATCH_SIZE) {
-      const batch = pending.splice(0)
-      if (args.apply && batch.length > 0) await upsertBatchOutput(batch)
-      inserted += batch.length
-    }
-
-    if ((index + 1) % 500 === 0 || index === candidates.length - 1) {
-      console.log(`processed ${index + 1}/${candidates.length} timeseries rows`)
-    }
   }
 
-  if (pending.length > 0) {
-    const batch = pending.splice(0)
-    if (args.apply && batch.length > 0) await upsertBatchOutput(batch)
-    inserted += batch.length
+  console.log(`computed ${outputs.length} outputs, writing...`)
+
+  const batches: Output[][] = []
+  for (let i = 0; i < outputs.length; i += WRITE_BATCH_SIZE) {
+    batches.push(outputs.slice(i, i + WRITE_BATCH_SIZE))
   }
 
-  console.log(`${args.apply ? 'upserted' : 'prepared (dry-run)'}: ${inserted} timeseries outputs`)
+  let written = 0
+  for (let i = 0; i < batches.length; i += WRITE_CONCURRENCY) {
+    const chunk = batches.slice(i, i + WRITE_CONCURRENCY)
+    if (args.apply) {
+      await Promise.all(chunk.map(batch => upsertBatchOutput(batch)))
+    }
+    written += chunk.reduce((sum, b) => sum + b.length, 0)
+    console.log(`written ${written}/${outputs.length} outputs`)
+  }
+
+  console.log(`${args.apply ? 'upserted' : 'prepared (dry-run)'}: ${outputs.length} timeseries outputs`)
 }
 
 async function main() {

--- a/packages/scripts/src/backfill-apr-oracle-netapr.ts.ts
+++ b/packages/scripts/src/backfill-apr-oracle-netapr.ts.ts
@@ -1,0 +1,268 @@
+import 'lib/global'
+
+import { extractFeesBps } from 'ingest/abis/yearn/3/vault/snapshot/hook'
+import db from 'ingest/db'
+import { upsertBatchOutput } from 'ingest/load'
+import { rpcs } from 'ingest/rpcs'
+import { mq } from 'lib'
+import type { Output } from 'lib/types'
+import { getAddress } from 'viem'
+
+type Args = {
+  apply: boolean
+  chainId?: number
+  address?: `0x${string}`
+}
+
+type TimeseriesCandidate = {
+  chainId: number
+  address: `0x${string}`
+  blockNumber: bigint
+  blockTime: bigint
+  apr: number
+  hasNetApr: boolean
+  hasNetApy: boolean
+}
+
+type VaultSnapshotRow = {
+  chainId: number
+  address: `0x${string}`
+  snapshot: Record<string, unknown>
+}
+
+type FeeRates = {
+  management: number
+  performance: number
+}
+
+const WRITE_BATCH_SIZE = 200
+
+function parseArgs(argv: string[]): Args {
+  const getArg = (flag: string) => {
+    const index = argv.indexOf(flag)
+    return index >= 0 ? argv[index + 1] : undefined
+  }
+
+  const hasArg = (flag: string) => argv.includes(flag)
+
+  if (hasArg('--help') || hasArg('-h')) {
+    console.log(`usage:
+  bun packages/scripts/src/backfill-apr-oracle-netapr.ts [--apply] [--chain-id 1] [--address 0x...]
+
+defaults:
+  dry-run unless --apply is provided`)
+    process.exit(0)
+  }
+
+  const chainId = getArg('--chain-id')
+  const address = getArg('--address')
+
+  return {
+    apply: hasArg('--apply'),
+    chainId: chainId ? Number(chainId) : undefined,
+    address: address ? getAddress(address as `0x${string}`) : undefined,
+  }
+}
+
+function computeFeeAdjustedApr(apr: number, fees: FeeRates): number {
+  const next = apr * (1 - fees.performance) - fees.management
+  return Number.isFinite(next) ? next : 0
+}
+
+function computeApy(apr: number): number {
+  const next = (1 + apr / 52) ** 52 - 1
+  return Number.isFinite(next) ? next : 0
+}
+
+async function getTimeseriesCandidates(args: Args): Promise<TimeseriesCandidate[]> {
+  const values: Array<number | string> = []
+  const filters: string[] = []
+
+  if (args.chainId !== undefined) {
+    values.push(args.chainId)
+    filters.push(`o.chain_id = $${values.length}`)
+  }
+
+  if (args.address) {
+    values.push(args.address)
+    filters.push(`o.address = $${values.length}`)
+  }
+
+  const whereClause = filters.length > 0 ? `AND ${filters.join(' AND ')}` : ''
+
+  const result = await db.query(`
+    WITH grouped AS (
+      SELECT
+        o.chain_id AS "chainId",
+        o.address,
+        MAX(o.block_number) AS "blockNumber",
+        EXTRACT(EPOCH FROM MAX(o.block_time))::bigint AS "blockTime",
+        MAX(CASE WHEN o.component = 'apr' THEN o.value END) AS apr,
+        BOOL_OR(o.component = 'netApr') AS "hasNetApr",
+        BOOL_OR(o.component = 'netApy') AS "hasNetApy"
+      FROM output o
+      JOIN thing t
+        ON t.chain_id = o.chain_id
+        AND t.address = o.address
+        AND t.label = 'vault'
+        AND COALESCE((t.defaults->>'v3')::boolean, false)
+      WHERE o.label = 'apr-oracle'
+        AND o.component IN ('apr', 'netApr', 'netApy')
+        ${whereClause}
+      GROUP BY o.chain_id, o.address, o.series_time
+    )
+    SELECT *
+    FROM grouped
+    WHERE apr IS NOT NULL
+      AND (NOT "hasNetApr" OR NOT "hasNetApy")
+    ORDER BY "chainId", address, "blockNumber"
+  `, values)
+
+  return result.rows.map(row => ({
+    chainId: row.chainId,
+    address: row.address,
+    blockNumber: BigInt(row.blockNumber),
+    blockTime: BigInt(row.blockTime),
+    apr: Number(row.apr),
+    hasNetApr: Boolean(row.hasNetApr),
+    hasNetApy: Boolean(row.hasNetApy),
+  }))
+}
+
+async function getV3VaultSnapshots(args: Args): Promise<Map<string, Record<string, unknown>>> {
+  const values: Array<number | string> = []
+  const filters: string[] = []
+
+  if (args.chainId !== undefined) {
+    values.push(args.chainId)
+    filters.push(`s.chain_id = $${values.length}`)
+  }
+
+  if (args.address) {
+    values.push(args.address)
+    filters.push(`s.address = $${values.length}`)
+  }
+
+  const whereClause = filters.length > 0 ? `AND ${filters.join(' AND ')}` : ''
+
+  const result = await db.query(`
+    SELECT
+      s.chain_id AS "chainId",
+      s.address,
+      s.snapshot
+    FROM snapshot s
+    JOIN thing t
+      ON t.chain_id = s.chain_id
+      AND t.address = s.address
+      AND t.label = 'vault'
+      AND COALESCE((t.defaults->>'v3')::boolean, false)
+    WHERE TRUE
+      ${whereClause}
+  `, values)
+
+  const map = new Map<string, Record<string, unknown>>()
+  for (const row of result.rows as VaultSnapshotRow[]) {
+    map.set(`${row.chainId}:${row.address}`, row.snapshot ?? {})
+  }
+
+  return map
+}
+
+async function backfillTimeseries(args: Args) {
+  const candidates = await getTimeseriesCandidates(args)
+  console.log(`🕒 timeseries candidates: ${candidates.length}`)
+  if (candidates.length === 0) return
+
+  const snapshots = await getV3VaultSnapshots(args)
+  const feesByVault = new Map<string, FeeRates>()
+  const pending: Output[] = []
+  let inserted = 0
+
+  for (const [index, candidate] of candidates.entries()) {
+    const vaultKey = `${candidate.chainId}:${candidate.address}`
+    let fees = feesByVault.get(vaultKey)
+
+    if (!fees) {
+      const snapshot = snapshots.get(vaultKey)
+      if (!snapshot) {
+        console.warn(`🚨 missing snapshot for ${vaultKey}, defaulting fees to zero`)
+        fees = { management: 0, performance: 0 }
+      } else {
+        const feeBps = await extractFeesBps(candidate.chainId, candidate.address, snapshot)
+        fees = {
+          management: feeBps.managementFee / 10_000,
+          performance: feeBps.performanceFee / 10_000,
+        }
+      }
+      feesByVault.set(vaultKey, fees)
+    }
+
+    const netApr = computeFeeAdjustedApr(candidate.apr, fees)
+    const netApy = computeApy(netApr)
+
+    if (!candidate.hasNetApr) {
+      pending.push({
+        chainId: candidate.chainId,
+        address: candidate.address,
+        label: 'apr-oracle',
+        component: 'netApr',
+        value: netApr,
+        blockNumber: candidate.blockNumber,
+        blockTime: candidate.blockTime,
+      })
+    }
+
+    if (!candidate.hasNetApy) {
+      pending.push({
+        chainId: candidate.chainId,
+        address: candidate.address,
+        label: 'apr-oracle',
+        component: 'netApy',
+        value: netApy,
+        blockNumber: candidate.blockNumber,
+        blockTime: candidate.blockTime,
+      })
+    }
+
+    if (pending.length >= WRITE_BATCH_SIZE) {
+      const batch = pending.splice(0)
+      if (args.apply && batch.length > 0) await upsertBatchOutput(batch)
+      inserted += batch.length
+    }
+
+    if ((index + 1) % 500 === 0 || index === candidates.length - 1) {
+      console.log(`🕒 processed ${index + 1}/${candidates.length} timeseries rows`)
+    }
+  }
+
+  if (pending.length > 0) {
+    const batch = pending.splice(0)
+    if (args.apply && batch.length > 0) await upsertBatchOutput(batch)
+    inserted += batch.length
+  }
+
+  console.log(`${args.apply ? '✅' : '🧪'} timeseries outputs ${args.apply ? 'upserted' : 'prepared'}: ${inserted}`)
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2))
+
+  console.log(args.apply ? '⚠️ apply mode' : '🧪 dry-run mode')
+  if (args.chainId !== undefined) console.log(`chainId=${args.chainId}`)
+  if (args.address) console.log(`address=${args.address}`)
+
+  await rpcs.up()
+
+  try {
+    await backfillTimeseries(args)
+  } finally {
+    await mq.down()
+    await rpcs.down()
+    await db.end()
+  }
+}
+
+main().catch(error => {
+  console.error('🤬 backfill-apr-oracle-netapr', error)
+  process.exit(1)
+})

--- a/packages/scripts/src/copy-output-fork-to-main.ts
+++ b/packages/scripts/src/copy-output-fork-to-main.ts
@@ -1,0 +1,139 @@
+import 'lib/global'
+
+import { Pool } from 'pg'
+
+const COMPONENTS = ['netApr', 'netApy']
+const READ_BATCH_SIZE = 10_000
+const WRITE_BATCH_SIZE = 1_000
+const WRITE_CONCURRENCY = 10
+
+function createPool(prefix: string): Pool {
+  return new Pool({
+    host: process.env[`${prefix}POSTGRES_HOST`] ?? 'localhost',
+    port: (process.env[`${prefix}POSTGRES_PORT`] ?? 5432) as number,
+    ssl: (process.env[`${prefix}POSTGRES_SSL`] ?? false)
+      ? (process.env[`${prefix}POSTGRES_SSL_REJECT_UNAUTHORIZED`] ?? true)
+        ? true
+        : { rejectUnauthorized: false }
+      : false,
+    database: process.env[`${prefix}POSTGRES_DATABASE`] ?? 'user',
+    user: process.env[`${prefix}POSTGRES_USER`] ?? 'user',
+    password: process.env[`${prefix}POSTGRES_PASSWORD`] ?? 'password',
+    max: 10,
+    idleTimeoutMillis: 10_000,
+    connectionTimeoutMillis: 60_000,
+  })
+}
+
+async function copyOutputs() {
+  const forkDb = createPool('FORK_')
+  const mainDb = createPool('')
+
+  try {
+    const countResult = await forkDb.query(`
+      SELECT COUNT(*) AS total
+      FROM output
+      WHERE component = ANY($1)
+    `, [COMPONENTS])
+    const total = Number(countResult.rows[0].total)
+    console.log(`source rows: ${total}`)
+    if (total === 0) return
+
+    let copied = 0
+    let lastBlockTime: string | null = null
+
+    while (true) {
+      const params: (string | string[] | number)[] = [COMPONENTS, READ_BATCH_SIZE]
+      let query: string
+
+      if (lastBlockTime === null) {
+        query = `
+          SELECT chain_id, address, label, component, value, block_number, block_time, series_time
+          FROM output
+          WHERE component = ANY($1)
+          ORDER BY block_time ASC, chain_id ASC, address ASC, component ASC
+          LIMIT $2
+        `
+      } else {
+        params.push(lastBlockTime)
+        query = `
+          SELECT chain_id, address, label, component, value, block_number, block_time, series_time
+          FROM output
+          WHERE component = ANY($1)
+            AND (block_time, chain_id, address, component) > ($3::timestamptz, 0, '', '')
+          ORDER BY block_time ASC, chain_id ASC, address ASC, component ASC
+          LIMIT $2
+        `
+      }
+
+      const result = await forkDb.query(query, params)
+      if (result.rows.length === 0) break
+
+      const rows = result.rows
+      const last = rows[rows.length - 1]
+      lastBlockTime = last.block_time instanceof Date
+        ? last.block_time.toISOString()
+        : String(last.block_time)
+
+      const batches: typeof rows[] = []
+      for (let i = 0; i < rows.length; i += WRITE_BATCH_SIZE) {
+        batches.push(rows.slice(i, i + WRITE_BATCH_SIZE))
+      }
+
+      for (let i = 0; i < batches.length; i += WRITE_CONCURRENCY) {
+        const chunk = batches.slice(i, i + WRITE_CONCURRENCY)
+        await Promise.all(chunk.map(batch => upsertBatch(mainDb, batch)))
+      }
+
+      copied += rows.length
+      console.log(`copied ${copied}/${total}`)
+    }
+
+    console.log(`done: copied ${copied} rows`)
+  } finally {
+    await forkDb.end()
+    await mainDb.end()
+  }
+}
+
+async function upsertBatch(pool: Pool, rows: Record<string, unknown>[]) {
+  if (rows.length === 0) return
+
+  const values: unknown[] = []
+  const rowClauses: string[] = []
+  const COLS = 7
+
+  for (const row of rows) {
+    const offset = values.length
+    values.push(
+      row.chain_id,
+      row.address,
+      row.label,
+      row.component,
+      row.value,
+      row.block_number,
+      row.series_time,
+    )
+    const placeholders = Array.from({ length: COLS }, (_, i) => `$${offset + i + 1}`)
+    rowClauses.push(`(${placeholders.join(', ')})`)
+  }
+
+  await pool.query(`
+    INSERT INTO output (chain_id, address, label, component, value, block_number, series_time)
+    VALUES ${rowClauses.join(',\n')}
+    ON CONFLICT (chain_id, address, label, component, series_time)
+    DO UPDATE SET
+      value = EXCLUDED.value,
+      block_number = EXCLUDED.block_number
+  `, values)
+}
+
+async function main() {
+  console.log(`copying [${COMPONENTS.join(', ')}] from fork to main`)
+  await copyOutputs()
+}
+
+main().catch(error => {
+  console.error('copy-output-fork-to-main', error)
+  process.exit(1)
+})

--- a/packages/scripts/src/copy-output-fork-to-main.ts
+++ b/packages/scripts/src/copy-output-fork-to-main.ts
@@ -40,13 +40,13 @@ async function copyOutputs() {
     if (total === 0) return
 
     let copied = 0
-    let lastBlockTime: string | null = null
+    let cursor: { blockTime: string; chainId: number; address: string; component: string } | null = null
 
     while (true) {
       const params: (string | string[] | number)[] = [COMPONENTS, READ_BATCH_SIZE]
       let query: string
 
-      if (lastBlockTime === null) {
+      if (cursor === null) {
         query = `
           SELECT chain_id, address, label, component, value, block_number, block_time, series_time
           FROM output
@@ -55,12 +55,12 @@ async function copyOutputs() {
           LIMIT $2
         `
       } else {
-        params.push(lastBlockTime)
+        params.push(cursor.blockTime, cursor.chainId, cursor.address, cursor.component)
         query = `
           SELECT chain_id, address, label, component, value, block_number, block_time, series_time
           FROM output
           WHERE component = ANY($1)
-            AND (block_time, chain_id, address, component) > ($3::timestamptz, 0, '', '')
+            AND (block_time, chain_id, address, component) > ($3::timestamptz, $4, $5, $6)
           ORDER BY block_time ASC, chain_id ASC, address ASC, component ASC
           LIMIT $2
         `
@@ -71,9 +71,14 @@ async function copyOutputs() {
 
       const rows = result.rows
       const last = rows[rows.length - 1]
-      lastBlockTime = last.block_time instanceof Date
-        ? last.block_time.toISOString()
-        : String(last.block_time)
+      cursor = {
+        blockTime: last.block_time instanceof Date
+          ? last.block_time.toISOString()
+          : String(last.block_time),
+        chainId: last.chain_id,
+        address: last.address,
+        component: last.component,
+      }
 
       const batches: typeof rows[] = []
       for (let i = 0; i < rows.length; i += WRITE_BATCH_SIZE) {
@@ -101,7 +106,7 @@ async function upsertBatch(pool: Pool, rows: Record<string, unknown>[]) {
 
   const values: unknown[] = []
   const rowClauses: string[] = []
-  const COLS = 7
+  const COLS = 8
 
   for (const row of rows) {
     const offset = values.length
@@ -112,6 +117,7 @@ async function upsertBatch(pool: Pool, rows: Record<string, unknown>[]) {
       row.component,
       row.value,
       row.block_number,
+      row.block_time,
       row.series_time,
     )
     const placeholders = Array.from({ length: COLS }, (_, i) => `$${offset + i + 1}`)
@@ -119,12 +125,13 @@ async function upsertBatch(pool: Pool, rows: Record<string, unknown>[]) {
   }
 
   await pool.query(`
-    INSERT INTO output (chain_id, address, label, component, value, block_number, series_time)
+    INSERT INTO output (chain_id, address, label, component, value, block_number, block_time, series_time)
     VALUES ${rowClauses.join(',\n')}
     ON CONFLICT (chain_id, address, label, component, series_time)
     DO UPDATE SET
       value = EXCLUDED.value,
-      block_number = EXCLUDED.block_number
+      block_number = EXCLUDED.block_number,
+      block_time = EXCLUDED.block_time
   `, values)
 }
 


### PR DESCRIPTION
## Summary

- Add `netApr` and `netApy` components to the apr-oracle timeseries, computed by applying vault fee deductions to the gross oracle APR
- Extract `computeNetApr` and `computeApy` into shared utilities in `lib/apy.ts` so all consumers (timeseries hook, snapshot hook, backfill script) use the same formulas
- Add backfill script (`backfill-apr-oracle-netapr.ts`) to retroactively populate `netApr`/`netApy` for existing timeseries rows
- Add copy script (`copy-output-fork-to-main.ts`) to transfer backfilled data from the fork DB to the main DB

### Net APR formula
```
netApr = (grossApr - managementFee) * (1 - performanceFee)
```

### Net APY formula (weekly compounding)
```
netApy = (1 + netApr / 52)^52 - 1
```

## Changes
- `packages/ingest/abis/yearn/lib/apy.ts` — new shared `computeNetApr` and `computeApy` exports
- `packages/ingest/abis/yearn/3/vault/timeseries/apr-oracle/hook.ts` — emits `netApr` and `netApy` outputs using shared functions
- `packages/ingest/abis/yearn/3/vault/snapshot/hook.ts` — uses shared functions instead of inline formulas
- `packages/scripts/src/backfill-apr-oracle-netapr.ts` — backfill script for historical data (already ran against fork DB)
- `packages/scripts/src/copy-output-fork-to-main.ts` — copies backfilled `netApr`/`netApy` rows from fork DB to main DB
- Tests added/moved to `lib/apy.spec.ts`

## Test plan

### Unit tests

- [ ] Run ingest tests to verify `computeNetApr` and `computeApy`
```
bun --filter ingest test
```
Expected: all tests pass, including `computeNetApr` and `computeApy` specs in `lib/apy.spec.ts`

### Integration test (timeseries hook + snapshot hook)

- [ ] Start the dev environment
```
make dev
```

- [ ] Create `config/abis.local.yaml` with a test vault
```yaml
cron:
  name: AbiFanout
  queue: fanout
  job: abis
  schedule: '*/15 * * * *'
  start: false

abis:
  - abiPath: 'yearn/3/vault'
    sources: [
      { chainId: 1, address: '0xBe53A109B494E5c9f97b9Cd39Fe969BE68BF6204', inceptBlock: 19419991 }
    ]

  - abiPath: 'yearn/3/strategy'
    things: {
      label: 'strategy',
      filter: [{ field: 'apiVersion', op: '>=', value: '3.0.0' }]
    }
```

- [ ] Create `config/manuals.local.yaml` so the vault is registered as a thing
```yaml
manuals:
  - chainId: 1
    address: '0xBe53A109B494E5c9f97b9Cd39Fe969BE68BF6204'
    label: 'vault'
    defaults: {
      erc4626: true,
      v3: true,
      yearn: true,
      origin: 'yearn',
      apiVersion: '3.0.2',
      registry: '0xff31A1B020c868F6eA3f61Eb953344920EeCA3af',
      asset: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
      decimals: 6,
      inceptBlock: 19419991,
      inceptTime: 1710258455
    }
```

- [ ] From the terminal UI, run `fanout abis` (run 2-3 times for full initialization)

- [ ] Verify `netApr` and `netApy` timeseries outputs were created
```
psql $POSTGRES_DATABASE -c "
  SELECT component, value, block_number
  FROM output
  WHERE label = 'apr-oracle'
    AND component IN ('netApr', 'netApy')
    AND chain_id = 1
    AND address = '0xBe53A109B494E5c9f97b9Cd39Fe969BE68BF6204'
  ORDER BY block_number DESC
  LIMIT 10;
"
```
Expected: rows with `netApr` and `netApy` components, values between 0 and 1

- [ ] Verify snapshot includes `netAPR` and `netAPY` in the oracle performance block
```
psql $POSTGRES_DATABASE -c "
  SELECT hook->'performance'->'oracle' AS oracle
  FROM snapshot
  WHERE chain_id = 1
    AND address = '0xBe53A109B494E5c9f97b9Cd39Fe969BE68BF6204'
  LIMIT 1;
"
```
Expected: JSON with `apr`, `netAPR`, `apy`, `netAPY` fields, all numeric

## Deployment procedure

The backfill was already run against a Neon fork DB (~787k output rows for netApr + netApy). After merge:

### Step 1 — Deploy

Deploy the new code to production. The indexer will start emitting `netApr`/`netApy` for new timeseries data going forward.

### Step 2 — Copy historical data from fork to main

Go to Render shell and run:
```bash
bun run packages/scripts/src/copy-output-fork-to-main.ts
```
Requires `FORK_POSTGRES_*` env vars (`FORK_POSTGRES_HOST`, `FORK_POSTGRES_DATABASE`, `FORK_POSTGRES_USER`, `FORK_POSTGRES_PASSWORD`, `FORK_POSTGRES_SSL`) pointing to the Neon fork DB.

### Step 3 — Verify
```sql
SELECT component, COUNT(*), MIN(series_time), MAX(series_time)
FROM output
WHERE component IN ('netApr', 'netApy')
GROUP BY component;
```
Expected: rows for both `netApr` and `netApy` spanning the full historical range.

### FAQ

**Do we need to stop the indexer?**
No. The copy script and the indexer write to different time ranges — the script backfills historical data while the indexer writes new data going forward. Both use upserts (`ON CONFLICT ... DO UPDATE`), so even if there's overlap at the boundary there's no conflict or data corruption.

**How long does the copy take?**
The script copies ~787k rows in read batches of 10k and write batches of 1k (concurrency 10). It's a straightforward DB-to-DB copy (no RPC calls or computation), so it should complete in a few minutes depending on network latency between Render and Neon.

**What if the copy fails mid-way?**
Safe to re-run. All writes are upserts, so already-copied rows are just overwritten with the same values. The script will re-read from the beginning but the writes are idempotent.

**Can we run step 1 and step 2 in any order?**
Yes. Deploy first is preferred so the indexer starts covering new data immediately, but the copy script is independent — it reads from the fork DB and writes to main DB regardless of what the indexer is doing.