### PR TITLE
Split timeseries and reports cache refresh into historical and latest stacks to reduce database egress

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Lint
+name: lint
 
 on:
   pull_request:

--- a/.github/workflows/reports-refresh-historical.yml
+++ b/.github/workflows/reports-refresh-historical.yml
@@ -1,4 +1,4 @@
-name: Reports Refresh Historical
+name: reports-refresh-historical
 
 on:
   schedule:

--- a/.github/workflows/reports-refresh-historical.yml
+++ b/.github/workflows/reports-refresh-historical.yml
@@ -17,7 +17,7 @@ jobs:
           bun-version: latest
 
       - name: Install dependencies
-        run: cd packages/web && bun install
+        run: bun install --frozen-lockfile
 
       - name: Run Refresh Script
         env:
@@ -29,4 +29,4 @@ jobs:
           POSTGRES_SSL: ${{ secrets.POSTGRES_SSL }}
           POSTGRES_POOL_MAX: ${{ vars.POSTGRES_POOL_MAX }}
           REST_CACHE_REDIS_URL: ${{ secrets.REST_CACHE_REDIS_URL }}
-        run: cd packages/web && bun app/api/rest/reports/refresh-historical.ts
+        run: bun packages/web/app/api/rest/reports/refresh-historical.ts

--- a/.github/workflows/reports-refresh-historical.yml
+++ b/.github/workflows/reports-refresh-historical.yml
@@ -1,8 +1,8 @@
-name: timeseries-refresh
+name: Reports Refresh Historical
 
 on:
   schedule:
-    - cron: '0 * * * *'
+    - cron: '0 0 * * *'
   workflow_dispatch:
 
 jobs:
@@ -10,10 +10,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v1
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
       - name: Install dependencies
-        run: bun install --frozen-lockfile
-      - name: Refresh timeseries cache
+        run: cd packages/web && bun install
+
+      - name: Run Refresh Script
         env:
           POSTGRES_HOST: ${{ secrets.POSTGRES_HOST }}
           POSTGRES_DATABASE: ${{ secrets.POSTGRES_DATABASE }}
@@ -23,4 +29,4 @@ jobs:
           POSTGRES_SSL: ${{ secrets.POSTGRES_SSL }}
           POSTGRES_POOL_MAX: ${{ vars.POSTGRES_POOL_MAX }}
           REST_CACHE_REDIS_URL: ${{ secrets.REST_CACHE_REDIS_URL }}
-        run: bun packages/web/app/api/rest/timeseries/refresh.ts
+        run: cd packages/web && bun app/api/rest/reports/refresh-historical.ts

--- a/.github/workflows/reports-refresh.yml
+++ b/.github/workflows/reports-refresh.yml
@@ -1,4 +1,4 @@
-name: Reports Refresh
+name: reports-refresh
 
 on:
   schedule:

--- a/.github/workflows/reports-refresh.yml
+++ b/.github/workflows/reports-refresh.yml
@@ -17,7 +17,7 @@ jobs:
           bun-version: latest
 
       - name: Install dependencies
-        run: cd packages/web && bun install
+        run: bun install --frozen-lockfile
 
       - name: Run Refresh Script
         env:
@@ -29,4 +29,4 @@ jobs:
           POSTGRES_SSL: ${{ secrets.POSTGRES_SSL }}
           POSTGRES_POOL_MAX: ${{ vars.POSTGRES_POOL_MAX }}
           REST_CACHE_REDIS_URL: ${{ secrets.REST_CACHE_REDIS_URL }}
-        run: cd packages/web && bun app/api/rest/reports/refresh.ts
+        run: bun packages/web/app/api/rest/reports/refresh.ts

--- a/.github/workflows/timeseries-refresh-historical.yml
+++ b/.github/workflows/timeseries-refresh-historical.yml
@@ -1,8 +1,8 @@
-name: timeseries-refresh
+name: timeseries-refresh-historical
 
 on:
   schedule:
-    - cron: '0 * * * *'
+    - cron: '0 0 * * *'
   workflow_dispatch:
 
 jobs:
@@ -13,7 +13,7 @@ jobs:
       - uses: oven-sh/setup-bun@v1
       - name: Install dependencies
         run: bun install --frozen-lockfile
