### PR TITLE
Add netAPR and netAPY to vault list REST endpoint

### DIFF
--- a/packages/web/app/api/rest/list/db.ts
+++ b/packages/web/app/api/rest/list/db.ts
@@ -30,7 +30,9 @@ export const VaultListItemSchema = z.object({
   performance: z.object({
     oracle: z.object({
       apr: CoerceNumber,
+      netAPR: CoerceNumber,
       apy: CoerceNumber,
+      netAPY: CoerceNumber,
     }).nullish(),
     historical: z.object({
       net: CoerceNumber,


### PR DESCRIPTION
## Summary

- Adds `netAPR` and `netAPY` to the `performance.oracle` object in the `GET /api/rest/list/vaults` REST endpoint
- The snapshot hook already computes these values, but the Zod schema was stripping them out — this adds them to the schema so they pass through

**Before:**
```json
"performance": {
  "oracle": {
    "apr": 0.0375,
    "apy": 0.0382
  }
}
```

**After:**
```json
"performance": {
  "oracle": {
    "apr": 0.0375,
    "netAPR": 0.0341,
    "apy": 0.0382,
    "netAPY": 0.0347
  }
}
```

## Test plan

- [ ] Configure `packages/web/.env.local` to point to the read replica database and Redis
```
POSTGRES_HOST=<read-replica-host>
POSTGRES_DATABASE=<database>
POSTGRES_USER=<user>
POSTGRES_PASSWORD=<password>
POSTGRES_SSL=true
POSTGRES_PORT=5432
REST_CACHE_REDIS_URL=redis://localhost:6379
```

- [ ] Start Redis
```
docker start redis 2>/dev/null || docker run -d --name redis -p 6379:6379 redis
```

- [ ] Refresh the list cache
```
cd packages/web && bun run app/api/rest/list/refresh.ts
```
Expected: `✓ Completed: <N> vaults cached across <N> chains`

- [ ] Verify `netAPR` and `netAPY` are present in the response
```
curl -s http://localhost:3000/api/rest/list/vaults/1 | jq '.value[0].performance.oracle'
```
Expected: response includes all four fields — `apr`, `netAPR`, `apy`, `netAPY`
```json
{
  "apr": <number or null>,
  "netAPR": <number or null>,
  "apy": <number or null>,
  "netAPY": <number or null>
}
```

- [ ] Verify the all-chains endpoint also includes the fields
```
curl -s http://localhost:3000/api/rest/list/vaults | jq '[.value[] | select(.performance.oracle.netAPR != null)] | length'
```
Expected: a non-zero count of vaults with `netAPR` populated

- [ ] Verify snapshot endpoint already has matching values (cross-check)
```
VAULT=$(curl -s http://localhost:3000/api/rest/list/vaults/1 | jq -r '.value[0].address')
curl -s "http://localhost:3000/api/rest/snapshot/1/$VAULT" | jq '.performance.oracle'
```
Expected: `netAPR` and `netAPY` values match between list and snapshot endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)