### PR TITLE
[codex] add yield splitter vault metadata

### DIFF
--- a/packages/web/app/api/gql/resolvers/index.ts
+++ b/packages/web/app/api/gql/resolvers/index.ts
@@ -28,6 +28,7 @@ import allocator from './allocator'
 import newSplitterLogs from './splitter'
 import newYieldSplitterLogs from './yieldSplitter'
 import vestingEscrowCreatedLogs from './vestingEscrow'
+import vaultType from './vaultType'
 
 const resolvers = {
   BigInt: bigintScalar,
@@ -61,7 +62,8 @@ const resolvers = {
     newSplitterLogs,
     newYieldSplitterLogs,
     vestingEscrowCreatedLogs
-  }
+  },
+  Vault: vaultType
 }
 
 export default resolvers

--- a/packages/web/app/api/gql/resolvers/vault.ts
+++ b/packages/web/app/api/gql/resolvers/vault.ts
@@ -1,5 +1,4 @@
 import db from '@/app/api/db'
-import { attachYieldSplitterMetadataToRow } from '@/app/api/yieldSplitters'
 import { getAddress } from 'viem'
 
 const vault = async (_: object, args: { chainId: number, address: `0x${string}` }) => {
@@ -34,7 +33,7 @@ const vault = async (_: object, args: { chainId: number, address: `0x${string}` 
       return null
     }
 
-    return attachYieldSplitterMetadataToRow(first)
+    return first
 
   } catch (error) {
     console.error(error)

--- a/packages/web/app/api/gql/resolvers/vault.ts
+++ b/packages/web/app/api/gql/resolvers/vault.ts
@@ -1,4 +1,5 @@
 import db from '@/app/api/db'
+import { attachYieldSplitterMetadataToRow } from '@/app/api/yieldSplitters'
 import { getAddress } from 'viem'
 
 const vault = async (_: object, args: { chainId: number, address: `0x${string}` }) => {
@@ -29,7 +30,11 @@ const vault = async (_: object, args: { chainId: number, address: `0x${string}` 
       ...row.hook
     }))
 
-    return first
+    if (!first) {
+      return null
+    }
+
+    return attachYieldSplitterMetadataToRow(first)
 
   } catch (error) {
     console.error(error)

--- a/packages/web/app/api/gql/resolvers/vaultType.ts
+++ b/packages/web/app/api/gql/resolvers/vaultType.ts
@@ -1,0 +1,55 @@
+import {
+  attachYieldSplitterMetadataToRow,
+  attachYieldSplitterMetadataToRowTargeted,
+  type YieldSplitterMetadata
+} from '@/app/api/yieldSplitters'
+import type { GraphQLResolveInfo } from 'graphql'
+
+type TVaultResolverParent = {
+  chainId?: number | null
+  address?: string | null
+  asset?: {
+    address?: string | null
+    name?: string | null
+    symbol?: string | null
+  } | null
+  yieldSplitter?: YieldSplitterMetadata | null
+}
+
+type TGraphQLPath = {
+  key: string | number
+  prev?: TGraphQLPath
+}
+
+function getRootFieldName(path: TGraphQLPath): string | undefined {
+  let currentPath: TGraphQLPath | undefined = path
+  while (currentPath?.prev) {
+    currentPath = currentPath.prev
+  }
+
+  return typeof currentPath?.key === 'string' ? currentPath.key : undefined
+}
+
+const vaultType = {
+  async yieldSplitter(parent: TVaultResolverParent, _args: object, _context: object, info: GraphQLResolveInfo) {
+    if (parent.yieldSplitter !== undefined) {
+      return parent.yieldSplitter ?? null
+    }
+
+    if (typeof parent.chainId !== 'number' || typeof parent.address !== 'string') {
+      return null
+    }
+
+    const attachMetadata = getRootFieldName(info.path) === 'vault'
+      ? attachYieldSplitterMetadataToRowTargeted
+      : attachYieldSplitterMetadataToRow
+
+    const rowWithMetadata = await attachMetadata(
+      parent as TVaultResolverParent & { chainId: number, address: string }
+    )
+
+    return rowWithMetadata.yieldSplitter ?? null
+  }
+}
+
+export default vaultType

--- a/packages/web/app/api/gql/resolvers/vaults.ts
+++ b/packages/web/app/api/gql/resolvers/vaults.ts
@@ -1,4 +1,5 @@
 import db from '@/app/api/db'
+import { attachYieldSplitterMetadata } from '@/app/api/yieldSplitters'
 import { compare } from '@/lib/compare'
 import { DefaultRiskScore, EvmAddressSchema } from 'lib/types'
 
@@ -112,7 +113,7 @@ const vaults = async (_: object, args: {
       })
     }
 
-    return rows
+    return attachYieldSplitterMetadata(rows)
 
   } catch (error) {
     console.error(error)

--- a/packages/web/app/api/gql/resolvers/vaults.ts
+++ b/packages/web/app/api/gql/resolvers/vaults.ts
@@ -1,5 +1,4 @@
 import db from '@/app/api/db'
-import { attachYieldSplitterMetadata } from '@/app/api/yieldSplitters'
 import { compare } from '@/lib/compare'
 import { DefaultRiskScore, EvmAddressSchema } from 'lib/types'
 
@@ -113,7 +112,7 @@ const vaults = async (_: object, args: {
       })
     }
 
