### PR TITLE
ci: add retry job to refresh cron workflows

### DIFF
--- a/.github/workflows/refresh-lists.yml
+++ b/.github/workflows/refresh-lists.yml
@@ -25,11 +25,38 @@ jobs:
           POSTGRES_POOL_MAX: ${{ vars.POSTGRES_POOL_MAX }}
           REST_CACHE_REDIS_URL: ${{ secrets.REST_CACHE_REDIS_URL }}
         run: bun packages/web/app/api/rest/list/refresh.ts
+
+  refresh_retry:
+    needs: refresh
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v1
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Refresh lists cache
+        env:
+          POSTGRES_HOST: ${{ secrets.POSTGRES_HOST }}
+          POSTGRES_DATABASE: ${{ secrets.POSTGRES_DATABASE }}
+          POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+          POSTGRES_PORT: ${{ secrets.POSTGRES_PORT }}
+          POSTGRES_SSL: ${{ secrets.POSTGRES_SSL }}
+          POSTGRES_POOL_MAX: ${{ vars.POSTGRES_POOL_MAX }}
+          REST_CACHE_REDIS_URL: ${{ secrets.REST_CACHE_REDIS_URL }}
+        run: bun packages/web/app/api/rest/list/refresh.ts
+
+  notify:
+    needs: [refresh, refresh_retry]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
       - name: Report success to Uptime Kuma
-        if: success()
+        if: needs.refresh.result == 'success' || needs.refresh_retry.result == 'success'
         continue-on-error: true
         run: curl -fsS -m 10 -o /dev/null "${{ secrets.UPTIME_KUMA_PUSH_URL_REFRESH_LISTS }}?status=up&msg=OK"
       - name: Report failure to Uptime Kuma
-        if: failure()
+        if: needs.refresh.result != 'success' && needs.refresh_retry.result != 'success'
         continue-on-error: true
         run: curl -fsS -m 10 -o /dev/null "${{ secrets.UPTIME_KUMA_PUSH_URL_REFRESH_LISTS }}?status=down&msg=Run+failed"

--- a/.github/workflows/reports-refresh-historical.yml
+++ b/.github/workflows/reports-refresh-historical.yml
@@ -30,3 +30,30 @@ jobs:
           POSTGRES_POOL_MAX: ${{ vars.POSTGRES_POOL_MAX }}
           REST_CACHE_REDIS_URL: ${{ secrets.REST_CACHE_REDIS_URL }}
         run: bun packages/web/app/api/rest/reports/refresh-historical.ts
+
+  refresh_retry:
+    needs: refresh
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run Refresh Script
+        env:
+          POSTGRES_HOST: ${{ secrets.POSTGRES_HOST }}
+          POSTGRES_DATABASE: ${{ secrets.POSTGRES_DATABASE }}
+          POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+          POSTGRES_PORT: ${{ secrets.POSTGRES_PORT }}
+          POSTGRES_SSL: ${{ secrets.POSTGRES_SSL }}
+          POSTGRES_POOL_MAX: ${{ vars.POSTGRES_POOL_MAX }}
+          REST_CACHE_REDIS_URL: ${{ secrets.REST_CACHE_REDIS_URL }}
+        run: bun packages/web/app/api/rest/reports/refresh-historical.ts

--- a/.github/workflows/reports-refresh.yml
+++ b/.github/workflows/reports-refresh.yml
@@ -30,11 +30,44 @@ jobs:
           POSTGRES_POOL_MAX: ${{ vars.POSTGRES_POOL_MAX }}
           REST_CACHE_REDIS_URL: ${{ secrets.REST_CACHE_REDIS_URL }}
         run: bun packages/web/app/api/rest/reports/refresh.ts
