### PR TITLE
Move 0xff31A1 vault registry from registry2 to registry3 sources

### DIFF
--- a/config/abis.yaml
+++ b/config/abis.yaml
@@ -57,16 +57,11 @@ abis:
 
   - abiPath: 'yearn/3/registry2'
     sources: [
-      { chainId: 1, address: '0xff31A1B020c868F6eA3f61Eb953344920EeCA3af', inceptBlock: 19072527 },
       { chainId: 1, address: '0x0377b4daDDA86C89A0091772B79ba67d0E5F7198', inceptBlock: 20966875 },
-      { chainId: 100, address: '0xff31A1B020c868F6eA3f61Eb953344920EeCA3af', inceptBlock: 32902749 },
       { chainId: 100, address: '0x0377b4daDDA86C89A0091772B79ba67d0E5F7198', inceptBlock: 126847258 },
-      { chainId: 137, address: '0xff31A1B020c868F6eA3f61Eb953344920EeCA3af', inceptBlock: 52488140 },
       { chainId: 137, address: '0x0377b4daDDA86C89A0091772B79ba67d0E5F7198', inceptBlock: 63167078 },
       { chainId: 146, address: '0x0377b4daDDA86C89A0091772B79ba67d0E5F7198', inceptBlock: 307793 },
-      { chainId: 8453, address: '0xff31A1B020c868F6eA3f61Eb953344920EeCA3af', inceptBlock: 17559000 },
       { chainId: 8453, address: '0x0377b4daDDA86C89A0091772B79ba67d0E5F7198', inceptBlock: 21261966 },
-      { chainId: 42161, address: '0xff31A1B020c868F6eA3f61Eb953344920EeCA3af', inceptBlock: 171850013 },
       { chainId: 42161, address: '0x0377b4daDDA86C89A0091772B79ba67d0E5F7198', inceptBlock: 265347635 },
       { chainId: 80094, address: '0x0377b4daDDA86C89A0091772B79ba67d0E5F7198', inceptBlock: 827648 },
       { chainId: 747474, address: '0x0377b4daDDA86C89A0091772B79ba67d0E5F7198', inceptBlock: 2236977 }
@@ -74,10 +69,15 @@ abis:
 
   - abiPath: 'yearn/3/registry3'
     sources: [
+      { chainId: 1, address: '0xff31A1B020c868F6eA3f61Eb953344920EeCA3af', inceptBlock: 19072527 },
       { chainId: 1, address: '0xd40ecF29e001c76Dcc4cC0D9cd50520CE845B038', inceptBlock: 21176924 },
+      { chainId: 100, address: '0xff31A1B020c868F6eA3f61Eb953344920EeCA3af', inceptBlock: 32902749 },
+      { chainId: 137, address: '0xff31A1B020c868F6eA3f61Eb953344920EeCA3af', inceptBlock: 52488140 },
       { chainId: 137, address: '0xd40ecF29e001c76Dcc4cC0D9cd50520CE845B038', inceptBlock: 64224620 },
       { chainId: 146, address: '0xd40ecF29e001c76Dcc4cC0D9cd50520CE845B038', inceptBlock: 4459165},
+      { chainId: 8453, address: '0xff31A1B020c868F6eA3f61Eb953344920EeCA3af', inceptBlock: 17559000 },
       { chainId: 8453, address: '0xd40ecF29e001c76Dcc4cC0D9cd50520CE845B038', inceptBlock: 22344791 },
+      { chainId: 42161, address: '0xff31A1B020c868F6eA3f61Eb953344920EeCA3af', inceptBlock: 171850013 },
       { chainId: 42161, address: '0xd40ecF29e001c76Dcc4cC0D9cd50520CE845B038', inceptBlock: 273947409 },
       { chainId: 747474, address: '0xd40ecF29e001c76Dcc4cC0D9cd50520CE845B038', inceptBlock: 2852031 }
     ]


### PR DESCRIPTION
## Summary
- On-chain ABI for `0xff31A1B020c868F6eA3f61Eb953344920EeCA3af` matches `registry3`, not `registry2`
- It was miscategorized causing `NewEndorsedVault` events to be missed on all 5 affected chains (1, 100, 137, 8453, 42161)
- Moved all entries to `registry3` sources, `registry2` now only contains `0x0377b4...` (ReleaseRegistry) sources

## Rollout
- [ ] Disable abi fanout cron
- [ ] Reset log strides for affected registries
- [ ] Manual run abi fanout
- [ ] Enable fanout cron

## Test plan
- [ ] Run `fanout abis` with `abis.local.yaml` scoped to Base registry3 and verify `NewEndorsedVault` events appear in `evmlog`

🤖 Generated with [Claude Code](https://claude.com/claude-code)