-    return attachYieldSplitterMetadata(rows)
+    return rows
 
   } catch (error) {
     console.error(error)

--- a/packages/web/app/api/gql/typeDefs/vault.ts
+++ b/packages/web/app/api/gql/typeDefs/vault.ts
@@ -164,6 +164,25 @@ type Staking {
   rewards: [StakingReward!]
 }
 
+type YieldSplitter {
+  enabled: Boolean!
+  sourceVaultAddress: String!
+  sourceVaultName: String
+  sourceVaultSymbol: String
+  wantVaultAddress: String!
+  wantVaultName: String
+  wantVaultSymbol: String
+  depositAssetAddress: String
+  depositAssetName: String
+  depositAssetSymbol: String
+  rewardTokenAddresses: [String!]!
+  rewardHandlerAddress: String
+  tokenizedStrategyAddress: String
+  displayType: String!
+  displayKind: String!
+  uiDescription: String!
+}
+
 type Vault {
   DOMAIN_SEPARATOR: String
   FACTORY: String
@@ -240,5 +259,6 @@ type Vault {
   yearn: Boolean
   origin: String
   staking: Staking
+  yieldSplitter: YieldSplitter
 }
 `

--- a/packages/web/app/api/rest/list/db.ts
+++ b/packages/web/app/api/rest/list/db.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 import db from '../../db'
+import { attachYieldSplitterMetadata } from '../../yieldSplitters'
 
 const CoerceNumber = z.preprocess(
   (val) => (val === null || val === undefined) ? null : Number(val),
@@ -89,6 +90,25 @@ export const VaultListItemSchema = z.object({
 
   // Price
   pricePerShare: CoerceNumber,
+
+  yieldSplitter: z.object({
+    enabled: z.literal(true),
+    sourceVaultAddress: z.string(),
+    sourceVaultName: z.string().optional(),
+    sourceVaultSymbol: z.string().optional(),
+    wantVaultAddress: z.string(),
+    wantVaultName: z.string().optional(),
+    wantVaultSymbol: z.string().optional(),
+    depositAssetAddress: z.string().optional(),
+    depositAssetName: z.string().optional(),
+    depositAssetSymbol: z.string().optional(),
+    rewardTokenAddresses: z.array(z.string()),
+    rewardHandlerAddress: z.string().optional(),
+    tokenizedStrategyAddress: z.string().optional(),
+    displayType: z.literal('Yield Splitter'),
+    displayKind: z.literal('Vault-to-Vault'),
+    uiDescription: z.string()
+  }).optional(),
 })
 
 export type VaultListItem = z.infer<typeof VaultListItemSchema>
@@ -201,5 +221,6 @@ export async function getVaultsList(): Promise<VaultListItem[]> {
     ORDER BY (snapshot.hook->'tvl'->>'close')::double precision DESC NULLS LAST
   `)
 
-  return z.array(VaultListItemSchema).parse(result.rows)
+  const rows = await attachYieldSplitterMetadata(result.rows)
+  return z.array(VaultListItemSchema).parse(rows)
 }

--- a/packages/web/app/api/rest/snapshot/db.ts
+++ b/packages/web/app/api/rest/snapshot/db.ts
@@ -1,5 +1,6 @@
 import db from '../../db'
 import { getAddress } from 'viem'
+import { attachYieldSplitterMetadataToRow } from '../../yieldSplitters'
 
 export type VaultRow = {
   chainId: number
@@ -72,7 +73,10 @@ export async function getVaultSnapshot(
     ...row.hook
   }
 
-  return await hydrateStrategyEstimatedApr(chainId, row.address, snapshot)
+  const hydratedSnapshot = await hydrateStrategyEstimatedApr(chainId, row.address, snapshot)
+  return attachYieldSplitterMetadataToRow(hydratedSnapshot as VaultSnapshot & {
+    asset?: { address?: string | null; name?: string | null; symbol?: string | null } | null
+  })
 }
 
 type EstimatedMetric = 'apr' | 'apy'

--- a/packages/web/app/api/rest/snapshot/db.ts
+++ b/packages/web/app/api/rest/snapshot/db.ts
@@ -1,6 +1,6 @@
 import db from '../../db'
 import { getAddress } from 'viem'