+
+  refresh_retry:
+    needs: refresh
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run Refresh Script
+        env:
+          POSTGRES_HOST: ${{ secrets.POSTGRES_HOST }}
+          POSTGRES_DATABASE: ${{ secrets.POSTGRES_DATABASE }}
+          POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+          POSTGRES_PORT: ${{ secrets.POSTGRES_PORT }}
+          POSTGRES_SSL: ${{ secrets.POSTGRES_SSL }}
+          POSTGRES_POOL_MAX: ${{ vars.POSTGRES_POOL_MAX }}
+          REST_CACHE_REDIS_URL: ${{ secrets.REST_CACHE_REDIS_URL }}
+        run: bun packages/web/app/api/rest/reports/refresh.ts
+
+  notify:
+    needs: [refresh, refresh_retry]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
       - name: Report success to Uptime Kuma
-        if: success()
+        if: needs.refresh.result == 'success' || needs.refresh_retry.result == 'success'
         continue-on-error: true
         run: curl -fsS -m 10 -o /dev/null "${{ secrets.UPTIME_KUMA_PUSH_URL_REPORTS_REFRESH }}?status=up&msg=OK"
       - name: Report failure to Uptime Kuma
-        if: failure()
+        if: needs.refresh.result != 'success' && needs.refresh_retry.result != 'success'
         continue-on-error: true
         run: curl -fsS -m 10 -o /dev/null "${{ secrets.UPTIME_KUMA_PUSH_URL_REPORTS_REFRESH }}?status=down&msg=Run+failed"

--- a/.github/workflows/snapshot-refresh.yml
+++ b/.github/workflows/snapshot-refresh.yml
@@ -24,11 +24,38 @@ jobs:
           POSTGRES_POOL_MAX: ${{ vars.POSTGRES_POOL_MAX }}
           REST_CACHE_REDIS_URL: ${{ secrets.REST_CACHE_REDIS_URL }}
         run: bun packages/web/app/api/rest/snapshot/refresh-snapshot.ts
+
+  refresh_retry:
+    needs: refresh
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v1
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Refresh snapshot cache
+        env:
+          POSTGRES_HOST: ${{ secrets.POSTGRES_HOST }}
+          POSTGRES_DATABASE: ${{ secrets.POSTGRES_DATABASE }}
+          POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+          POSTGRES_PORT: ${{ secrets.POSTGRES_PORT }}
+          POSTGRES_SSL: ${{ secrets.POSTGRES_SSL }}
+          POSTGRES_POOL_MAX: ${{ vars.POSTGRES_POOL_MAX }}
+          REST_CACHE_REDIS_URL: ${{ secrets.REST_CACHE_REDIS_URL }}
+        run: bun packages/web/app/api/rest/snapshot/refresh-snapshot.ts
+
+  notify:
+    needs: [refresh, refresh_retry]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
       - name: Report success to Uptime Kuma
-        if: success()
+        if: needs.refresh.result == 'success' || needs.refresh_retry.result == 'success'
         continue-on-error: true
         run: curl -fsS -m 10 -o /dev/null "${{ secrets.UPTIME_KUMA_PUSH_URL_SNAPSHOT_REFRESH }}?status=up&msg=OK"
       - name: Report failure to Uptime Kuma
-        if: failure()
+        if: needs.refresh.result != 'success' && needs.refresh_retry.result != 'success'
         continue-on-error: true
         run: curl -fsS -m 10 -o /dev/null "${{ secrets.UPTIME_KUMA_PUSH_URL_SNAPSHOT_REFRESH }}?status=down&msg=Run+failed"

--- a/.github/workflows/timeseries-refresh-historical.yml
+++ b/.github/workflows/timeseries-refresh-historical.yml
@@ -24,3 +24,24 @@ jobs:
           POSTGRES_POOL_MAX: ${{ vars.POSTGRES_POOL_MAX }}
           REST_CACHE_REDIS_URL: ${{ secrets.REST_CACHE_REDIS_URL }}
         run: bun packages/web/app/api/rest/timeseries/refresh-historical.ts