-      - name: Refresh timeseries cache
+      - name: Refresh timeseries historical cache
         env:
           POSTGRES_HOST: ${{ secrets.POSTGRES_HOST }}
           POSTGRES_DATABASE: ${{ secrets.POSTGRES_DATABASE }}
@@ -23,4 +23,4 @@ jobs:
           POSTGRES_SSL: ${{ secrets.POSTGRES_SSL }}
           POSTGRES_POOL_MAX: ${{ vars.POSTGRES_POOL_MAX }}
           REST_CACHE_REDIS_URL: ${{ secrets.REST_CACHE_REDIS_URL }}
-        run: bun packages/web/app/api/rest/timeseries/refresh.ts
+        run: bun packages/web/app/api/rest/timeseries/refresh-historical.ts

--- a/packages/web/app/api/rest/reports/[chainId]/[address]/route.ts
+++ b/packages/web/app/api/rest/reports/[chainId]/[address]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getKeyvClient } from '../../../cache'
 import { VaultReport } from '../../db'
-import { getReportKey } from '../../redis'
+import { getReportKey, getReportLatestKey } from '../../redis'
 
 const keyv = getKeyvClient()
 
@@ -25,17 +25,31 @@ export async function GET(
     )
   }
 
-  const key = getReportKey(chainId, address)
-  const data = await keyv.get(key) as VaultReport[] | undefined
+  const historicalKey = getReportKey(chainId, address)
+  const latestKey = getReportLatestKey(chainId, address)
 
