### PR TITLE
feat: add Uptime Kuma push heartbeats to cron workflows

### DIFF
--- a/.github/workflows/refresh-lists.yml
+++ b/.github/workflows/refresh-lists.yml
@@ -27,7 +27,9 @@ jobs:
         run: bun packages/web/app/api/rest/list/refresh.ts
       - name: Report success to Uptime Kuma
         if: success()
+        continue-on-error: true
         run: curl -fsS -m 10 -o /dev/null "${{ secrets.UPTIME_KUMA_PUSH_URL_REFRESH_LISTS }}?status=up&msg=OK"
       - name: Report failure to Uptime Kuma
         if: failure()
+        continue-on-error: true
         run: curl -fsS -m 10 -o /dev/null "${{ secrets.UPTIME_KUMA_PUSH_URL_REFRESH_LISTS }}?status=down&msg=Run+failed"

--- a/.github/workflows/refresh-lists.yml
+++ b/.github/workflows/refresh-lists.yml
@@ -25,3 +25,9 @@ jobs:
           POSTGRES_POOL_MAX: ${{ vars.POSTGRES_POOL_MAX }}
           REST_CACHE_REDIS_URL: ${{ secrets.REST_CACHE_REDIS_URL }}
         run: bun packages/web/app/api/rest/list/refresh.ts
+      - name: Report success to Uptime Kuma
+        if: success()
+        run: curl -fsS -m 10 -o /dev/null "${{ secrets.UPTIME_KUMA_PUSH_URL_REFRESH_LISTS }}?status=up&msg=OK"
+      - name: Report failure to Uptime Kuma
+        if: failure()
+        run: curl -fsS -m 10 -o /dev/null "${{ secrets.UPTIME_KUMA_PUSH_URL_REFRESH_LISTS }}?status=down&msg=Run+failed"

--- a/.github/workflows/reports-refresh.yml
+++ b/.github/workflows/reports-refresh.yml
@@ -32,7 +32,9 @@ jobs:
         run: bun packages/web/app/api/rest/reports/refresh.ts
       - name: Report success to Uptime Kuma
         if: success()
+        continue-on-error: true
         run: curl -fsS -m 10 -o /dev/null "${{ secrets.UPTIME_KUMA_PUSH_URL_REPORTS_REFRESH }}?status=up&msg=OK"
       - name: Report failure to Uptime Kuma
         if: failure()
+        continue-on-error: true
         run: curl -fsS -m 10 -o /dev/null "${{ secrets.UPTIME_KUMA_PUSH_URL_REPORTS_REFRESH }}?status=down&msg=Run+failed"

--- a/.github/workflows/reports-refresh.yml
+++ b/.github/workflows/reports-refresh.yml
@@ -30,3 +30,9 @@ jobs:
           POSTGRES_POOL_MAX: ${{ vars.POSTGRES_POOL_MAX }}
           REST_CACHE_REDIS_URL: ${{ secrets.REST_CACHE_REDIS_URL }}
         run: bun packages/web/app/api/rest/reports/refresh.ts
+      - name: Report success to Uptime Kuma
+        if: success()
+        run: curl -fsS -m 10 -o /dev/null "${{ secrets.UPTIME_KUMA_PUSH_URL_REPORTS_REFRESH }}?status=up&msg=OK"
+      - name: Report failure to Uptime Kuma
+        if: failure()
+        run: curl -fsS -m 10 -o /dev/null "${{ secrets.UPTIME_KUMA_PUSH_URL_REPORTS_REFRESH }}?status=down&msg=Run+failed"

--- a/.github/workflows/snapshot-refresh.yml
+++ b/.github/workflows/snapshot-refresh.yml
@@ -24,3 +24,9 @@ jobs:
           POSTGRES_POOL_MAX: ${{ vars.POSTGRES_POOL_MAX }}
           REST_CACHE_REDIS_URL: ${{ secrets.REST_CACHE_REDIS_URL }}
         run: bun packages/web/app/api/rest/snapshot/refresh-snapshot.ts
+      - name: Report success to Uptime Kuma
+        if: success()
+        run: curl -fsS -m 10 -o /dev/null "${{ secrets.UPTIME_KUMA_PUSH_URL_SNAPSHOT_REFRESH }}?status=up&msg=OK"
+      - name: Report failure to Uptime Kuma
+        if: failure()
+        run: curl -fsS -m 10 -o /dev/null "${{ secrets.UPTIME_KUMA_PUSH_URL_SNAPSHOT_REFRESH }}?status=down&msg=Run+failed"