+
+  refresh_retry:
+    needs: refresh
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v1
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Refresh timeseries historical cache
+        env:
+          POSTGRES_HOST: ${{ secrets.POSTGRES_HOST }}
+          POSTGRES_DATABASE: ${{ secrets.POSTGRES_DATABASE }}
+          POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+          POSTGRES_PORT: ${{ secrets.POSTGRES_PORT }}
+          POSTGRES_SSL: ${{ secrets.POSTGRES_SSL }}
+          POSTGRES_POOL_MAX: ${{ vars.POSTGRES_POOL_MAX }}
+          REST_CACHE_REDIS_URL: ${{ secrets.REST_CACHE_REDIS_URL }}
+        run: bun packages/web/app/api/rest/timeseries/refresh-historical.ts

--- a/.github/workflows/timeseries-refresh.yml
+++ b/.github/workflows/timeseries-refresh.yml
@@ -24,11 +24,38 @@ jobs:
           POSTGRES_POOL_MAX: ${{ vars.POSTGRES_POOL_MAX }}
           REST_CACHE_REDIS_URL: ${{ secrets.REST_CACHE_REDIS_URL }}
         run: bun packages/web/app/api/rest/timeseries/refresh.ts
+
+  refresh_retry:
+    needs: refresh
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v1
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Refresh timeseries cache
+        env:
+          POSTGRES_HOST: ${{ secrets.POSTGRES_HOST }}
+          POSTGRES_DATABASE: ${{ secrets.POSTGRES_DATABASE }}
+          POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+          POSTGRES_PORT: ${{ secrets.POSTGRES_PORT }}
+          POSTGRES_SSL: ${{ secrets.POSTGRES_SSL }}
+          POSTGRES_POOL_MAX: ${{ vars.POSTGRES_POOL_MAX }}
+          REST_CACHE_REDIS_URL: ${{ secrets.REST_CACHE_REDIS_URL }}
+        run: bun packages/web/app/api/rest/timeseries/refresh.ts
+
+  notify:
+    needs: [refresh, refresh_retry]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
       - name: Report success to Uptime Kuma
-        if: success()
+        if: needs.refresh.result == 'success' || needs.refresh_retry.result == 'success'
         continue-on-error: true
         run: curl -fsS -m 10 -o /dev/null "${{ secrets.UPTIME_KUMA_PUSH_URL_TIMESERIES_REFRESH }}?status=up&msg=OK"
       - name: Report failure to Uptime Kuma
-        if: failure()
+        if: needs.refresh.result != 'success' && needs.refresh_retry.result != 'success'
         continue-on-error: true
         run: curl -fsS -m 10 -o /dev/null "${{ secrets.UPTIME_KUMA_PUSH_URL_TIMESERIES_REFRESH }}?status=down&msg=Run+failed"


### PR DESCRIPTION
## Summary
- Adds a `refresh_retry` job to each refresh workflow (lists, snapshot, timeseries, reports, and both historical variants) that runs only when the primary `refresh` job fails. This absorbs transient GitHub infra failures like action-download errors (e.g. `Failed to download archive '.../oven-sh/setup-bun/...'`).
- Consolidates Uptime Kuma reporting into a final `notify` job so success/failure is based on whether *either* attempt succeeded, instead of firing from the primary job that just failed.
- Historical workflows get the retry job but no notify job, since they didn't have Uptime Kuma reporting before.

## Test plan

- [ ] Trigger `refresh-lists` manually and confirm only the `refresh` job runs on success
\`\`\`
gh workflow run refresh-lists.yml
gh run list --workflow=refresh-lists.yml --limit 1
\`\`\`
Expected: single run with `refresh` + `notify` jobs, no retry job executed.

- [ ] Simulate failure (temporarily break the refresh command on a test branch) and confirm `refresh_retry` runs
\`\`\`
gh workflow run refresh-lists.yml --ref <test-branch>
gh run view <run-id>
\`\`\`
Expected: `refresh` fails, `refresh_retry` runs, `notify` reports based on retry result.

- [ ] Verify Uptime Kuma gets exactly one status update per workflow run (no duplicates from both attempts reporting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)