-  if (!data) {
+  const [historical, latest] = await Promise.all([
+    keyv.get(historicalKey) as Promise<VaultReport[] | undefined>,
+    keyv.get(latestKey) as Promise<VaultReport[] | undefined>,
+  ])
+
+  if (!historical && !latest) {
     return NextResponse.json(
       { error: 'Not found' },
       { status: 404 }
     )
   }
 
-  return NextResponse.json(data, {
+  // Merge: dedupe by txHash+logIndex, latest wins, keep DESC order, cap at 1000
+  const latestTxKeys = new Set(
+    (latest || []).map((r) => `${r.transactionHash}:${r.logIndex}`)
+  )
+  const merged = [
+    ...(latest || []),
+    ...(historical || []).filter((r) => !latestTxKeys.has(`${r.transactionHash}:${r.logIndex}`)),
+  ].slice(0, 1000)
+
+  return NextResponse.json(merged, {
     headers: {
       'Cache-Control': 'public, max-age=900, s-maxage=900, stale-while-revalidate=600',
       ...corsHeaders,

--- a/packages/web/app/api/rest/reports/db.ts
+++ b/packages/web/app/api/rest/reports/db.ts
@@ -133,3 +133,59 @@ export const getStrategyReports = async (chainId?: number, address?: string) => 
     throw new Error('!getStrategyReports')
   }
 }
+
+export const getRecentStrategyReports = async (chainId?: number, address?: string) => {
+  try {
+    const result = await db.query(`
+   SELECT
+      chain_id AS "chainId",
+      address,
+      event_name AS "eventName",
+
+      args->>'strategy' AS strategy,
+      args->>'gain' AS gain,
+      args->>'loss' AS loss,
+      args->>'debtPaid' AS "debtPaid",
+      args->>'totalGain' AS "totalGain",
+      args->>'totalLoss' AS "totalLoss",
+      args->>'totalDebt' AS "totalDebt",
+      args->>'debtAdded' AS "debtAdded",
+      args->>'debtRatio' AS "debtRatio",
+      args->>'current_debt' AS "currentDebt",
+      args->>'protocol_fees' AS "protocolFees",
+      args->>'total_fees' AS "totalFees",
+      args->>'total_refunds' AS "totalRefunds",
+
+      hook->>'gainUsd' AS "gainUsd",
+      hook->>'lossUsd' AS "lossUsd",
+      hook->>'debtPaidUsd' AS "debtPaidUsd",
+      hook->>'totalGainUsd' AS "totalGainUsd",
+      hook->>'totalLossUsd' AS "totalLossUsd",
+      hook->>'totalDebtUsd' AS "totalDebtUsd",
+      hook->>'debtAddedUsd' AS "debtAddedUsd",
+      hook->>'currentDebtUsd' AS "currentDebtUsd",
+      hook->>'protocolFeesUsd' AS "protocolFeesUsd",
+      hook->>'totalFeesUsd' AS "totalFeesUsd",
+      hook->>'totalRefundsUsd' AS "totalRefundsUsd",
+      hook->'apr' AS "apr",
+
+      block_number AS "blockNumber",
+      block_time AS "blockTime",
+      log_index AS "logIndex",
+      transaction_hash AS "transactionHash"
+    FROM evmlog
+    WHERE
+      (chain_id = $1 OR $1 IS NULL) AND (address = $2 OR $2 IS NULL)
+      AND event_name = 'StrategyReported'
+      AND block_time > NOW() - INTERVAL '2 days'
+    ORDER BY
+      block_time DESC, log_index DESC
+      LIMIT 1000;`,
+    [chainId, address ? getAddress(address) : null])
+
+    return result.rows as VaultReport[]
+  } catch (error) {
+    console.error(error)
+    throw new Error('!getRecentStrategyReports')
+  }
+}

--- a/packages/web/app/api/rest/reports/redis.ts
+++ b/packages/web/app/api/rest/reports/redis.ts
@@ -4,3 +4,10 @@ export function getReportKey(
 ): string {
   return `rest:vault_reports:${chainId}:${address.toLowerCase()}`
 }
+
+export function getReportLatestKey(
+  chainId: number,
+  address: string,
+): string {
+  return `rest:vault_reports:latest:${chainId}:${address.toLowerCase()}`
+}

--- a/packages/web/app/api/rest/reports/refresh-historical.ts
+++ b/packages/web/app/api/rest/reports/refresh-historical.ts
@@ -1,12 +1,12 @@
 import 'lib/global'
 import { cacheMSet, disconnect } from '../cache'
-import { getRecentStrategyReports, getVaults } from './db'
-import { getReportLatestKey } from './redis'
+import { getStrategyReports, getVaults } from './db'
+import { getReportKey } from './redis'
 
 const BATCH_SIZE = parseInt(process.env.REFRESH_BATCH_SIZE || '10', 10)
 
-async function refreshLatest(): Promise<void> {
-  console.time('refresh vault_reports latest')
+async function refreshHistorical(): Promise<void> {
+  console.time('refresh vault_reports historical')
 
   console.log('Fetching vaults...')
   const vaults = await getVaults()
@@ -19,10 +19,10 @@ async function refreshLatest(): Promise<void> {
     const pairs: Array<[string, string]> = []
 
     await Promise.all(batch.map(async (vault) => {
-      const reports = await getRecentStrategyReports(vault.chainId, vault.address)
+      const reports = await getStrategyReports(vault.chainId, vault.address)
       if (!reports || reports.length === 0) return
       pairs.push([
-        getReportLatestKey(vault.chainId, vault.address.toLowerCase()),
+        getReportKey(vault.chainId, vault.address.toLowerCase()),
         JSON.stringify({ value: reports }),
       ])
     }))
@@ -36,11 +36,11 @@ async function refreshLatest(): Promise<void> {
   }
 
   console.log(`✓ Completed: ${processed} vaults processed`)
-  console.timeEnd('refresh vault_reports latest')
+  console.timeEnd('refresh vault_reports historical')
 }
 
 if (require.main === module) {
-  refreshLatest()
+  refreshHistorical()
     .then(async () => {
       await disconnect()
       process.exit(0)

--- a/packages/web/app/api/rest/reports/refresh-historical.ts
+++ b/packages/web/app/api/rest/reports/refresh-historical.ts
@@ -29,7 +29,7 @@ async function refreshHistorical(): Promise<void> {
 
     await cacheMSet(pairs)
 
-    processed += pairs.length
+    processed += batch.length
     if (processed % 10 === 0) {
       console.log(`Processed ${processed}/${vaults.length} vaults`)
     }

--- a/packages/web/app/api/rest/reports/refresh.ts
+++ b/packages/web/app/api/rest/reports/refresh.ts
@@ -29,7 +29,7 @@ async function refreshLatest(): Promise<void> {
 
     await cacheMSet(pairs)
 
-    processed += pairs.length
+    processed += batch.length
     if (processed % 10 === 0) {
       console.log(`Processed ${processed}/${vaults.length} vaults`)
     }

--- a/packages/web/app/api/rest/timeseries/[segment]/[chainId]/[address]/route.ts
+++ b/packages/web/app/api/rest/timeseries/[segment]/[chainId]/[address]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getKeyvClient } from '../../../../cache'
 import { labels } from '../../../labels'
-import { getTimeseriesKey } from '../../../redis'
+import { getTimeseriesKey, getTimeseriesLatestKey } from '../../../redis'
 
 export const runtime = 'nodejs'
 
@@ -44,20 +44,35 @@ export async function GET(
     ? requestedComponents
     : [entry.defaultComponent]
 
+  type TimeseriesEntry = { time: number; component: string; value: number }
+
   const addressLower = address.toLowerCase()
-  const cacheKey = getTimeseriesKey(entry.label, Number(chainId), addressLower)
-  let cached
+  const chainIdNum = Number(chainId)
+  const historicalKey = getTimeseriesKey(entry.label, chainIdNum, addressLower)
+  const latestKey = getTimeseriesLatestKey(entry.label, chainIdNum, addressLower)
+
+  let historical: TimeseriesEntry[] = []
+  let latest: TimeseriesEntry[] = []
   try {
-    cached = await timeseriesKeyv.get(cacheKey)
+    const [historicalCached, latestCached] = await Promise.all([
+      timeseriesKeyv.get(historicalKey),
+      timeseriesKeyv.get(latestKey),
+    ])
+    historical = (historicalCached as TimeseriesEntry[]) || []
+    latest = (latestCached as TimeseriesEntry[]) || []
   } catch (err) {
-    console.error(`Redis read failed for ${cacheKey}:`, err)
+    console.error(`Redis read failed for ${historicalKey}:`, err)
     throw err
   }
-  const parsed: Array<{ time: number; component: string; value: number }> = cached
-    ? (cached as Array<{ time: number; component: string; value: number }>)
-    : []
 
-  const filtered = parsed.filter((row) => components.includes(row.component))
+  // Merge: latest rows override historical rows for the same time+component
+  const latestTimes = new Set(latest.map((r) => `${r.time}:${r.component}`))
+  const merged = [
+    ...historical.filter((r) => !latestTimes.has(`${r.time}:${r.component}`)),
+    ...latest,
+  ].sort((a, b) => a.time - b.time)
+
+  const filtered = merged.filter((row) => components.includes(row.component))
 
   return NextResponse.json(filtered, {
     status: 200,

--- a/packages/web/app/api/rest/timeseries/db.ts
+++ b/packages/web/app/api/rest/timeseries/db.ts
@@ -76,7 +76,7 @@ export async function getRecentTimeseries(
     WHERE chain_id = $1
       AND address = $2
       AND label = $3
-      AND series_time >= date_trunc('day', NOW()) - INTERVAL '1 day'
+      AND series_time >= date_trunc('day', NOW()) - INTERVAL '2 days'
     GROUP BY chain_id, address, component, time
     ORDER BY time ASC
   `,

--- a/packages/web/app/api/rest/timeseries/db.ts
+++ b/packages/web/app/api/rest/timeseries/db.ts
@@ -76,7 +76,7 @@ export async function getRecentTimeseries(
     WHERE chain_id = $1
       AND address = $2
       AND label = $3
-      AND series_time > NOW() - INTERVAL '2 days'
+      AND series_time >= date_trunc('day', NOW()) - INTERVAL '1 day'
     GROUP BY chain_id, address, component, time
     ORDER BY time ASC
   `,

--- a/packages/web/app/api/rest/timeseries/db.ts
+++ b/packages/web/app/api/rest/timeseries/db.ts
@@ -57,6 +57,35 @@ export async function getFullTimeseries(
   return result.rows as TimeseriesRow[]
 }
 
+export async function getRecentTimeseries(
+  chainId: number,
+  address: string,
+  label: string,
+): Promise<TimeseriesRow[]> {
+  const result = await db.query(
+    `
+    SELECT
+      chain_id AS "chainId",
+      address,
+      $3::text AS label,
+      component,
+      COALESCE(AVG(NULLIF(value, 0)), 0) AS value,
+      '1 day'::text AS period,
+      time_bucket('1 day'::interval, series_time) AS time
+    FROM output
+    WHERE chain_id = $1
+      AND address = $2
+      AND label = $3
+      AND series_time > NOW() - INTERVAL '2 days'
+    GROUP BY chain_id, address, component, time
+    ORDER BY time ASC
+  `,
+    [chainId, getAddress(address as `0x${string}`), label],
+  )
+
+  return result.rows as TimeseriesRow[]
+}
+
 export async function getLatestTimeseries(
   chainId: number,
   address: string,

--- a/packages/web/app/api/rest/timeseries/redis.ts
+++ b/packages/web/app/api/rest/timeseries/redis.ts
@@ -5,3 +5,11 @@ export function getTimeseriesKey(
 ): string {
   return `rest:timeseries:${label}:${chainId}:${addressLower.toLowerCase()}`
 }
+
+export function getTimeseriesLatestKey(
+  label: string,
+  chainId: number,
+  addressLower: string,
+): string {
+  return `rest:timeseries:latest:${label}:${chainId}:${addressLower.toLowerCase()}`
+}

--- a/packages/web/app/api/rest/timeseries/refresh-historical.ts
+++ b/packages/web/app/api/rest/timeseries/refresh-historical.ts
@@ -5,8 +5,8 @@ import { getTimeseriesKey } from './redis'
 
 const BATCH_SIZE = 10
 
-async function refresh24hr(): Promise<void> {
-  console.time('refresh24hr')
+async function refreshHistorical(): Promise<void> {
+  console.time('refreshHistorical')
 
   console.log('Fetching vaults...')
   const vaults = await getVaults()
@@ -50,11 +50,11 @@ async function refresh24hr(): Promise<void> {
   }
 
   console.log(`✓ Completed: ${processed} vaults processed`)
-  console.timeEnd('refresh24hr')
+  console.timeEnd('refreshHistorical')
 }
 
 if (require.main === module) {
-  refresh24hr()
+  refreshHistorical()
     .then(async () => {
       await disconnect()
       process.exit(0)

--- a/packages/web/app/api/rest/timeseries/refresh.ts
+++ b/packages/web/app/api/rest/timeseries/refresh.ts
@@ -1,12 +1,12 @@
-import 'lib/global'
 import { cacheMSet, disconnect } from '../cache'
-import { getRecentStrategyReports, getVaults } from './db'
-import { getReportLatestKey } from './redis'
+import { getRecentTimeseries, getVaults, TimeseriesRow } from './db'
+import { labels } from './labels'
+import { getTimeseriesLatestKey } from './redis'
 
-const BATCH_SIZE = parseInt(process.env.REFRESH_BATCH_SIZE || '10', 10)
+const BATCH_SIZE = 10
 
 async function refreshLatest(): Promise<void> {
-  console.time('refresh vault_reports latest')
+  console.time('refreshLatest')
 
   console.log('Fetching vaults...')
   const vaults = await getVaults()
@@ -19,24 +19,38 @@ async function refreshLatest(): Promise<void> {
     const pairs: Array<[string, string]> = []
 
     await Promise.all(batch.map(async (vault) => {
-      const reports = await getRecentStrategyReports(vault.chainId, vault.address)
-      if (!reports || reports.length === 0) return
-      pairs.push([
-        getReportLatestKey(vault.chainId, vault.address.toLowerCase()),
-        JSON.stringify({ value: reports }),
-      ])
+      const addressLower = vault.address.toLowerCase()
+
+      await Promise.all(labels.map(async ({ label }) => {
+        const rows: TimeseriesRow[] = await getRecentTimeseries(
+          vault.chainId,
+          vault.address,
+          label,
+        )
+
+        const minimal = rows.map(row => ({
+          time: Number(row.time),
+          component: row.component,
+          value: row.value,
+        }))
+
+        pairs.push([
+          getTimeseriesLatestKey(label, vault.chainId, addressLower),
+          JSON.stringify({ value: minimal }),
+        ])
+      }))
     }))
 
     await cacheMSet(pairs)
 
-    processed += pairs.length
+    processed += batch.length
     if (processed % 10 === 0) {
       console.log(`Processed ${processed}/${vaults.length} vaults`)
     }
   }
 
   console.log(`✓ Completed: ${processed} vaults processed`)
-  console.timeEnd('refresh vault_reports latest')
+  console.timeEnd('refreshLatest')
 }
 
 if (require.main === module) {


### PR DESCRIPTION
## Summary
- Splits timeseries and reports cache refresh into separate historical and latest stacks
- Historical refreshes run independently from latest data refreshes, reducing unnecessary database queries
- Adds new GitHub Actions workflows for historical refresh jobs
- Adds Redis and DB helper modules for both timeseries and reports

## Why
Reduce database egress costs by avoiding redundant full-range queries when only the latest data needs refreshing.

## Test plan

- [ ] start redis if not already started
```
docker start redis 2>/dev/null || docker run -d --name redis -p 6379:6379 redis
timeout 1 bash -c '</dev/tcp/localhost/6379' && echo up || echo down
```

- [ ] configure redis cache in `packages/web/.env`
```
REST_CACHE_REDIS_URL=redis://localhost:6379
```

- [ ] configure database read replica in `.env` and `packages/web/.env.local`
```
POSTGRES_HOST=
POSTGRES_DATABASE=neondb
POSTGRES_USER=
POSTGRES_PASSWORD=
POSTGRES_SSL=true
POSTGRES_PORT=5432
```

- [ ] start web server
```
(cd packages/web && bun dev)
```

### Timeseries

- [ ] run the historical refresh script
```
bun packages/web/app/api/rest/timeseries/refresh-historical.ts
```
Expected: completes without errors, e.g. `✓ Completed: N vaults processed`

- [ ] run the latest refresh script
```
bun packages/web/app/api/rest/timeseries/refresh.ts
```
Expected: completes without errors, e.g. `✓ Completed: N vaults processed`

- [ ] confirm historical and latest keys exist in redis
```
docker exec redis redis-cli KEYS 'rest:timeseries:*' | head -10
docker exec redis redis-cli KEYS 'rest:timeseries:latest:*' | head -10
```
Expected: both patterns return keys

- [ ] confirm the route merges historical and latest data
```
curl -s 'http://localhost:3000/api/rest/timeseries/apy/1/0x028eC7330ff87667b6dfb0D94b954c820195336c' | jq 'length'
```
Expected: non-zero count, data sorted by time ascending

### Reports

- [ ] run the historical refresh script
```
bun packages/web/app/api/rest/reports/refresh-historical.ts
```
Expected: completes without errors, e.g. `✓ Completed: N vaults processed`

- [ ] run the latest refresh script
```
bun packages/web/app/api/rest/reports/refresh.ts
```
Expected: completes without errors, e.g. `✓ Completed: N vaults processed`

- [ ] confirm historical and latest keys exist in redis
```
docker exec redis redis-cli KEYS 'rest:vault_reports:*' | grep -v latest | head -10
docker exec redis redis-cli KEYS 'rest:vault_reports:latest:*' | head -10
```
Expected: both patterns return keys

- [ ] confirm the route merges historical and latest data
```
curl -s 'http://localhost:3000/api/rest/reports/1/0x028eC7330ff87667b6dfb0D94b954c820195336c' | jq 'length'
```
Expected: non-zero count, latest reports appear first (DESC order), capped at 1000

- [ ] confirm deduplication works (latest wins over historical for same txHash:logIndex)
```
curl -s 'http://localhost:3000/api/rest/reports/1/0x028eC7330ff87667b6dfb0D94b954c820195336c' | jq '[.[].transactionHash] | unique | length'
curl -s 'http://localhost:3000/api/rest/reports/1/0x028eC7330ff87667b6dfb0D94b954c820195336c' | jq 'length'
```
Expected: both counts should be equal (no duplicate txHash:logIndex pairs)

- [ ] stop redis if you started it
```
docker stop redis 2>/dev/null || true
```