### PR TITLE
Split Redis MSET into size-aware chunks to stay under Upstash 10MB request limit

### DIFF
--- a/packages/web/app/api/rest/cache.spec.ts
+++ b/packages/web/app/api/rest/cache.spec.ts
@@ -1,0 +1,41 @@
+import { strict as assert } from 'node:assert'
+import { estimateMSetRequestSize, splitPairsForMSet } from './cache'
+
+describe('splitPairsForMSet', () => {
+  it('keeps all pairs in one chunk when below the target', () => {
+    const pairs: Array<[string, string]> = [
+      ['alpha', '1'],
+      ['beta', '2'],
+    ]
+
+    const chunks = splitPairsForMSet(pairs, estimateMSetRequestSize(pairs) + 1)
+
+    assert.deepEqual(chunks, [pairs])
+  })
+
+  it('splits pairs into ordered chunks below the target', () => {
+    const pairs: Array<[string, string]> = [
+      ['alpha', 'x'.repeat(32)],
+      ['beta', 'y'.repeat(32)],
+      ['gamma', 'z'.repeat(32)],
+    ]
+
+    const singlePairSize = estimateMSetRequestSize([pairs[0]])
+    const targetBytes = singlePairSize + 10
+    const chunks = splitPairsForMSet(pairs, targetBytes)
+
+    assert.deepEqual(chunks, [
+      [pairs[0]],
+      [pairs[1]],
+      [pairs[2]],
+    ])
+  })
+
+  it('throws when a single pair exceeds the Redis hard limit', () => {
+    const tooLarge: Array<[string, string]> = [
+      ['huge', 'x'.repeat((10 * 1024 * 1024) + 1)],
+    ]
+
+    assert.throws(() => splitPairsForMSet(tooLarge), /exceeds hard limit/)
+  })
+})

--- a/packages/web/app/api/rest/cache.ts
+++ b/packages/web/app/api/rest/cache.ts
@@ -5,6 +5,16 @@ const writeClient = createClient({ url: process.env.REST_CACHE_REDIS_URL || 'red
 
 const keyv = createKeyv(process.env.REST_CACHE_REDIS_URL || 'redis://localhost:6379')
 
+const DEFAULT_REDIS_MSET_TARGET_BYTES = 8 * 1024 * 1024
+const REDIS_MSET_HARD_LIMIT_BYTES = 10 * 1024 * 1024
+const parsedRedisMSetTargetBytes = parseInt(
+  process.env.REST_CACHE_REDIS_MAX_REQUEST_BYTES || `${DEFAULT_REDIS_MSET_TARGET_BYTES}`,
+  10,
+)
+const REDIS_MSET_TARGET_BYTES = Number.isFinite(parsedRedisMSetTargetBytes) && parsedRedisMSetTargetBytes > 0
+  ? Math.min(parsedRedisMSetTargetBytes, REDIS_MSET_HARD_LIMIT_BYTES)
+  : DEFAULT_REDIS_MSET_TARGET_BYTES
+
 export function getKeyvClient() {
   return keyv
 }
@@ -14,10 +24,62 @@ export function getKeyvClient() {
  * setMany which uses MULTI + N SETs + EXEC (N+2 commands).
  */
 
+function getRespBulkStringSize(value: string): number {
+  const bytes = Buffer.byteLength(value)
+  return bytes + String(bytes).length + 5
+}
+
+function getRespArrayHeaderSize(itemCount: number): number {
+  return String(itemCount).length + 3
+}
+
+export function estimateMSetRequestSize(pairs: Array<[string, string]>): number {
+  const itemCount = 1 + (pairs.length * 2)
+  return pairs.reduce((size, [key, value]) => (
+    size + getRespBulkStringSize(key) + getRespBulkStringSize(value)
+  ), getRespArrayHeaderSize(itemCount) + getRespBulkStringSize('MSET'))
+}
+
+export function splitPairsForMSet(
+  pairs: Array<[string, string]>,
+  targetBytes = REDIS_MSET_TARGET_BYTES,
+): Array<Array<[string, string]>> {
+  if (pairs.length === 0) return []
+
+  const safeTargetBytes = Math.min(targetBytes, REDIS_MSET_HARD_LIMIT_BYTES)
+  const chunks: Array<Array<[string, string]>> = []
+  let currentChunk: Array<[string, string]> = []
+
+  for (const pair of pairs) {
+    const pairSize = estimateMSetRequestSize([pair])
+    if (pairSize > REDIS_MSET_HARD_LIMIT_BYTES) {
+      throw new Error(`Redis MSET payload exceeds hard limit for key "${pair[0]}" (${pairSize} bytes)`)
+    }
+
+    const nextChunk = [...currentChunk, pair]
+    const nextSize = estimateMSetRequestSize(nextChunk)
+
+    if (currentChunk.length > 0 && nextSize > safeTargetBytes) {
+      chunks.push(currentChunk)
+      currentChunk = [pair]
+      continue
+    }
+
+    currentChunk = nextChunk
+  }
+
+  if (currentChunk.length > 0) chunks.push(currentChunk)
+
+  return chunks
+}
+
 export async function cacheMSet(pairs: Array<[string, string]>): Promise<void> {
   if (pairs.length === 0) return
   if (!writeClient.isOpen) await writeClient.connect()
-  await writeClient.mSet(pairs)
+
+  for (const chunk of splitPairsForMSet(pairs)) {
+    await writeClient.mSet(chunk)
+  }
 }
 
 export async function disconnect(): Promise<void> {


### PR DESCRIPTION
## Summary
- Adds `splitPairsForMSet` that estimates RESP wire size for MSET payloads and splits key-value pairs into chunks that stay under a configurable target (default 8MB, hard cap 10MB)
- `cacheMSet` now iterates over chunks instead of sending all pairs in a single MSET call
- Target byte limit is configurable via `REST_CACHE_REDIS_MAX_REQUEST_BYTES` env var
- Includes unit tests for chunking logic and the single-pair hard limit guard

## Test plan
- [x] Unit tests cover: single chunk when below target, multi-chunk splitting, and throws on oversized single pair
- [ ] Verify cache refresh works end-to-end against Upstash without hitting the 10MB limit