-import { attachYieldSplitterMetadataToRow } from '../../yieldSplitters'
+import { attachYieldSplitterMetadataToRowTargeted } from '../../yieldSplitters'
 
 export type VaultRow = {
   chainId: number
@@ -74,7 +74,7 @@ export async function getVaultSnapshot(
   }
 
   const hydratedSnapshot = await hydrateStrategyEstimatedApr(chainId, row.address, snapshot)
-  return attachYieldSplitterMetadataToRow(hydratedSnapshot as VaultSnapshot & {
+  return attachYieldSplitterMetadataToRowTargeted(hydratedSnapshot as VaultSnapshot & {
     asset?: { address?: string | null; name?: string | null; symbol?: string | null } | null
   })
 }

--- a/packages/web/app/api/rest/snapshot/refresh-snapshot.ts
+++ b/packages/web/app/api/rest/snapshot/refresh-snapshot.ts
@@ -1,6 +1,7 @@
 import { cacheMSet, disconnect } from '../cache'
 import { getVaults, getVaultSnapshot } from './db'
 import { getSnapshotKey } from './redis'
+import { primeYieldSplitterCache } from '../../yieldSplitters'
 
 const BATCH_SIZE = 10
 
@@ -10,6 +11,8 @@ async function refresh(): Promise<void> {
   console.log('Fetching vaults...')
   const vaults = await getVaults()
   console.log(`Found ${vaults.length} vaults (batch size: ${BATCH_SIZE})`)
+
+  await primeYieldSplitterCache()
 
   let processed = 0
 

--- a/packages/web/app/api/yieldSplitterConfig.ts
+++ b/packages/web/app/api/yieldSplitterConfig.ts
@@ -1,0 +1,43 @@
+import { getAddress, type Address } from 'viem'
+
+type TYieldSplitterFactorySource = {
+  chainId: number
+  address: string
+  obsolete?: boolean
+}
+
+// Intentional product constraint: only expose metadata for the current live Katana
+// yield splitters. On 2026-04-08 we verified the six live splitter contracts
+// against all three Katana factories with `isDeployedStrategy(address)`, and each
+// resolved only to 0x3E13dB939c03c03852407Ca90D5A59183D28dA62. Older factories did
+// emit historical deployments, but those are intentionally excluded from REST and
+// GraphQL metadata unless product requirements change.
+const YIELD_SPLITTER_FACTORY_SOURCES: TYieldSplitterFactorySource[] = [
+  {
+    chainId: 747474,
+    address: '0x72bd640a903DAE71E1eaA315f31F4dA33C82872d',
+    obsolete: true
+  },
+  {
+    chainId: 747474,
+    address: '0xfb277c7DfDa414aF824AF08c3596d6c28570347d',
+    obsolete: true
+  },
+  {
+    chainId: 747474,
+    address: '0x3E13dB939c03c03852407Ca90D5A59183D28dA62'
+  }
+]
+
+export function getActiveYieldSplitterFactories(
+  sources: TYieldSplitterFactorySource[] = YIELD_SPLITTER_FACTORY_SOURCES
+): Array<{ chainId: number, address: Address }> {
+  return sources
+    .filter((source) => !source.obsolete)
+    .map((source) => ({
+      chainId: source.chainId,
+      address: getAddress(source.address)
+    }))
+}
+
+export const ACTIVE_YIELD_SPLITTER_FACTORIES = getActiveYieldSplitterFactories()

--- a/packages/web/app/api/yieldSplitters.spec.ts
+++ b/packages/web/app/api/yieldSplitters.spec.ts
@@ -1,0 +1,38 @@
+import { strict as assert } from 'node:assert'
+import { getActiveYieldSplitterFactories } from './yieldSplitterConfig'
+
+describe('getActiveYieldSplitterFactories', () => {
+  it('keeps only non-obsolete yield splitter factories', () => {
+    const testFactories = [
+      {
+        chainId: 747474,
+        address: '0x72bd640a903DAE71E1eaA315f31F4dA33C82872d',
+        obsolete: true
+      },
+      {
+        chainId: 747474,
+        address: '0xfb277c7DfDa414aF824AF08c3596d6c28570347d',
+        obsolete: true
+      },
+      {
+        chainId: 747474,
+        address: '0x3E13dB939c03c03852407Ca90D5A59183D28dA62'
+      },
+      {
+        chainId: 1,
+        address: '0xe28fCC9FB2998ba57754789F6666DAa8C815614D'
+      }
+    ]
+
+    assert.deepEqual(getActiveYieldSplitterFactories(testFactories), [
+      {
+        chainId: 747474,
+        address: '0x3E13dB939c03c03852407Ca90D5A59183D28dA62'
+      },
+      {
+        chainId: 1,
+        address: '0xe28fCC9FB2998ba57754789F6666DAa8C815614D'
+      }
+    ])
+  })
+})

--- a/packages/web/app/api/yieldSplitters.ts
+++ b/packages/web/app/api/yieldSplitters.ts
@@ -1,0 +1,367 @@
+import db from './db'
+import chains from 'lib/chains'
+import { createPublicClient, getAddress, http, type Address, type Chain, type PublicClient } from 'viem'
+
+type TAssetLike = {
+  address?: string | null
+  name?: string | null
+  symbol?: string | null
+}
+
+type TAddressRow = {
+  chainId: number
+  address: string
+  asset?: TAssetLike | null
+}
+
+type TYieldSplitterLogRow = {
+  chainId: number
+  splitterAddress: Address
+  sourceVaultAddress: Address
+  sourceVaultName?: string
+  sourceVaultSymbol?: string
+  wantVaultAddress: Address
+  wantVaultName?: string
+  wantVaultSymbol?: string
+}
+
+type TYieldSplitterDynamicRow = {
+  rewardHandlerAddress?: Address
+  tokenizedStrategyAddress?: Address
+  rewardTokenAddresses: Address[]
+}
+
+export type YieldSplitterMetadata = {
+  enabled: true
+  sourceVaultAddress: Address
+  sourceVaultName?: string
+  sourceVaultSymbol?: string
+  wantVaultAddress: Address
+  wantVaultName?: string
+  wantVaultSymbol?: string
+  depositAssetAddress?: Address
+  depositAssetName?: string
+  depositAssetSymbol?: string
+  rewardTokenAddresses: Address[]
+  rewardHandlerAddress?: Address
+  tokenizedStrategyAddress?: Address
+  displayType: 'Yield Splitter'
+  displayKind: 'Vault-to-Vault'
+  uiDescription: string
+}
+
+type TCachedYieldSplitterData = Map<string, TYieldSplitterLogRow & TYieldSplitterDynamicRow>
+
+const YIELD_SPLITTER_ABI = [
+  {
+    inputs: [],
+    name: 'rewardHandler',
+    outputs: [{ internalType: 'address', name: '', type: 'address' }],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [],
+    name: 'tokenizedStrategyAddress',
+    outputs: [{ internalType: 'address', name: '', type: 'address' }],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [],
+    name: 'getRewardTokens',
+    outputs: [{ internalType: 'address[]', name: '', type: 'address[]' }],
+    stateMutability: 'view',
+    type: 'function'
+  }
+] as const
+
+const CACHE_TTL_MS = 5 * 60 * 1000
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
+
+let cachedYieldSplitters: { expiresAt: number, data: TCachedYieldSplitterData } | undefined
+let cachedYieldSplittersPromise: Promise<TCachedYieldSplitterData> | undefined
+const rpcClients = new Map<number, PublicClient>()
+
+function getRpcUrl(chain: Chain): string {
+  return (
+    process.env[`HTTP_FULLNODE_${chain.id}`]
+    || process.env[`HTTP_ARCHIVE_${chain.id}`]
+    || chain.rpcUrls.default.http[0]
+  )
+}
+
+function getRpcClient(chainId: number): PublicClient {
+  const existing = rpcClients.get(chainId)
+  if (existing) {
+    return existing
+  }
+
+  const chain = chains.find((candidate) => candidate.id === chainId)
+  if (!chain) {
+    throw new Error(`Unknown chain id: ${chainId}`)
+  }
+
+  const client = createPublicClient({
+    chain,
+    transport: http(getRpcUrl(chain))
+  })
+  rpcClients.set(chainId, client)
+  return client
+}
+
+function normalizeAddress(value: unknown): Address | undefined {
+  if (typeof value !== 'string') {
+    return undefined
+  }
+
+  try {
+    return getAddress(value)
+  } catch {
+    return undefined
+  }
+}
+
+function normalizeAddressArray(value: unknown): Address[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value
+    .map((item) => normalizeAddress(item))
+    .filter((item): item is Address => !!item && item !== ZERO_ADDRESS)
+}
+
+function buildYieldSplitterDescription(
+  splitter: TYieldSplitterLogRow,
+  asset?: TAssetLike | null
+): string {
+  const depositAssetLabel = asset?.symbol || asset?.name || 'the deposit asset'
+  const sourceVaultLabel = splitter.sourceVaultSymbol || splitter.sourceVaultName || 'the source vault'
+  const wantVaultLabel = splitter.wantVaultSymbol || splitter.wantVaultName || 'the target vault'
+
+  return `Deposit ${depositAssetLabel}; principal is routed through ${sourceVaultLabel} and yield accrues in ${wantVaultLabel}.`
+}
+
+async function fetchYieldSplitterLogRows(): Promise<TYieldSplitterLogRow[]> {
+  const result = await db.query(`
+    SELECT DISTINCT
+      evmlog.chain_id AS "chainId",
+      evmlog.args->>'strategy' AS "splitterAddress",
+      evmlog.args->>'vault' AS "sourceVaultAddress",
+      COALESCE(
+        source_thing.defaults->>'name',
+        source_snapshot.snapshot->>'name',
+        source_snapshot.hook->'meta'->>'displayName'
+      ) AS "sourceVaultName",
+      COALESCE(
+        source_snapshot.snapshot->>'symbol',
+        source_snapshot.hook->'meta'->>'displaySymbol'
+      ) AS "sourceVaultSymbol",
+      evmlog.args->>'want' AS "wantVaultAddress",
+      COALESCE(
+        want_thing.defaults->>'name',
+        want_snapshot.snapshot->>'name',
+        want_snapshot.hook->'meta'->>'displayName'
+      ) AS "wantVaultName",
+      COALESCE(
+        want_snapshot.snapshot->>'symbol',
+        want_snapshot.hook->'meta'->>'displaySymbol'
+      ) AS "wantVaultSymbol"
+    FROM evmlog
+    LEFT JOIN thing AS source_thing
+      ON source_thing.chain_id = evmlog.chain_id
+      AND source_thing.address = evmlog.args->>'vault'
+      AND source_thing.label = 'vault'
+    LEFT JOIN snapshot AS source_snapshot
+      ON source_snapshot.chain_id = evmlog.chain_id
+      AND source_snapshot.address = evmlog.args->>'vault'
+    LEFT JOIN thing AS want_thing
+      ON want_thing.chain_id = evmlog.chain_id
+      AND want_thing.address = evmlog.args->>'want'
+      AND want_thing.label = 'vault'
+    LEFT JOIN snapshot AS want_snapshot
+      ON want_snapshot.chain_id = evmlog.chain_id
+      AND want_snapshot.address = evmlog.args->>'want'
+    WHERE evmlog.event_name = 'NewYieldSplitter'
+  `)
+
+  const mappedRows: Array<TYieldSplitterLogRow | null> = result.rows
+    .map((row) => {
+      const splitterAddress = normalizeAddress(row.splitterAddress)
+      const sourceVaultAddress = normalizeAddress(row.sourceVaultAddress)
+      const wantVaultAddress = normalizeAddress(row.wantVaultAddress)
+
+      if (!splitterAddress || !sourceVaultAddress || !wantVaultAddress) {
+        return null
+      }
+
+      return {
+        chainId: Number(row.chainId),
+        splitterAddress,
+        sourceVaultAddress,
+        sourceVaultName: typeof row.sourceVaultName === 'string' ? row.sourceVaultName : undefined,
+        sourceVaultSymbol: typeof row.sourceVaultSymbol === 'string' ? row.sourceVaultSymbol : undefined,
+        wantVaultAddress,
+        wantVaultName: typeof row.wantVaultName === 'string' ? row.wantVaultName : undefined,
+        wantVaultSymbol: typeof row.wantVaultSymbol === 'string' ? row.wantVaultSymbol : undefined
+      }
+    })
+
+  return mappedRows.filter((row): row is TYieldSplitterLogRow => row !== null)
+}
+
+async function fetchYieldSplitterDynamicRows(
+  splitters: TYieldSplitterLogRow[]
+): Promise<Map<string, TYieldSplitterDynamicRow>> {
+  const rowsByKey = new Map<string, TYieldSplitterDynamicRow>()
+  const rowsByChain = splitters.reduce((accumulator, splitter) => {
+    if (!accumulator.has(splitter.chainId)) {
+      accumulator.set(splitter.chainId, [])
+    }
+    accumulator.get(splitter.chainId)?.push(splitter)
+    return accumulator
+  }, new Map<number, TYieldSplitterLogRow[]>())
+
+  await Promise.all(
+    Array.from(rowsByChain.entries()).map(async ([chainId, chainSplitters]) => {
+      const client = getRpcClient(chainId)
+      const contracts = chainSplitters.flatMap((splitter) => [
+        {
+          address: splitter.splitterAddress,
+          abi: YIELD_SPLITTER_ABI,
+          functionName: 'rewardHandler' as const
+        },
+        {
+          address: splitter.splitterAddress,
+          abi: YIELD_SPLITTER_ABI,
+          functionName: 'tokenizedStrategyAddress' as const
+        },
+        {
+          address: splitter.splitterAddress,
+          abi: YIELD_SPLITTER_ABI,
+          functionName: 'getRewardTokens' as const
+        }
+      ])
+
+      const results = await client.multicall({
+        contracts,
+        allowFailure: true
+      })
+
+      chainSplitters.forEach((splitter, index) => {
+        const rewardHandler = results[index * 3]
+        const tokenizedStrategy = results[index * 3 + 1]
+        const rewardTokens = results[index * 3 + 2]
+        const splitterKey = `${splitter.chainId}:${splitter.splitterAddress.toLowerCase()}`
+
+        rowsByKey.set(splitterKey, {
+          rewardHandlerAddress:
+            rewardHandler?.status === 'success' ? normalizeAddress(rewardHandler.result) : undefined,
+          tokenizedStrategyAddress:
+            tokenizedStrategy?.status === 'success' ? normalizeAddress(tokenizedStrategy.result) : undefined,
+          rewardTokenAddresses:
+            rewardTokens?.status === 'success' ? normalizeAddressArray(rewardTokens.result) : []
+        })
+      })
+    })
+  )
+
+  return rowsByKey
+}
+
+async function loadYieldSplitterData(): Promise<TCachedYieldSplitterData> {
+  const logRows = await fetchYieldSplitterLogRows()
+  if (logRows.length === 0) {
+    return new Map()
+  }
+
+  const dynamicRows = await fetchYieldSplitterDynamicRows(logRows)
+  return logRows.reduce((accumulator, row) => {
+    const key = `${row.chainId}:${row.splitterAddress.toLowerCase()}`
+    accumulator.set(key, {
+      ...row,
+      ...(dynamicRows.get(key) ?? {
+        rewardTokenAddresses: []
+      })
+    })
+    return accumulator
+  }, new Map<string, TYieldSplitterLogRow & TYieldSplitterDynamicRow>())
+}
+
+async function getYieldSplitterData(): Promise<TCachedYieldSplitterData> {
+  const now = Date.now()
+  if (cachedYieldSplitters && cachedYieldSplitters.expiresAt > now) {
+    return cachedYieldSplitters.data
+  }
+
+  if (!cachedYieldSplittersPromise) {
+    cachedYieldSplittersPromise = loadYieldSplitterData()
+      .then((data) => {
+        cachedYieldSplitters = {
+          expiresAt: Date.now() + CACHE_TTL_MS,
+          data
+        }
+        return data
+      })
+      .finally(() => {
+        cachedYieldSplittersPromise = undefined
+      })
+  }
+
+  return cachedYieldSplittersPromise
+}
+
+function attachYieldSplitterRow<T extends TAddressRow>(
+  row: T,
+  yieldSplitters: TCachedYieldSplitterData
+): T & { yieldSplitter?: YieldSplitterMetadata } {
+  const key = `${row.chainId}:${row.address.toLowerCase()}`
+  const splitter = yieldSplitters.get(key)
+  if (!splitter) {
+    return row
+  }
+
+  const depositAssetAddress = normalizeAddress(row.asset?.address)
+  const yieldSplitter: YieldSplitterMetadata = {
+    enabled: true,
+    sourceVaultAddress: splitter.sourceVaultAddress,
+    sourceVaultName: splitter.sourceVaultName,
+    sourceVaultSymbol: splitter.sourceVaultSymbol,
+    wantVaultAddress: splitter.wantVaultAddress,
+    wantVaultName: splitter.wantVaultName,
+    wantVaultSymbol: splitter.wantVaultSymbol,
+    depositAssetAddress,
+    depositAssetName: row.asset?.name ?? undefined,
+    depositAssetSymbol: row.asset?.symbol ?? undefined,
+    rewardTokenAddresses: splitter.rewardTokenAddresses,
+    rewardHandlerAddress: splitter.rewardHandlerAddress,
+    tokenizedStrategyAddress: splitter.tokenizedStrategyAddress,
+    displayType: 'Yield Splitter',
+    displayKind: 'Vault-to-Vault',
+    uiDescription: buildYieldSplitterDescription(splitter, row.asset)
+  }
+
+  return {
+    ...row,
+    yieldSplitter
+  }
+}
+
+export async function attachYieldSplitterMetadata<T extends TAddressRow>(
+  rows: T[]
+): Promise<Array<T & { yieldSplitter?: YieldSplitterMetadata }>> {
+  if (rows.length === 0) {
+    return []
+  }
+
+  const yieldSplitters = await getYieldSplitterData()
+  return rows.map((row) => attachYieldSplitterRow(row, yieldSplitters))
+}
+
+export async function attachYieldSplitterMetadataToRow<T extends TAddressRow>(
+  row: T
+): Promise<T & { yieldSplitter?: YieldSplitterMetadata }> {
+  const yieldSplitters = await getYieldSplitterData()
+  return attachYieldSplitterRow(row, yieldSplitters)
+}

--- a/packages/web/app/api/yieldSplitters.ts
+++ b/packages/web/app/api/yieldSplitters.ts
@@ -1,6 +1,7 @@
 import db from './db'
-import chains from 'lib/chains'
-import { createPublicClient, getAddress, http, type Address, type Chain, type PublicClient } from 'viem'
+import chains from '@/chains'
+import { ACTIVE_YIELD_SPLITTER_FACTORIES } from './yieldSplitterConfig'
+import { createPublicClient, getAddress, http, keccak256, toBytes, type Address, type Chain, type PublicClient } from 'viem'
 
 type TAssetLike = {
   address?: string | null
@@ -31,6 +32,11 @@ type TYieldSplitterDynamicRow = {
   rewardTokenAddresses: Address[]
 }
 
+type TYieldSplitterLogQuery = {
+  chainId?: number
+  splitterAddress?: Address
+}
+
 export type YieldSplitterMetadata = {
   enabled: true
   sourceVaultAddress: Address
@@ -51,6 +57,10 @@ export type YieldSplitterMetadata = {
 }
 
 type TCachedYieldSplitterData = Map<string, TYieldSplitterLogRow & TYieldSplitterDynamicRow>
+type TCachedTargetedYieldSplitter = {
+  expiresAt: number
+  data: TYieldSplitterLogRow & TYieldSplitterDynamicRow | null
+}
 
 const YIELD_SPLITTER_ABI = [
   {
@@ -77,10 +87,13 @@ const YIELD_SPLITTER_ABI = [
 ] as const
 
 const CACHE_TTL_MS = 5 * 60 * 1000
+const NEW_YIELD_SPLITTER_EVENT_SIGNATURE = keccak256(toBytes('NewYieldSplitter(address,address,address)'))
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 
 let cachedYieldSplitters: { expiresAt: number, data: TCachedYieldSplitterData } | undefined
 let cachedYieldSplittersPromise: Promise<TCachedYieldSplitterData> | undefined
+const cachedTargetedYieldSplitters = new Map<string, TCachedTargetedYieldSplitter>()
+const cachedTargetedYieldSplittersPromises = new Map<string, Promise<TCachedYieldSplitterData>>()
 const rpcClients = new Map<number, PublicClient>()
 
 function getRpcUrl(chain: Chain): string {
@@ -122,6 +135,11 @@ function normalizeAddress(value: unknown): Address | undefined {
   }
 }
 
+function normalizeOptionalAddress(value: unknown): Address | undefined {
+  const address = normalizeAddress(value)
+  return address && address !== ZERO_ADDRESS ? address : undefined
+}
+
 function normalizeAddressArray(value: unknown): Address[] {
   if (!Array.isArray(value)) {
     return []
@@ -143,7 +161,95 @@ function buildYieldSplitterDescription(
   return `Deposit ${depositAssetLabel}; principal is routed through ${sourceVaultLabel} and yield accrues in ${wantVaultLabel}.`
 }
 
-async function fetchYieldSplitterLogRows(): Promise<TYieldSplitterLogRow[]> {
+function buildActiveFactoryValuesClause(startIndex = 1): { clause: string, values: Array<number | string> } {
+  const values: Array<number | string> = []
+  const clause = ACTIVE_YIELD_SPLITTER_FACTORIES.map((factory) => {
+    values.push(factory.chainId)
+    const chainIdIndex = startIndex + values.length - 1
+    values.push(factory.address)
+    const addressIndex = startIndex + values.length - 1
+    return `($${chainIdIndex}::integer, $${addressIndex}::text)`
+  }).join(', ')
+
+  return { clause, values }
+}
+
+function buildYieldSplitterData(
+  logRows: TYieldSplitterLogRow[],
+  dynamicRows: Map<string, TYieldSplitterDynamicRow>
+): TCachedYieldSplitterData {
+  return logRows.reduce((accumulator, row) => {
+    const key = getYieldSplitterKey(row.chainId, row.splitterAddress)
+    accumulator.set(key, {
+      ...row,
+      ...(dynamicRows.get(key) ?? {
+        rewardTokenAddresses: []
+      })
+    })
+    return accumulator
+  }, new Map<string, TYieldSplitterLogRow & TYieldSplitterDynamicRow>())
+}
+
+function getYieldSplitterKey(chainId: number, splitterAddress: string): string {
+  return `${chainId}:${splitterAddress.toLowerCase()}`
+}
+
+function buildTargetedYieldSplitterData(
+  key: string,
+  data: TYieldSplitterLogRow & TYieldSplitterDynamicRow | null
+): TCachedYieldSplitterData {
+  if (!data) {
+    return new Map()
+  }
+
+  return new Map([[key, data]])
+}
+
+function getCachedYieldSplitterData(): TCachedYieldSplitterData | undefined {
+  const now = Date.now()
+  if (cachedYieldSplitters && cachedYieldSplitters.expiresAt > now) {
+    return cachedYieldSplitters.data
+  }
+
+  return undefined
+}
+
+function getCachedTargetedYieldSplitterData(key: string): TCachedYieldSplitterData | undefined {
+  const now = Date.now()
+  const cachedData = cachedTargetedYieldSplitters.get(key)
+  if (!cachedData) {
+    return undefined
+  }
+
+  if (cachedData.expiresAt <= now) {
+    cachedTargetedYieldSplitters.delete(key)
+    return undefined
+  }
+
+  return buildTargetedYieldSplitterData(key, cachedData.data)
+}
+
+async function fetchYieldSplitterLogRows(
+  query: TYieldSplitterLogQuery = {}
+): Promise<TYieldSplitterLogRow[]> {
+  if (ACTIVE_YIELD_SPLITTER_FACTORIES.length === 0) {
+    return []
+  }
+
+  const activeFactoryValues = buildActiveFactoryValuesClause()
+  const params: Array<number | string> = [...activeFactoryValues.values, NEW_YIELD_SPLITTER_EVENT_SIGNATURE]
+  const filters = [`evmlog.signature = $${params.length}`]
+
+  if (query.chainId !== undefined) {
+    params.push(query.chainId)
+    filters.push(`evmlog.chain_id = $${params.length}`)
+  }
+
+  if (query.splitterAddress !== undefined) {
+    params.push(query.splitterAddress)
+    filters.push(`evmlog.args->>'strategy' = $${params.length}`)
+  }
+
   const result = await db.query(`
     SELECT DISTINCT
       evmlog.chain_id AS "chainId",
@@ -169,6 +275,9 @@ async function fetchYieldSplitterLogRows(): Promise<TYieldSplitterLogRow[]> {
         want_snapshot.hook->'meta'->>'displaySymbol'
       ) AS "wantVaultSymbol"
     FROM evmlog
+    JOIN (VALUES ${activeFactoryValues.clause}) AS active_factory(chain_id, address)
+      ON active_factory.chain_id = evmlog.chain_id
+      AND active_factory.address = evmlog.address
     LEFT JOIN thing AS source_thing
       ON source_thing.chain_id = evmlog.chain_id
       AND source_thing.address = evmlog.args->>'vault'
@@ -183,8 +292,8 @@ async function fetchYieldSplitterLogRows(): Promise<TYieldSplitterLogRow[]> {
     LEFT JOIN snapshot AS want_snapshot
       ON want_snapshot.chain_id = evmlog.chain_id
       AND want_snapshot.address = evmlog.args->>'want'
-    WHERE evmlog.event_name = 'NewYieldSplitter'
-  `)
+    WHERE ${filters.join('\n      AND ')}
+  `, params)
 
   const mappedRows: Array<TYieldSplitterLogRow | null> = result.rows
     .map((row) => {
@@ -215,6 +324,14 @@ async function fetchYieldSplitterDynamicRows(
   splitters: TYieldSplitterLogRow[]
 ): Promise<Map<string, TYieldSplitterDynamicRow>> {
   const rowsByKey = new Map<string, TYieldSplitterDynamicRow>()
+  const setDefaultDynamicRows = (chainSplitters: TYieldSplitterLogRow[]) => {
+    chainSplitters.forEach((splitter) => {
+      const splitterKey = `${splitter.chainId}:${splitter.splitterAddress.toLowerCase()}`
+      rowsByKey.set(splitterKey, {
+        rewardTokenAddresses: []
+      })
+    })
+  }
   const rowsByChain = splitters.reduce((accumulator, splitter) => {
     if (!accumulator.has(splitter.chainId)) {
       accumulator.set(splitter.chainId, [])
@@ -225,45 +342,50 @@ async function fetchYieldSplitterDynamicRows(
 
   await Promise.all(
     Array.from(rowsByChain.entries()).map(async ([chainId, chainSplitters]) => {
-      const client = getRpcClient(chainId)
-      const contracts = chainSplitters.flatMap((splitter) => [
-        {
-          address: splitter.splitterAddress,
-          abi: YIELD_SPLITTER_ABI,
-          functionName: 'rewardHandler' as const
-        },
-        {
-          address: splitter.splitterAddress,
-          abi: YIELD_SPLITTER_ABI,
-          functionName: 'tokenizedStrategyAddress' as const
-        },
-        {
-          address: splitter.splitterAddress,
-          abi: YIELD_SPLITTER_ABI,
-          functionName: 'getRewardTokens' as const
-        }
-      ])
+      try {
+        const client = getRpcClient(chainId)
+        const contracts = chainSplitters.flatMap((splitter) => [
+          {
+            address: splitter.splitterAddress,
+            abi: YIELD_SPLITTER_ABI,
+            functionName: 'rewardHandler' as const
+          },
+          {
+            address: splitter.splitterAddress,
+            abi: YIELD_SPLITTER_ABI,
+            functionName: 'tokenizedStrategyAddress' as const
+          },
+          {
+            address: splitter.splitterAddress,
+            abi: YIELD_SPLITTER_ABI,
+            functionName: 'getRewardTokens' as const
+          }
+        ])
 
-      const results = await client.multicall({
-        contracts,
-        allowFailure: true
-      })
-
-      chainSplitters.forEach((splitter, index) => {
-        const rewardHandler = results[index * 3]
-        const tokenizedStrategy = results[index * 3 + 1]
-        const rewardTokens = results[index * 3 + 2]
-        const splitterKey = `${splitter.chainId}:${splitter.splitterAddress.toLowerCase()}`
-
-        rowsByKey.set(splitterKey, {
-          rewardHandlerAddress:
-            rewardHandler?.status === 'success' ? normalizeAddress(rewardHandler.result) : undefined,
-          tokenizedStrategyAddress:
-            tokenizedStrategy?.status === 'success' ? normalizeAddress(tokenizedStrategy.result) : undefined,
-          rewardTokenAddresses:
-            rewardTokens?.status === 'success' ? normalizeAddressArray(rewardTokens.result) : []
+        const results = await client.multicall({
+          contracts,
+          allowFailure: true
         })
-      })
+
+        chainSplitters.forEach((splitter, index) => {
+          const rewardHandler = results[index * 3]
+          const tokenizedStrategy = results[index * 3 + 1]
+          const rewardTokens = results[index * 3 + 2]
+          const splitterKey = `${splitter.chainId}:${splitter.splitterAddress.toLowerCase()}`
+
+          rowsByKey.set(splitterKey, {
+            rewardHandlerAddress:
+              rewardHandler?.status === 'success' ? normalizeOptionalAddress(rewardHandler.result) : undefined,
+            tokenizedStrategyAddress:
+              tokenizedStrategy?.status === 'success' ? normalizeOptionalAddress(tokenizedStrategy.result) : undefined,
+            rewardTokenAddresses:
+              rewardTokens?.status === 'success' ? normalizeAddressArray(rewardTokens.result) : []
+          })
+        })
+      } catch (error) {
+        console.error(`Failed to load yield splitter dynamic metadata for chain ${chainId}`, error)
+        setDefaultDynamicRows(chainSplitters)
+      }
     })
   )
 
@@ -277,16 +399,7 @@ async function loadYieldSplitterData(): Promise<TCachedYieldSplitterData> {
   }
 
   const dynamicRows = await fetchYieldSplitterDynamicRows(logRows)
-  return logRows.reduce((accumulator, row) => {
-    const key = `${row.chainId}:${row.splitterAddress.toLowerCase()}`
-    accumulator.set(key, {
-      ...row,
-      ...(dynamicRows.get(key) ?? {
-        rewardTokenAddresses: []
-      })
-    })
-    return accumulator
-  }, new Map<string, TYieldSplitterLogRow & TYieldSplitterDynamicRow>())
+  return buildYieldSplitterData(logRows, dynamicRows)
 }
 
 async function getYieldSplitterData(): Promise<TCachedYieldSplitterData> {
@@ -302,6 +415,7 @@ async function getYieldSplitterData(): Promise<TCachedYieldSplitterData> {
           expiresAt: Date.now() + CACHE_TTL_MS,
           data
         }
+        cachedTargetedYieldSplitters.clear()
         return data
       })
       .finally(() => {
@@ -312,17 +426,76 @@ async function getYieldSplitterData(): Promise<TCachedYieldSplitterData> {
   return cachedYieldSplittersPromise
 }
 
+async function getYieldSplitterDataForRow<T extends TAddressRow>(
+  row: T
+): Promise<TCachedYieldSplitterData> {
+  const cachedData = getCachedYieldSplitterData()
+  if (cachedData) {
+    return cachedData
+  }
+
+  if (cachedYieldSplittersPromise) {
+    return cachedYieldSplittersPromise
+  }
+
+  const splitterAddress = normalizeAddress(row.address)
+  if (!splitterAddress) {
+    return new Map()
+  }
+
+  const key = getYieldSplitterKey(row.chainId, splitterAddress)
+  const cachedTargetedData = getCachedTargetedYieldSplitterData(key)
+  if (cachedTargetedData) {
+    return cachedTargetedData
+  }
+
+  const cachedPromise = cachedTargetedYieldSplittersPromises.get(key)
+  if (cachedPromise) {
+    return cachedPromise
+  }
+
+  const targetedPromise = fetchYieldSplitterLogRows({
+    chainId: row.chainId,
+    splitterAddress
+  })
+    .then(async (logRows) => {
+      if (logRows.length === 0) {
+        cachedTargetedYieldSplitters.set(key, {
+          expiresAt: Date.now() + CACHE_TTL_MS,
+          data: null
+        })
+        return new Map()
+      }
+
+      const dynamicRows = await fetchYieldSplitterDynamicRows(logRows)
+      const yieldSplitters = buildYieldSplitterData(logRows, dynamicRows)
+
+      cachedTargetedYieldSplitters.set(key, {
+        expiresAt: Date.now() + CACHE_TTL_MS,
+        data: yieldSplitters.get(key) ?? null
+      })
+
+      return yieldSplitters
+    })
+    .finally(() => {
+      cachedTargetedYieldSplittersPromises.delete(key)
+    })
+
+  cachedTargetedYieldSplittersPromises.set(key, targetedPromise)
+  return targetedPromise
+}
+
 function attachYieldSplitterRow<T extends TAddressRow>(
   row: T,
   yieldSplitters: TCachedYieldSplitterData
 ): T & { yieldSplitter?: YieldSplitterMetadata } {
-  const key = `${row.chainId}:${row.address.toLowerCase()}`
+  const key = getYieldSplitterKey(row.chainId, row.address)
   const splitter = yieldSplitters.get(key)
   if (!splitter) {
     return row
   }
 
-  const depositAssetAddress = normalizeAddress(row.asset?.address)
+  const depositAssetAddress = normalizeOptionalAddress(row.asset?.address)
   const yieldSplitter: YieldSplitterMetadata = {
     enabled: true,
     sourceVaultAddress: splitter.sourceVaultAddress,
@@ -363,5 +536,16 @@ export async function attachYieldSplitterMetadataToRow<T extends TAddressRow>(
   row: T
 ): Promise<T & { yieldSplitter?: YieldSplitterMetadata }> {
   const yieldSplitters = await getYieldSplitterData()
+  return attachYieldSplitterRow(row, yieldSplitters)
+}
+
+export async function primeYieldSplitterCache(): Promise<void> {
+  await getYieldSplitterData()
+}
+
+export async function attachYieldSplitterMetadataToRowTargeted<T extends TAddressRow>(
+  row: T
+): Promise<T & { yieldSplitter?: YieldSplitterMetadata }> {
+  const yieldSplitters = await getYieldSplitterDataForRow(row)
   return attachYieldSplitterRow(row, yieldSplitters)
 }


### PR DESCRIPTION
## What changed
Add `yieldSplitter` metadata to vault responses across the web API.

This includes:
- GraphQL schema support for `Vault.yieldSplitter`
- lazy GraphQL field resolution so hot top-level vault queries do not eagerly hydrate splitter data
- REST list and snapshot enrichment for yield splitters
- Katana yield-splitter discovery, dynamic contract reads, and cache handling
- targeted single-vault lookup behavior plus cache priming for snapshot refreshes

## Why
Clients need a structured way to identify yield-splitter vaults and render their source vault, target vault, reward token, and strategy metadata.

The follow-up work on this branch also fixes review issues uncovered during implementation:
- degrade gracefully on chain-specific RPC failures
- avoid widening hot GraphQL paths
- keep the web app independent of repo-root YAML config loaders
- normalize zero-address optional fields
- avoid cold-path regressions in single-vault and snapshot-refresh flows

## Impact
- GraphQL clients can request `yieldSplitter` from `Vault`
- REST consumers get yield-splitter metadata in list and snapshot payloads
- single-vault reads stay lazy and targeted
- snapshot refresh avoids repeated per-vault splitter misses once the cache is primed

## Root cause
Yield-splitter metadata was not previously modeled in the web API, so clients had no typed way to distinguish these vaults or understand their vault-to-vault routing.

## Validation
- `bun test` in `packages/web`
- `bunx tsc -p tsconfig.json --noEmit` in `packages/web`
- `bun run lint` in `packages/web`

Lint still shows the pre-existing warning in `packages/web/components/LatestBlocks.tsx` for an unused `index` variable.