--- a/.github/workflows/snapshot-refresh.yml
+++ b/.github/workflows/snapshot-refresh.yml
@@ -26,7 +26,9 @@ jobs:
         run: bun packages/web/app/api/rest/snapshot/refresh-snapshot.ts
       - name: Report success to Uptime Kuma
         if: success()
+        continue-on-error: true
         run: curl -fsS -m 10 -o /dev/null "${{ secrets.UPTIME_KUMA_PUSH_URL_SNAPSHOT_REFRESH }}?status=up&msg=OK"
       - name: Report failure to Uptime Kuma
         if: failure()
+        continue-on-error: true
         run: curl -fsS -m 10 -o /dev/null "${{ secrets.UPTIME_KUMA_PUSH_URL_SNAPSHOT_REFRESH }}?status=down&msg=Run+failed"

--- a/.github/workflows/timeseries-refresh.yml
+++ b/.github/workflows/timeseries-refresh.yml
@@ -26,7 +26,9 @@ jobs:
         run: bun packages/web/app/api/rest/timeseries/refresh.ts
       - name: Report success to Uptime Kuma
         if: success()
+        continue-on-error: true
         run: curl -fsS -m 10 -o /dev/null "${{ secrets.UPTIME_KUMA_PUSH_URL_TIMESERIES_REFRESH }}?status=up&msg=OK"
       - name: Report failure to Uptime Kuma
         if: failure()
+        continue-on-error: true
         run: curl -fsS -m 10 -o /dev/null "${{ secrets.UPTIME_KUMA_PUSH_URL_TIMESERIES_REFRESH }}?status=down&msg=Run+failed"

--- a/.github/workflows/timeseries-refresh.yml
+++ b/.github/workflows/timeseries-refresh.yml
@@ -24,3 +24,9 @@ jobs:
           POSTGRES_POOL_MAX: ${{ vars.POSTGRES_POOL_MAX }}
           REST_CACHE_REDIS_URL: ${{ secrets.REST_CACHE_REDIS_URL }}
         run: bun packages/web/app/api/rest/timeseries/refresh.ts
+      - name: Report success to Uptime Kuma
+        if: success()
+        run: curl -fsS -m 10 -o /dev/null "${{ secrets.UPTIME_KUMA_PUSH_URL_TIMESERIES_REFRESH }}?status=up&msg=OK"
+      - name: Report failure to Uptime Kuma
+        if: failure()
+        run: curl -fsS -m 10 -o /dev/null "${{ secrets.UPTIME_KUMA_PUSH_URL_TIMESERIES_REFRESH }}?status=down&msg=Run+failed"


### PR DESCRIPTION
### Summary

Add Uptime Kuma push-based heartbeat monitoring to all 4 scheduled cron workflows (`refresh-lists`, `snapshot-refresh`, `reports-refresh`, `timeseries-refresh`). Each workflow now reports `status=up` on success and `status=down` on failure, enabling alerts when runs fail or silently stop.

Both heartbeat steps use `continue-on-error: true` so a curl failure (secret not configured, network timeout, Uptime Kuma down) never marks the job as failed or triggers a false `status=down` report.

Closes #383

### How to review

Only `.github/workflows/*.yml` files changed — each gets two new steps appended (success + failure curl to Uptime Kuma). No existing behavior modified.

### Test plan

- [ ] **Prerequisites**: Create 4 push monitors in Uptime Kuma and add their URLs as GitHub repo secrets

| Secret name | Monitor |
|---|---|
| `UPTIME_KUMA_PUSH_URL_REFRESH_LISTS` | Kong — Refresh Lists (heartbeat: 1200s) |
| `UPTIME_KUMA_PUSH_URL_SNAPSHOT_REFRESH` | Kong — Snapshot Refresh (heartbeat: 1200s) |
| `UPTIME_KUMA_PUSH_URL_REPORTS_REFRESH` | Kong — Reports Refresh (heartbeat: 4500s) |
| `UPTIME_KUMA_PUSH_URL_TIMESERIES_REFRESH` | Kong — Timeseries Refresh (heartbeat: 4500s) |


### Risk / impact

- **Low risk**: Only appends new steps — no existing behavior changed
- **Graceful degradation**: Both heartbeat steps use `continue-on-error: true`, so if secrets are not set or Uptime Kuma is unreachable, the curl step fails without affecting the job status
- **Rollback**: Revert the commit to remove heartbeat steps