### PR TITLE
fix: floor net APR at half gross APR

### DIFF
--- a/packages/ingest/abis/yearn/lib/apy.spec.ts
+++ b/packages/ingest/abis/yearn/lib/apy.spec.ts
@@ -210,6 +210,10 @@ describe('abis/yearn/lib/apy', function() {
       expect(computeNetApr(0, { management: 0, performance: 0.20 })).to.equal(0)
     })
 
+    it('returns zero for negative gross APR', function() {
+      expect(computeNetApr(-0.01, { management: 0.0025, performance: 0.10 })).to.equal(0)
+    })
+
     it('floors net APR at half gross APR when fees exceed gross APR', function() {
       const gross = 0.00076638918973244
       expect(computeNetApr(gross, { management: 0.0025, performance: 0.10 })).to.equal(gross / 2)

--- a/packages/ingest/abis/yearn/lib/apy.spec.ts
+++ b/packages/ingest/abis/yearn/lib/apy.spec.ts
@@ -202,12 +202,17 @@ describe('abis/yearn/lib/apy', function() {
       expect(computeNetApr(0.10, { management: 0.02, performance: 0.20 })).to.be.closeTo(0.064, 1e-10)
     })
 
-    it('returns zero when performance fee is 100%', function() {
-      expect(computeNetApr(0.10, { management: 0, performance: 1.0 })).to.equal(0)
+    it('floors net APR at half gross APR when performance fee is 100%', function() {
+      expect(computeNetApr(0.10, { management: 0, performance: 1.0 })).to.equal(0.05)
     })
 
     it('handles zero gross APR', function() {
       expect(computeNetApr(0, { management: 0, performance: 0.20 })).to.equal(0)
+    })
+
+    it('floors net APR at half gross APR when fees exceed gross APR', function() {
+      const gross = 0.00076638918973244
+      expect(computeNetApr(gross, { management: 0.0025, performance: 0.10 })).to.equal(gross / 2)
     })
 
     it('handles no strategies (zero fees)', function() {

--- a/packages/ingest/abis/yearn/lib/apy.ts
+++ b/packages/ingest/abis/yearn/lib/apy.ts
@@ -489,6 +489,10 @@ export async function extractLockedProfit__v3(chainId: number, address: `0x${str
 }
 
 export function computeNetApr(grossApr: number, fees: { management: number; performance: number }): number {
+  // Accountant invariant: total fees cap at 50% of profit, so netApr cannot be
+  // worse than grossApr / 2. For non-positive gross, floor at 0 — a negative
+  // "floor" is meaningless and would let netApr stay negative.
+  if (grossApr <= 0) return 0
   const net = (grossApr - fees.management) * (1 - fees.performance)
   const floor = grossApr / 2
   if (net < floor) return floor

--- a/packages/ingest/abis/yearn/lib/apy.ts
+++ b/packages/ingest/abis/yearn/lib/apy.ts
@@ -489,7 +489,10 @@ export async function extractLockedProfit__v3(chainId: number, address: `0x${str
 }
 
 export function computeNetApr(grossApr: number, fees: { management: number; performance: number }): number {
-  return (grossApr - fees.management) * (1 - fees.performance)
+  const net = (grossApr - fees.management) * (1 - fees.performance)
+  const floor = grossApr / 2
+  if (net < floor) return floor
+  return net
 }
 
 export function computeApy(apr: number): number {

--- a/packages/scripts/src/backfill-apr-oracle-getCurrentApr/compute.ts
+++ b/packages/scripts/src/backfill-apr-oracle-getCurrentApr/compute.ts
@@ -49,6 +49,9 @@ type TempRow = {
   series_time: bigint
 }
 
+// TODO: migrate ensureTempTable + insertTempBatch below onto the shared helpers
+// in ../backfill-shared/tempTable.ts (resetTempTable / insertTempBatch). Left
+// as-is to keep the PR that introduced the shared helpers small.
 async function ensureTempTable() {
   await db.query(`
     CREATE TABLE IF NOT EXISTS ${TEMP_TABLE} (

--- a/packages/scripts/src/backfill-apr-oracle-getCurrentApr/compute.ts
+++ b/packages/scripts/src/backfill-apr-oracle-getCurrentApr/compute.ts
@@ -49,9 +49,6 @@ type TempRow = {
   series_time: bigint
 }
 
-// TODO: migrate ensureTempTable + insertTempBatch below onto the shared helpers
-// in ../backfill-shared/tempTable.ts (resetTempTable / insertTempBatch). Left
-// as-is to keep the PR that introduced the shared helpers small.
 async function ensureTempTable() {
   await db.query(`
     CREATE TABLE IF NOT EXISTS ${TEMP_TABLE} (

--- a/packages/scripts/src/backfill-apr-oracle-getCurrentApr/upsert.ts
+++ b/packages/scripts/src/backfill-apr-oracle-getCurrentApr/upsert.ts
@@ -2,6 +2,7 @@ import 'lib/global'
 
 import db from 'ingest/db'
 import { mq } from 'lib'
+import { parsePromoteArgs, promoteTempTable } from '../backfill-shared/upsert'
 
 /**
  * Phase 2: Promote computed apr-oracle outputs from the temp table into the
@@ -9,105 +10,16 @@ import { mq } from 'lib'
  */
 
 const TEMP_TABLE = 'output_temp_apr_oracle_backfill'
-
-function parseArgs(argv: string[]) {
-  const hasArg = (flag: string) => argv.includes(flag)
-
-  if (hasArg('--help') || hasArg('-h')) {
-    console.log(`usage:
-  bun packages/scripts/src/backfill-apr-oracle-getCurrentApr/upsert.ts [--dry-run]
-
-Promotes rows from ${TEMP_TABLE} into the output table and drops the temp table.
-Run compute.ts first to populate the temp table.`)
-    process.exit(0)
-  }
-
-  return {
-    dryRun: hasArg('--dry-run'),
-  }
-}
+const SCRIPT_PATH = 'packages/scripts/src/backfill-apr-oracle-getCurrentApr/upsert.ts'
 
 async function main() {
-  const args = parseArgs(process.argv.slice(2))
-
-  console.log(args.dryRun ? 'DRY RUN mode' : 'UPSERT mode')
-
+  const options = parsePromoteArgs(process.argv.slice(2), SCRIPT_PATH, TEMP_TABLE)
   try {
-    const count = await db.query(`SELECT COUNT(*) FROM ${TEMP_TABLE}`)
-    const rowCount = Number(count.rows[0].count)
-    console.log(`found ${rowCount} rows in ${TEMP_TABLE}`)
-
-    if (rowCount === 0) {
-      console.log('nothing to upsert. Run compute.ts first.')
-      await mq.down()
-      await db.end()
-      return
-    }
-
-    // Preview: sample some rows
-    const sample = await db.query(`
-      SELECT chain_id, address, component, value, series_time
-      FROM ${TEMP_TABLE}
-      ORDER BY chain_id, address, component
-      LIMIT 20
-    `)
-    console.log('\nsample rows:')
-    for (const row of sample.rows) {
-      console.log(`  ${row.chain_id}:${row.address} ${row.component}=${Number(row.value).toFixed(6)}`)
-    }
-
-    // Count distinct vaults
-    const vaultCount = await db.query(`
-      SELECT COUNT(DISTINCT (chain_id, address)) FROM ${TEMP_TABLE}
-    `)
-    console.log(`\ndistinct vaults: ${vaultCount.rows[0].count}`)
-
-    if (args.dryRun) {
-      console.log('\nDRY RUN: no changes made.')
-      await mq.down()
-      await db.end()
-      return
-    }
-
-    // Upsert and drop in a single transaction
-    console.log('\nupserting...')
-    const client = await db.connect()
-    try {
-      await client.query('BEGIN')
-
-      const result = await client.query(`
-        INSERT INTO output (chain_id, address, label, component, value, block_number, block_time, series_time)
-        SELECT chain_id, address, label, component, value, block_number, block_time, series_time
-        FROM ${TEMP_TABLE}
-        ON CONFLICT (chain_id, address, label, component, series_time)
-        DO UPDATE SET
-          value = EXCLUDED.value,
-          block_number = EXCLUDED.block_number,
-          block_time = EXCLUDED.block_time
-      `)
-      console.log(`upserted ${result.rowCount} rows`)
-
-      await client.query(`DROP TABLE ${TEMP_TABLE}`)
-      console.log(`dropped ${TEMP_TABLE}`)
-
-      await client.query('COMMIT')
-      console.log('done.')
-    } catch (err) {
-      await client.query('ROLLBACK')
-      throw err
-    } finally {
-      client.release()
-    }
-  } catch (err) {
-    if (err instanceof Error && 'code' in err && (err as { code: string }).code === '42P01') {
-      console.error(`table ${TEMP_TABLE} does not exist. Run compute.ts first.`)
-    } else {
-      throw err
-    }
+    await promoteTempTable(TEMP_TABLE, options)
+  } finally {
+    await mq.down()
+    await db.end()
   }
-
-  await mq.down()
-  await db.end()
 }
 
 main().catch(error => {

--- a/packages/scripts/src/backfill-apr-oracle-getCurrentApr/upsert.ts
+++ b/packages/scripts/src/backfill-apr-oracle-getCurrentApr/upsert.ts
@@ -2,7 +2,7 @@ import 'lib/global'
 
 import db from 'ingest/db'
 import { mq } from 'lib'
-import { parsePromoteArgs, promoteTempTable } from '../backfill-shared/upsert'
+import { promoteTempTable } from '../backfill-shared/upsert'
 
 /**
  * Phase 2: Promote computed apr-oracle outputs from the temp table into the
@@ -10,12 +10,10 @@ import { parsePromoteArgs, promoteTempTable } from '../backfill-shared/upsert'
  */
 
 const TEMP_TABLE = 'output_temp_apr_oracle_backfill'
-const SCRIPT_PATH = 'packages/scripts/src/backfill-apr-oracle-getCurrentApr/upsert.ts'
 
 async function main() {
-  const options = parsePromoteArgs(process.argv.slice(2), SCRIPT_PATH, TEMP_TABLE)
   try {
-    await promoteTempTable(TEMP_TABLE, options)
+    await promoteTempTable(TEMP_TABLE)
   } finally {
     await mq.down()
     await db.end()

--- a/packages/scripts/src/backfill-apr-oracle-getCurrentApr/upsert.ts
+++ b/packages/scripts/src/backfill-apr-oracle-getCurrentApr/upsert.ts
@@ -1,7 +1,6 @@
 import 'lib/global'
 
 import db from 'ingest/db'
-import { mq } from 'lib'
 import { promoteTempTable } from '../backfill-shared/upsert'
 
 /**
@@ -15,7 +14,6 @@ async function main() {
   try {
     await promoteTempTable(TEMP_TABLE)
   } finally {
-    await mq.down()
     await db.end()
   }
 }

--- a/packages/scripts/src/backfill-apr-oracle-negative-netapr/README.md
+++ b/packages/scripts/src/backfill-apr-oracle-negative-netapr/README.md
@@ -13,10 +13,14 @@ The hook has been fixed to enforce `grossApr / 2` as the lower bound (and `0` fo
 ### 1. compute.ts
 
 1. Truncates the temp table `output_temp_netapr_floor_backfill` (every run starts clean).
-2. Queries `(chain_id, address, series_time)` tuples where `netApr` OR `netApy` `< apr / 2` (LEFT JOIN on the matching `apr` row; rows without a gross row or with a negative gross are skipped).
-3. Dedupes by `(chain, address, series_time)` — one replay covers both net components.
-4. Replays `apr-oracle` timeseries hook at each affected `series_time`.
-5. Stages only the recomputed `netApr` and `netApy` rows into the temp table.
+2. Queries `(chain_id, address, series_time)` tuples where `netApr < apr / 2` (LEFT JOIN on the matching `apr` row). `netApy` is derived from `netApr`, so anchoring on `netApr` is sufficient — the replay recomputes both.
+3. Replays `apr-oracle` timeseries hook at each affected `series_time`.
+4. Stages the recomputed `netApr` and `netApy` rows into the temp table.
+
+**Skipped rows** (logged as counts, left untouched by this backfill):
+
+- Rows where no matching `apr` row exists for the same `series_time` — we can't evaluate the floor without the gross value.
+- Rows where the stored `apr` is negative. Under the fixed hook these would resolve to `netApr = 0`, but we defer to the next natural re-ingest (the regular timeseries fanout) to heal them rather than fabricating a value here.
 
 ```
 bun packages/scripts/src/backfill-apr-oracle-negative-netapr/compute.ts

--- a/packages/scripts/src/backfill-apr-oracle-negative-netapr/README.md
+++ b/packages/scripts/src/backfill-apr-oracle-negative-netapr/README.md
@@ -1,21 +1,21 @@
 # backfill-apr-oracle-negative-netapr
 
-Backfill scripts for v3 vault apr-oracle output rows where `netApr` / `netApy` were stored as a negative number because the management + performance fees exceeded the gross APR.
+Backfill scripts for v3 vault `apr-oracle` output rows where the stored `netApr` is below the new `grossApr / 2` floor (includes all rows that were stored as negative).
 
 ## Background
 
-`computeNetApr` previously returned `(grossApr - managementFee) * (1 - performanceFee)` unconditionally. When the vault's oracle reports a very small positive gross APR (below the management fee), the expression goes negative, so historical rows were written with negative `netApr` (and correspondingly negative `netApy` from `computeApy`).
+`computeNetApr` previously returned `(grossApr - managementFee) * (1 - performanceFee)` unconditionally. When the management fee (charged on TVL) exceeded a very small gross APR the expression went negative; more generally any row where `(gross - mgmt)(1 - perf) < gross / 2` ended up below the accountant's true 50%-of-profit floor.
 
-Yearn's accountant caps management + performance fees at **50% of profit**, so the true lower bound for net APR is `grossApr / 2`. The hook has been fixed to enforce that floor, but existing timeseries rows still carry the negative values. This backfill rewrites them to `grossApr / 2` (and `netApy` to `computeApy(grossApr / 2)`) to match the new invariant.
+The hook has been fixed to enforce `grossApr / 2` as the lower bound. This backfill replays the fixed hook against every stored timeseries bucket that is currently below that floor, so historical rows match current ingestion.
 
 ## Scripts
 
 ### 1. compute.ts
 
-Copies every affected `apr-oracle` / `netApr` + `netApy` row into a temp table with `value` rewritten to the `grossApr / 2` floor. Skips rows that have no matching same-series_time gross `apr` row or where gross is non-positive (nothing to floor against).
-
-- Writes to `output_temp_netapr_floor_backfill`
-- Matches the existing schema of `output_temp_apr_oracle_backfill` so downstream tooling behaves identically
+1. Truncates the temp table `output_temp_netapr_floor_backfill` (every run starts clean).
+2. Queries `(chain_id, address, series_time)` tuples where `netApr < apr / 2`.
+3. Replays `apr-oracle` timeseries hook at each affected `series_time`.
+4. Stages the 4 returned rows (`apr`, `apy`, `netApr`, `netApy`) into the temp table.
 
 ```
 bun packages/scripts/src/backfill-apr-oracle-negative-netapr/compute.ts
@@ -23,10 +23,10 @@ bun packages/scripts/src/backfill-apr-oracle-negative-netapr/compute.ts
 
 ### 2. upsert.ts
 
-Promotes floored values from the temp table into the production `output` table, then drops the temp table.
+Promotes every row from the temp table into `public.output` and drops the temp table.
 
 ```
-bun packages/scripts/src/backfill-apr-oracle-negative-netapr/upsert.ts [--dry-run]
+bun packages/scripts/src/backfill-apr-oracle-negative-netapr/upsert.ts
 ```
 
 ## Workflow
@@ -35,17 +35,20 @@ bun packages/scripts/src/backfill-apr-oracle-negative-netapr/upsert.ts [--dry-ru
 compute.ts  -->  upsert.ts
 ```
 
-1. Run `compute.ts` to stage the floored rows
-2. Run `upsert.ts --dry-run` to preview, then `upsert.ts` to apply
-3. Trigger a snapshot refresh so updated values propagate to the REST cache
-
 ## Verification
 
 After `upsert.ts` runs, this should return `0`:
 
 ```sql
-SELECT COUNT(*) FROM output
-WHERE label = 'apr-oracle'
-  AND component IN ('netApr', 'netApy')
-  AND value < 0;
+SELECT COUNT(*)
+FROM public.output n
+JOIN public.output g
+  ON g.chain_id    = n.chain_id
+ AND g.address     = n.address
+ AND g.label       = 'apr-oracle'
+ AND g.component   = 'apr'
+ AND g.series_time = n.series_time
+WHERE n.label = 'apr-oracle'
+  AND n.component = 'netApr'
+  AND n.value < g.value / 2;
 ```

--- a/packages/scripts/src/backfill-apr-oracle-negative-netapr/README.md
+++ b/packages/scripts/src/backfill-apr-oracle-negative-netapr/README.md
@@ -24,16 +24,16 @@ bun packages/scripts/src/backfill-apr-oracle-negative-netapr/compute.ts
 
 ### 2. upsert.ts
 
-Promotes every row from the temp table into `public.output` and drops the temp table. Supports `--dry-run` (previews row count, sample, and distinct vaults without writing) and `--help`.
+Promotes every row from the temp table into `public.output` and drops the temp table.
 
 ```
-bun packages/scripts/src/backfill-apr-oracle-negative-netapr/upsert.ts [--dry-run]
+bun packages/scripts/src/backfill-apr-oracle-negative-netapr/upsert.ts
 ```
 
 ## Workflow
 
 ```
-compute.ts  -->  upsert.ts [--dry-run]  -->  upsert.ts
+compute.ts  -->  upsert.ts
 ```
 
 ## Verification

--- a/packages/scripts/src/backfill-apr-oracle-negative-netapr/README.md
+++ b/packages/scripts/src/backfill-apr-oracle-negative-netapr/README.md
@@ -1,21 +1,22 @@
 # backfill-apr-oracle-negative-netapr
 
-Backfill scripts for v3 vault `apr-oracle` output rows where the stored `netApr` is below the new `grossApr / 2` floor (includes all rows that were stored as negative).
+Backfill scripts for v3 vault `apr-oracle` output rows where the stored `netApr` or `netApy` is below the new `grossApr / 2` floor (includes all rows that were stored as negative).
 
 ## Background
 
 `computeNetApr` previously returned `(grossApr - managementFee) * (1 - performanceFee)` unconditionally. When the management fee (charged on TVL) exceeded a very small gross APR the expression went negative; more generally any row where `(gross - mgmt)(1 - perf) < gross / 2` ended up below the accountant's true 50%-of-profit floor.
 
-The hook has been fixed to enforce `grossApr / 2` as the lower bound. This backfill replays the fixed hook against every stored timeseries bucket that is currently below that floor, so historical rows match current ingestion.
+The hook has been fixed to enforce `grossApr / 2` as the lower bound (and `0` for non-positive gross). This backfill replays the fixed hook against every stored timeseries bucket whose `netApr` or `netApy` is currently below that floor, so historical rows match current ingestion. Only the `netApr` / `netApy` rows are rewritten — the companion `apr` / `apy` rows are left untouched.
 
 ## Scripts
 
 ### 1. compute.ts
 
 1. Truncates the temp table `output_temp_netapr_floor_backfill` (every run starts clean).
-2. Queries `(chain_id, address, series_time)` tuples where `netApr < apr / 2`.
-3. Replays `apr-oracle` timeseries hook at each affected `series_time`.
-4. Stages the 4 returned rows (`apr`, `apy`, `netApr`, `netApy`) into the temp table.
+2. Queries `(chain_id, address, series_time)` tuples where `netApr` OR `netApy` `< apr / 2` (LEFT JOIN on the matching `apr` row; rows without a gross row or with a negative gross are skipped).
+3. Dedupes by `(chain, address, series_time)` — one replay covers both net components.
+4. Replays `apr-oracle` timeseries hook at each affected `series_time`.
+5. Stages only the recomputed `netApr` and `netApy` rows into the temp table.
 
 ```
 bun packages/scripts/src/backfill-apr-oracle-negative-netapr/compute.ts
@@ -23,16 +24,16 @@ bun packages/scripts/src/backfill-apr-oracle-negative-netapr/compute.ts
 
 ### 2. upsert.ts
 
-Promotes every row from the temp table into `public.output` and drops the temp table.
+Promotes every row from the temp table into `public.output` and drops the temp table. Supports `--dry-run` (previews row count, sample, and distinct vaults without writing) and `--help`.
 
 ```
-bun packages/scripts/src/backfill-apr-oracle-negative-netapr/upsert.ts
+bun packages/scripts/src/backfill-apr-oracle-negative-netapr/upsert.ts [--dry-run]
 ```
 
 ## Workflow
 
 ```
-compute.ts  -->  upsert.ts
+compute.ts  -->  upsert.ts [--dry-run]  -->  upsert.ts
 ```
 
 ## Verification
@@ -49,6 +50,6 @@ JOIN public.output g
  AND g.component   = 'apr'
  AND g.series_time = n.series_time
 WHERE n.label = 'apr-oracle'
-  AND n.component = 'netApr'
+  AND n.component IN ('netApr', 'netApy')
   AND n.value < g.value / 2;
 ```

--- a/packages/scripts/src/backfill-apr-oracle-negative-netapr/README.md
+++ b/packages/scripts/src/backfill-apr-oracle-negative-netapr/README.md
@@ -1,0 +1,51 @@
+# backfill-apr-oracle-negative-netapr
+
+Backfill scripts for v3 vault apr-oracle output rows where `netApr` / `netApy` were stored as a negative number because the management + performance fees exceeded the gross APR.
+
+## Background
+
+`computeNetApr` previously returned `(grossApr - managementFee) * (1 - performanceFee)` unconditionally. When the vault's oracle reports a very small positive gross APR (below the management fee), the expression goes negative, so historical rows were written with negative `netApr` (and correspondingly negative `netApy` from `computeApy`).
+
+Yearn's accountant caps management + performance fees at **50% of profit**, so the true lower bound for net APR is `grossApr / 2`. The hook has been fixed to enforce that floor, but existing timeseries rows still carry the negative values. This backfill rewrites them to `grossApr / 2` (and `netApy` to `computeApy(grossApr / 2)`) to match the new invariant.
+
+## Scripts
+
+### 1. compute.ts
+
+Copies every affected `apr-oracle` / `netApr` + `netApy` row into a temp table with `value` rewritten to the `grossApr / 2` floor. Skips rows that have no matching same-series_time gross `apr` row or where gross is non-positive (nothing to floor against).
+
+- Writes to `output_temp_netapr_floor_backfill`
+- Matches the existing schema of `output_temp_apr_oracle_backfill` so downstream tooling behaves identically
+
+```
+bun packages/scripts/src/backfill-apr-oracle-negative-netapr/compute.ts
+```
+
+### 2. upsert.ts
+
+Promotes floored values from the temp table into the production `output` table, then drops the temp table.
+
+```
+bun packages/scripts/src/backfill-apr-oracle-negative-netapr/upsert.ts [--dry-run]
+```
+
+## Workflow
+
+```
+compute.ts  -->  upsert.ts
+```
+
+1. Run `compute.ts` to stage the floored rows
+2. Run `upsert.ts --dry-run` to preview, then `upsert.ts` to apply
+3. Trigger a snapshot refresh so updated values propagate to the REST cache
+
+## Verification
+
+After `upsert.ts` runs, this should return `0`:
+
+```sql
+SELECT COUNT(*) FROM output
+WHERE label = 'apr-oracle'
+  AND component IN ('netApr', 'netApy')
+  AND value < 0;
+```

--- a/packages/scripts/src/backfill-apr-oracle-negative-netapr/compute.ts
+++ b/packages/scripts/src/backfill-apr-oracle-negative-netapr/compute.ts
@@ -7,12 +7,13 @@ import type { Output } from 'lib/types'
 import { insertTempBatch, resetTempTable, type TempRow } from '../backfill-shared/tempTable'
 
 /**
- * Recompute apr-oracle outputs for rows where the stored netApr is below the
- * new floor (grossApr / 2) — which also covers rows stored as negative.
+ * Recompute apr-oracle netApr/netApy outputs for rows where either is below
+ * the new floor (grossApr / 2). Covers rows stored as negative.
  *
- * - Identifies (chain_id, address) + series_time pairs where netApr < apr / 2
+ * - Identifies (chain_id, address) + series_time pairs where netApr OR netApy
+ *   is below the corresponding gross apr / 2
  * - Replays the apr-oracle timeseries hook at each affected series_time
- * - Stages the full 4-row hook output (apr, apy, netApr, netApy) in the temp table
+ * - Stages only the recomputed netApr and netApy rows (apr / apy are untouched)
  * - Temp table is truncated at the start of every run to avoid stale staged rows
  *
  * Run upsert.ts to promote results to the output table.
@@ -117,6 +118,11 @@ function outputToTempRow(output: Output): TempRow | null {
   }
 }
 
+// Only the net components are affected by the floor change. Staging the
+// companion `apr` / `apy` rows would rewrite their block_time and value
+// unnecessarily, so we filter here.
+const STAGED_COMPONENTS = new Set(['netApr', 'netApy'])
+
 async function replayVault(vault: Affected) {
   const staged: TempRow[] = []
   let errors = 0
@@ -137,6 +143,7 @@ async function replayVault(vault: Affected) {
         blockTime: seriesTime,
       })
       for (const output of outputs) {
+        if (!output.component || !STAGED_COMPONENTS.has(output.component)) continue
         const row = outputToTempRow(output)
         if (row) staged.push(row)
       }
@@ -199,7 +206,7 @@ async function main() {
     console.log(`Staged (gross >= 0):     ${stageable}`)
     console.log(`Skipped (no gross row):  ${skippedNoGross}`)
     console.log(`Skipped (gross < 0):     ${skippedGrossNegative}`)
-    console.log(`Output rows staged:      ${totalStaged}  (${uniqueSeriesTimes} replays x up to 4 components)`)
+    console.log(`Output rows staged:      ${totalStaged}  (${uniqueSeriesTimes} replays x 2 net components)`)
     console.log(`Vaults replayed:         ${affected.length}`)
     console.log(`Errors:                  ${totalErrors}`)
     console.log(`Duration:                ${duration}s`)

--- a/packages/scripts/src/backfill-apr-oracle-negative-netapr/compute.ts
+++ b/packages/scripts/src/backfill-apr-oracle-negative-netapr/compute.ts
@@ -7,11 +7,12 @@ import type { Output } from 'lib/types'
 import { insertTempBatch, resetTempTable, type TempRow } from '../backfill-shared/tempTable'
 
 /**
- * Recompute apr-oracle netApr/netApy outputs for rows where either is below
- * the new floor (grossApr / 2). Covers rows stored as negative.
+ * Recompute apr-oracle netApr/netApy outputs for rows whose stored netApr is
+ * below the new floor (grossApr / 2). Covers rows stored as negative.
  *
- * - Identifies (chain_id, address) + series_time pairs where netApr OR netApy
- *   is below the corresponding gross apr / 2
+ * - Identifies (chain_id, address) + series_time pairs where netApr < apr / 2
+ *   (netApy is derived from netApr, so anchoring on netApr is sufficient —
+ *   the replay recomputes both components)
  * - Replays the apr-oracle timeseries hook at each affected series_time
  * - Stages only the recomputed netApr and netApy rows (apr / apy are untouched)
  * - Temp table is truncated at the start of every run to avoid stale staged rows
@@ -37,14 +38,14 @@ type FindAffectedResult = {
 }
 
 async function findAffected(): Promise<FindAffectedResult> {
-  // Count every netApr and netApy row below floor (both are derived from the
-  // same replay). LEFT JOIN so we can distinguish "no matching gross row"
-  // from "gross is negative"; both are skipped.
+  // Target only netApr rows: netApy is derived from netApr via computeApy,
+  // which is non-linear — comparing netApy against apr/2 would be the wrong
+  // check. We identify affected series_times from netApr alone, and the
+  // replay recomputes both netApr and netApy.
   const { rows } = await db.query(`
     SELECT
       n.chain_id,
       n.address,
-      n.component,
       EXTRACT(EPOCH FROM n.series_time)::bigint AS series_time_epoch,
       g.value AS gross_value
     FROM public.output n
@@ -55,15 +56,13 @@ async function findAffected(): Promise<FindAffectedResult> {
      AND g.component   = 'apr'
      AND g.series_time = n.series_time
     WHERE n.label = 'apr-oracle'
-      AND n.component IN ('netApr', 'netApy')
+      AND n.component = 'netApr'
       AND (g.value IS NULL OR n.value < g.value / 2)
-    ORDER BY n.chain_id, n.address, n.series_time, n.component
+    ORDER BY n.chain_id, n.address, n.series_time
   `)
 
   let skippedNoGross = 0
   let skippedGrossNegative = 0
-  // Dedupe by (chain, address, series_time): one replay covers both netApr and netApy.
-  const seen = new Set<string>()
   const grouped = new Map<string, Affected>()
 
   for (const r of rows) {
@@ -75,9 +74,6 @@ async function findAffected(): Promise<FindAffectedResult> {
       skippedGrossNegative++
       continue
     }
-    const dedupeKey = `${r.chain_id}:${r.address.toLowerCase()}:${r.series_time_epoch}`
-    if (seen.has(dedupeKey)) continue
-    seen.add(dedupeKey)
 
     const vaultKey = `${r.chain_id}:${r.address.toLowerCase()}`
     const seriesTime = BigInt(r.series_time_epoch)
@@ -178,7 +174,7 @@ async function main() {
 
     const { affected, totalBelowFloor, skippedNoGross, skippedGrossNegative, stageable } = await findAffected()
     const uniqueSeriesTimes = affected.reduce((acc, v) => acc + v.series_times.length, 0)
-    console.log(`Below-floor rows found: ${totalBelowFloor}  (netApr + netApy)`)
+    console.log(`Below-floor netApr rows found: ${totalBelowFloor}`)
     console.log(`Skipped (no gross row): ${skippedNoGross}`)
     console.log(`Skipped (gross < 0): ${skippedGrossNegative}`)
     console.log(`To replay: ${uniqueSeriesTimes} unique series_times across ${affected.length} vaults\n`)

--- a/packages/scripts/src/backfill-apr-oracle-negative-netapr/compute.ts
+++ b/packages/scripts/src/backfill-apr-oracle-negative-netapr/compute.ts
@@ -1,0 +1,175 @@
+import 'lib/global'
+
+import { computeApy } from 'ingest/abis/yearn/lib/apy'
+import db from 'ingest/db'
+
+/**
+ * Compute corrected apr-oracle outputs for rows where netApr/netApy were
+ * stored as a negative number because fees exceeded the gross APR.
+ *
+ * Yearn's accountant caps management + performance fees at 50% of profit, so
+ * the lower bound for net APR is grossApr / 2. The hook now enforces that
+ * floor, and this backfill rewrites existing negative rows to the same value.
+ *
+ * - Joins each negative netApr/netApy row to its same-series_time gross `apr`
+ * - Writes `gross / 2` (or `computeApy(gross / 2)` for netApy) into a temp table
+ * - Skips rows with no matching gross apr row or where gross is negative
+ *
+ * Run upsert.ts to promote results to the output table.
+ */
+
+const TEMP_TABLE = 'output_temp_netapr_floor_backfill'
+
+type NegativeRow = {
+  chain_id: number
+  address: `0x${string}`
+  component: 'netApr' | 'netApy'
+  value: string
+  block_number: string
+  block_time: Date
+  series_time: Date
+  gross_apr: string | null
+}
+
+async function ensureTempTable() {
+  await db.query(`
+    CREATE TABLE IF NOT EXISTS ${TEMP_TABLE} (
+      chain_id     integer NOT NULL,
+      address      text NOT NULL,
+      label        text NOT NULL,
+      component    text NOT NULL,
+      value        numeric,
+      block_number bigint NOT NULL,
+      block_time   timestamptz NOT NULL,
+      series_time  timestamptz NOT NULL,
+      PRIMARY KEY  (chain_id, address, label, component, series_time)
+    )
+  `)
+  const count = await db.query(`SELECT COUNT(*) FROM ${TEMP_TABLE}`)
+  console.log(`temp table ${TEMP_TABLE}: ${count.rows[0].count} existing rows`)
+}
+
+async function insertBatch(rows: {
+  chain_id: number
+  address: string
+  component: string
+  value: number
+  block_number: string
+  block_time: Date
+  series_time: Date
+}[]) {
+  if (rows.length === 0) return
+
+  const values: string[] = []
+  const params: (string | number | Date)[] = []
+  let idx = 1
+
+  for (const row of rows) {
+    values.push(`($${idx}, $${idx + 1}, 'apr-oracle', $${idx + 2}, $${idx + 3}, $${idx + 4}, $${idx + 5}, $${idx + 6})`)
+    params.push(row.chain_id, row.address, row.component, row.value, row.block_number, row.block_time, row.series_time)
+    idx += 7
+  }
+
+  await db.query(`
+    INSERT INTO ${TEMP_TABLE} (chain_id, address, label, component, value, block_number, block_time, series_time)
+    VALUES ${values.join(', ')}
+    ON CONFLICT (chain_id, address, label, component, series_time)
+    DO UPDATE SET value = EXCLUDED.value, block_number = EXCLUDED.block_number, block_time = EXCLUDED.block_time
+  `, params)
+}
+
+async function main() {
+  const startTime = Date.now()
+
+  await ensureTempTable()
+
+  const preview = await db.query(`
+    SELECT chain_id, address, component, count(*) AS rows, min(value) AS min_value
+    FROM public.output
+    WHERE label = 'apr-oracle'
+      AND component IN ('netApr', 'netApy')
+      AND value < 0
+    GROUP BY chain_id, address, component
+    ORDER BY chain_id, address, component
+  `)
+  console.log(`found negative rows across ${preview.rows.length} (vault, component) pairs`)
+  for (const row of preview.rows) {
+    console.log(`  ${row.chain_id}:${row.address} ${row.component} rows=${row.rows} min=${row.min_value}`)
+  }
+
+  if (preview.rows.length === 0) {
+    console.log('nothing to backfill.')
+    await db.end()
+    return
+  }
+
+  const { rows }: { rows: NegativeRow[] } = await db.query(`
+    SELECT
+      n.chain_id,
+      n.address,
+      n.component,
+      n.value,
+      n.block_number,
+      n.block_time,
+      n.series_time,
+      g.value AS gross_apr
+    FROM public.output n
+    LEFT JOIN public.output g
+      ON g.chain_id    = n.chain_id
+     AND g.address     = n.address
+     AND g.label       = 'apr-oracle'
+     AND g.component   = 'apr'
+     AND g.series_time = n.series_time
+    WHERE n.label = 'apr-oracle'
+      AND n.component IN ('netApr', 'netApy')
+      AND n.value < 0
+    ORDER BY n.chain_id, n.address, n.series_time, n.component
+  `)
+
+  const staged: Parameters<typeof insertBatch>[0] = []
+  let skippedNoGross = 0
+  let skippedNegativeGross = 0
+
+  for (const row of rows) {
+    if (row.gross_apr === null) {
+      skippedNoGross++
+      continue
+    }
+    const gross = Number(row.gross_apr)
+    if (gross < 0) {
+      skippedNegativeGross++
+      continue
+    }
+    const floor = gross / 2
+    const value = row.component === 'netApr' ? floor : computeApy(floor)
+    staged.push({
+      chain_id: row.chain_id,
+      address: row.address,
+      component: row.component,
+      value,
+      block_number: row.block_number,
+      block_time: row.block_time,
+      series_time: row.series_time,
+    })
+  }
+
+  const BATCH = 500
+  for (let i = 0; i < staged.length; i += BATCH) {
+    await insertBatch(staged.slice(i, i + BATCH))
+  }
+
+  const duration = ((Date.now() - startTime) / 1000).toFixed(2)
+  console.log('=== Summary ===')
+  console.log(`Negative rows found:     ${rows.length}`)
+  console.log(`Staged (gross >= 0):     ${staged.length}`)
+  console.log(`Skipped (no gross row):  ${skippedNoGross}`)
+  console.log(`Skipped (gross < 0):     ${skippedNegativeGross}`)
+  console.log(`Duration:                ${duration}s`)
+
+  await db.end()
+}
+
+main().catch(error => {
+  console.error('Fatal error:', error)
+  process.exit(1)
+})

--- a/packages/scripts/src/backfill-apr-oracle-negative-netapr/compute.ts
+++ b/packages/scripts/src/backfill-apr-oracle-negative-netapr/compute.ts
@@ -1,172 +1,150 @@
 import 'lib/global'
 
-import { computeApy } from 'ingest/abis/yearn/lib/apy'
+import aprOracleHook from 'ingest/abis/yearn/3/vault/timeseries/apr-oracle/hook'
 import db from 'ingest/db'
+import { rpcs } from 'ingest/rpcs'
+import type { Output } from 'lib/types'
+import { insertTempBatch, resetTempTable, type TempRow } from '../backfill-shared/tempTable'
 
 /**
- * Compute corrected apr-oracle outputs for rows where netApr/netApy were
- * stored as a negative number because fees exceeded the gross APR.
+ * Recompute apr-oracle outputs for rows where the stored netApr is below the
+ * new floor (grossApr / 2) — which also covers rows stored as negative.
  *
- * Yearn's accountant caps management + performance fees at 50% of profit, so
- * the lower bound for net APR is grossApr / 2. The hook now enforces that
- * floor, and this backfill rewrites existing negative rows to the same value.
- *
- * - Joins each negative netApr/netApy row to its same-series_time gross `apr`
- * - Writes `gross / 2` (or `computeApy(gross / 2)` for netApy) into a temp table
- * - Skips rows with no matching gross apr row or where gross is negative
+ * - Identifies (chain_id, address) + series_time pairs where netApr < apr / 2
+ * - Replays the apr-oracle timeseries hook at each affected series_time
+ * - Stages the full 4-row hook output (apr, apy, netApr, netApy) in the temp table
+ * - Temp table is truncated at the start of every run to avoid stale staged rows
  *
  * Run upsert.ts to promote results to the output table.
  */
 
 const TEMP_TABLE = 'output_temp_netapr_floor_backfill'
+const CONCURRENCY = 8
 
-type NegativeRow = {
+type Affected = {
   chain_id: number
   address: `0x${string}`
-  component: 'netApr' | 'netApy'
-  value: string
-  block_number: string
-  block_time: Date
-  series_time: Date
-  gross_apr: string | null
+  series_times: bigint[]
 }
 
-async function ensureTempTable() {
-  await db.query(`
-    CREATE TABLE IF NOT EXISTS ${TEMP_TABLE} (
-      chain_id     integer NOT NULL,
-      address      text NOT NULL,
-      label        text NOT NULL,
-      component    text NOT NULL,
-      value        numeric,
-      block_number bigint NOT NULL,
-      block_time   timestamptz NOT NULL,
-      series_time  timestamptz NOT NULL,
-      PRIMARY KEY  (chain_id, address, label, component, series_time)
-    )
-  `)
-  const count = await db.query(`SELECT COUNT(*) FROM ${TEMP_TABLE}`)
-  console.log(`temp table ${TEMP_TABLE}: ${count.rows[0].count} existing rows`)
-}
-
-async function insertBatch(rows: {
-  chain_id: number
-  address: string
-  component: string
-  value: number
-  block_number: string
-  block_time: Date
-  series_time: Date
-}[]) {
-  if (rows.length === 0) return
-
-  const values: string[] = []
-  const params: (string | number | Date)[] = []
-  let idx = 1
-
-  for (const row of rows) {
-    values.push(`($${idx}, $${idx + 1}, 'apr-oracle', $${idx + 2}, $${idx + 3}, $${idx + 4}, $${idx + 5}, $${idx + 6})`)
-    params.push(row.chain_id, row.address, row.component, row.value, row.block_number, row.block_time, row.series_time)
-    idx += 7
-  }
-
-  await db.query(`
-    INSERT INTO ${TEMP_TABLE} (chain_id, address, label, component, value, block_number, block_time, series_time)
-    VALUES ${values.join(', ')}
-    ON CONFLICT (chain_id, address, label, component, series_time)
-    DO UPDATE SET value = EXCLUDED.value, block_number = EXCLUDED.block_number, block_time = EXCLUDED.block_time
-  `, params)
-}
-
-async function main() {
-  const startTime = Date.now()
-
-  await ensureTempTable()
-
-  const preview = await db.query(`
-    SELECT chain_id, address, component, count(*) AS rows, min(value) AS min_value
-    FROM public.output
-    WHERE label = 'apr-oracle'
-      AND component IN ('netApr', 'netApy')
-      AND value < 0
-    GROUP BY chain_id, address, component
-    ORDER BY chain_id, address, component
-  `)
-  console.log(`found negative rows across ${preview.rows.length} (vault, component) pairs`)
-  for (const row of preview.rows) {
-    console.log(`  ${row.chain_id}:${row.address} ${row.component} rows=${row.rows} min=${row.min_value}`)
-  }
-
-  if (preview.rows.length === 0) {
-    console.log('nothing to backfill.')
-    await db.end()
-    return
-  }
-
-  const { rows }: { rows: NegativeRow[] } = await db.query(`
-    SELECT
-      n.chain_id,
-      n.address,
-      n.component,
-      n.value,
-      n.block_number,
-      n.block_time,
-      n.series_time,
-      g.value AS gross_apr
+async function findAffected(): Promise<Affected[]> {
+  const { rows } = await db.query(`
+    SELECT n.chain_id, n.address, n.series_time
     FROM public.output n
-    LEFT JOIN public.output g
+    JOIN public.output g
       ON g.chain_id    = n.chain_id
      AND g.address     = n.address
      AND g.label       = 'apr-oracle'
      AND g.component   = 'apr'
      AND g.series_time = n.series_time
     WHERE n.label = 'apr-oracle'
-      AND n.component IN ('netApr', 'netApy')
-      AND n.value < 0
-    ORDER BY n.chain_id, n.address, n.series_time, n.component
+      AND n.component = 'netApr'
+      AND n.value < g.value / 2
+    ORDER BY n.chain_id, n.address, n.series_time
   `)
 
-  const staged: Parameters<typeof insertBatch>[0] = []
-  let skippedNoGross = 0
-  let skippedNegativeGross = 0
+  const grouped = new Map<string, Affected>()
+  for (const r of rows) {
+    const key = `${r.chain_id}:${r.address.toLowerCase()}`
+    const seriesTime = BigInt(Math.floor(new Date(r.series_time).getTime() / 1000))
+    const existing = grouped.get(key)
+    if (existing) {
+      existing.series_times.push(seriesTime)
+    } else {
+      grouped.set(key, { chain_id: r.chain_id, address: r.address, series_times: [seriesTime] })
+    }
+  }
+  return [...grouped.values()]
+}
 
-  for (const row of rows) {
-    if (row.gross_apr === null) {
-      skippedNoGross++
-      continue
+function outputToTempRow(output: Output): TempRow | null {
+  if (output.component == null || output.value == null) return null
+  return {
+    chain_id: output.chainId,
+    address: output.address,
+    label: output.label,
+    component: output.component,
+    value: output.value,
+    block_number: output.blockNumber,
+    block_time: new Date(Number(output.blockTime) * 1000),
+    series_time: new Date(Number(output.blockTime) * 1000),
+  }
+}
+
+async function replayVault(vault: Affected) {
+  const staged: TempRow[] = []
+  let errors = 0
+
+  for (const seriesTime of vault.series_times) {
+    try {
+      const outputs = await aprOracleHook(vault.chain_id, vault.address, {
+        abiPath: 'yearn/3/vault',
+        chainId: vault.chain_id,
+        address: vault.address,
+        outputLabel: 'apr-oracle',
+        blockTime: seriesTime,
+      })
+      for (const output of outputs) {
+        const row = outputToTempRow(output)
+        if (row) staged.push(row)
+      }
+    } catch (error) {
+      errors++
+      console.error(`  error ${vault.chain_id}:${vault.address} @ ${seriesTime}:`, error instanceof Error ? error.message : error)
     }
-    const gross = Number(row.gross_apr)
-    if (gross < 0) {
-      skippedNegativeGross++
-      continue
-    }
-    const floor = gross / 2
-    const value = row.component === 'netApr' ? floor : computeApy(floor)
-    staged.push({
-      chain_id: row.chain_id,
-      address: row.address,
-      component: row.component,
-      value,
-      block_number: row.block_number,
-      block_time: row.block_time,
-      series_time: row.series_time,
-    })
   }
 
-  const BATCH = 500
-  for (let i = 0; i < staged.length; i += BATCH) {
-    await insertBatch(staged.slice(i, i + BATCH))
+  if (staged.length > 0) {
+    const BATCH = 500
+    for (let i = 0; i < staged.length; i += BATCH) {
+      await insertTempBatch(TEMP_TABLE, staged.slice(i, i + BATCH))
+    }
   }
 
-  const duration = ((Date.now() - startTime) / 1000).toFixed(2)
-  console.log('=== Summary ===')
-  console.log(`Negative rows found:     ${rows.length}`)
-  console.log(`Staged (gross >= 0):     ${staged.length}`)
-  console.log(`Skipped (no gross row):  ${skippedNoGross}`)
-  console.log(`Skipped (gross < 0):     ${skippedNegativeGross}`)
-  console.log(`Duration:                ${duration}s`)
+  console.log(`  ${vault.chain_id}:${vault.address} series=${vault.series_times.length} staged=${staged.length} errors=${errors}`)
+  return { staged: staged.length, errors }
+}
 
-  await db.end()
+async function main() {
+  const startTime = Date.now()
+
+  try {
+    await rpcs.up()
+    await resetTempTable(TEMP_TABLE)
+    console.log(`reset temp table ${TEMP_TABLE}`)
+
+    const affected = await findAffected()
+    const totalSeries = affected.reduce((acc, v) => acc + v.series_times.length, 0)
+    console.log(`${affected.length} vaults, ${totalSeries} series_time rows below floor\n`)
+
+    if (affected.length === 0) {
+      console.log('nothing to backfill.')
+      return
+    }
+
+    let totalStaged = 0
+    let totalErrors = 0
+
+    for (let i = 0; i < affected.length; i += CONCURRENCY) {
+      const batch = affected.slice(i, i + CONCURRENCY)
+      const results = await Promise.all(batch.map(replayVault))
+      for (const r of results) {
+        totalStaged += r.staged
+        totalErrors += r.errors
+      }
+    }
+
+    const duration = ((Date.now() - startTime) / 1000).toFixed(2)
+    console.log('\n=== Summary ===')
+    console.log(`Vaults:    ${affected.length}`)
+    console.log(`Series:    ${totalSeries}`)
+    console.log(`Staged:    ${totalStaged}`)
+    console.log(`Errors:    ${totalErrors}`)
+    console.log(`Duration:  ${duration}s`)
+  } finally {
+    await rpcs.down()
+    await db.end()
+  }
 }
 
 main().catch(error => {

--- a/packages/scripts/src/backfill-apr-oracle-negative-netapr/compute.ts
+++ b/packages/scripts/src/backfill-apr-oracle-negative-netapr/compute.ts
@@ -21,7 +21,7 @@ import { insertTempBatch, resetTempTable, type TempRow } from '../backfill-share
  */
 
 const TEMP_TABLE = 'output_temp_netapr_floor_backfill'
-const CONCURRENCY = 8
+const CONCURRENCY = 150
 
 type Affected = {
   chain_id: number
@@ -42,6 +42,8 @@ async function findAffected(): Promise<FindAffectedResult> {
   // which is non-linear — comparing netApy against apr/2 would be the wrong
   // check. We identify affected series_times from netApr alone, and the
   // replay recomputes both netApr and netApy.
+  console.log('querying below-floor netApr rows...')
+  const queryStart = Date.now()
   const { rows } = await db.query(`
     SELECT
       n.chain_id,
@@ -60,6 +62,7 @@ async function findAffected(): Promise<FindAffectedResult> {
       AND (g.value IS NULL OR n.value < g.value / 2)
     ORDER BY n.chain_id, n.address, n.series_time
   `)
+  console.log(`query returned ${rows.length} rows in ${((Date.now() - queryStart) / 1000).toFixed(2)}s`)
 
   let skippedNoGross = 0
   let skippedGrossNegative = 0
@@ -186,14 +189,23 @@ async function main() {
 
     let totalStaged = 0
     let totalErrors = 0
+    let completedVaults = 0
 
     for (let i = 0; i < affected.length; i += CONCURRENCY) {
       const batch = affected.slice(i, i + CONCURRENCY)
+      const batchStart = Date.now()
+      console.log(`\nbatch ${i / CONCURRENCY + 1}/${Math.ceil(affected.length / CONCURRENCY)}: vaults ${i + 1}-${Math.min(i + CONCURRENCY, affected.length)}/${affected.length}`)
       const results = await Promise.all(batch.map(replayVault))
       for (const r of results) {
         totalStaged += r.staged
         totalErrors += r.errors
       }
+      completedVaults += batch.length
+      const elapsed = (Date.now() - startTime) / 1000
+      const rate = completedVaults / elapsed
+      const remaining = affected.length - completedVaults
+      const eta = rate > 0 ? (remaining / rate).toFixed(0) : '?'
+      console.log(`batch done in ${((Date.now() - batchStart) / 1000).toFixed(2)}s | progress ${completedVaults}/${affected.length} vaults | staged=${totalStaged} errors=${totalErrors} | eta=${eta}s`)
     }
 
     const duration = ((Date.now() - startTime) / 1000).toFixed(2)

--- a/packages/scripts/src/backfill-apr-oracle-negative-netapr/compute.ts
+++ b/packages/scripts/src/backfill-apr-oracle-negative-netapr/compute.ts
@@ -27,41 +27,84 @@ type Affected = {
   series_times: bigint[]
 }
 
-async function findAffected(): Promise<Affected[]> {
+type FindAffectedResult = {
+  affected: Affected[]
+  totalBelowFloor: number
+  skippedNoGross: number
+  skippedGrossNegative: number
+  stageable: number
+}
+
+async function findAffected(): Promise<FindAffectedResult> {
+  // Count every netApr and netApy row below floor (both are derived from the
+  // same replay). LEFT JOIN so we can distinguish "no matching gross row"
+  // from "gross is negative"; both are skipped.
   const { rows } = await db.query(`
     SELECT
       n.chain_id,
       n.address,
-      EXTRACT(EPOCH FROM n.series_time)::bigint AS series_time_epoch
+      n.component,
+      EXTRACT(EPOCH FROM n.series_time)::bigint AS series_time_epoch,
+      g.value AS gross_value
     FROM public.output n
-    JOIN public.output g
+    LEFT JOIN public.output g
       ON g.chain_id    = n.chain_id
      AND g.address     = n.address
      AND g.label       = 'apr-oracle'
      AND g.component   = 'apr'
      AND g.series_time = n.series_time
     WHERE n.label = 'apr-oracle'
-      AND n.component = 'netApr'
-      AND n.value < g.value / 2
-    ORDER BY n.chain_id, n.address, n.series_time
+      AND n.component IN ('netApr', 'netApy')
+      AND (g.value IS NULL OR n.value < g.value / 2)
+    ORDER BY n.chain_id, n.address, n.series_time, n.component
   `)
 
+  let skippedNoGross = 0
+  let skippedGrossNegative = 0
+  // Dedupe by (chain, address, series_time): one replay covers both netApr and netApy.
+  const seen = new Set<string>()
   const grouped = new Map<string, Affected>()
+
   for (const r of rows) {
-    const key = `${r.chain_id}:${r.address.toLowerCase()}`
+    if (r.gross_value === null || r.gross_value === undefined) {
+      skippedNoGross++
+      continue
+    }
+    if (Number(r.gross_value) < 0) {
+      skippedGrossNegative++
+      continue
+    }
+    const dedupeKey = `${r.chain_id}:${r.address.toLowerCase()}:${r.series_time_epoch}`
+    if (seen.has(dedupeKey)) continue
+    seen.add(dedupeKey)
+
+    const vaultKey = `${r.chain_id}:${r.address.toLowerCase()}`
     const seriesTime = BigInt(r.series_time_epoch)
-    const existing = grouped.get(key)
+    const existing = grouped.get(vaultKey)
     if (existing) {
       existing.series_times.push(seriesTime)
     } else {
-      grouped.set(key, { chain_id: r.chain_id, address: r.address, series_times: [seriesTime] })
+      grouped.set(vaultKey, { chain_id: r.chain_id, address: r.address, series_times: [seriesTime] })
     }
   }
-  return [...grouped.values()]
+
+  const stageable = rows.length - skippedNoGross - skippedGrossNegative
+
+  return {
+    affected: [...grouped.values()],
+    totalBelowFloor: rows.length,
+    skippedNoGross,
+    skippedGrossNegative,
+    stageable,
+  }
 }
 
 function outputToTempRow(output: Output): TempRow | null {
   if (output.component == null || output.value == null) return null
+  // We pass the original series_time epoch in as `blockTime`, so the hook echoes it
+  // back and series_time/block_time are both the series-bucket timestamp. This matches
+  // the primary key (chain_id, address, label, component, series_time) used on upsert.
+  const seriesDate = new Date(Number(output.blockTime) * 1000)
   return {
     chain_id: output.chainId,
     address: output.address,
@@ -69,8 +112,8 @@ function outputToTempRow(output: Output): TempRow | null {
     component: output.component,
     value: output.value,
     block_number: output.blockNumber,
-    block_time: new Date(Number(output.blockTime) * 1000),
-    series_time: new Date(Number(output.blockTime) * 1000),
+    block_time: seriesDate,
+    series_time: seriesDate,
   }
 }
 
@@ -126,9 +169,12 @@ async function main() {
     await resetTempTable(TEMP_TABLE)
     console.log(`reset temp table ${TEMP_TABLE}`)
 
-    const affected = await findAffected()
-    const totalSeries = affected.reduce((acc, v) => acc + v.series_times.length, 0)
-    console.log(`${affected.length} vaults, ${totalSeries} series_time rows below floor\n`)
+    const { affected, totalBelowFloor, skippedNoGross, skippedGrossNegative, stageable } = await findAffected()
+    const uniqueSeriesTimes = affected.reduce((acc, v) => acc + v.series_times.length, 0)
+    console.log(`Below-floor rows found: ${totalBelowFloor}  (netApr + netApy)`)
+    console.log(`Skipped (no gross row): ${skippedNoGross}`)
+    console.log(`Skipped (gross < 0): ${skippedGrossNegative}`)
+    console.log(`To replay: ${uniqueSeriesTimes} unique series_times across ${affected.length} vaults\n`)
 
     if (affected.length === 0) {
       console.log('nothing to backfill.')
@@ -149,11 +195,14 @@ async function main() {
 
     const duration = ((Date.now() - startTime) / 1000).toFixed(2)
     console.log('\n=== Summary ===')
-    console.log(`Vaults:    ${affected.length}`)
-    console.log(`Series:    ${totalSeries}`)
-    console.log(`Staged:    ${totalStaged}`)
-    console.log(`Errors:    ${totalErrors}`)
-    console.log(`Duration:  ${duration}s`)
+    console.log(`Below-floor rows found:  ${totalBelowFloor}`)
+    console.log(`Staged (gross >= 0):     ${stageable}`)
+    console.log(`Skipped (no gross row):  ${skippedNoGross}`)
+    console.log(`Skipped (gross < 0):     ${skippedGrossNegative}`)
+    console.log(`Output rows staged:      ${totalStaged}  (${uniqueSeriesTimes} replays x up to 4 components)`)
+    console.log(`Vaults replayed:         ${affected.length}`)
+    console.log(`Errors:                  ${totalErrors}`)
+    console.log(`Duration:                ${duration}s`)
   } finally {
     await rpcs.down()
     await db.end()

--- a/packages/scripts/src/backfill-apr-oracle-negative-netapr/compute.ts
+++ b/packages/scripts/src/backfill-apr-oracle-negative-netapr/compute.ts
@@ -29,7 +29,10 @@ type Affected = {
 
 async function findAffected(): Promise<Affected[]> {
   const { rows } = await db.query(`
-    SELECT n.chain_id, n.address, n.series_time
+    SELECT
+      n.chain_id,
+      n.address,
+      EXTRACT(EPOCH FROM n.series_time)::bigint AS series_time_epoch
     FROM public.output n
     JOIN public.output g
       ON g.chain_id    = n.chain_id
@@ -46,7 +49,7 @@ async function findAffected(): Promise<Affected[]> {
   const grouped = new Map<string, Affected>()
   for (const r of rows) {
     const key = `${r.chain_id}:${r.address.toLowerCase()}`
-    const seriesTime = BigInt(Math.floor(new Date(r.series_time).getTime() / 1000))
+    const seriesTime = BigInt(r.series_time_epoch)
     const existing = grouped.get(key)
     if (existing) {
       existing.series_times.push(seriesTime)
@@ -74,8 +77,14 @@ function outputToTempRow(output: Output): TempRow | null {
 async function replayVault(vault: Affected) {
   const staged: TempRow[] = []
   let errors = 0
+  const total = vault.series_times.length
+  const tag = `${vault.chain_id}:${vault.address}`
+  const logEvery = Math.max(1, Math.floor(total / 10))
 
-  for (const seriesTime of vault.series_times) {
+  console.log(`  ${tag} start series=${total}`)
+
+  for (let i = 0; i < total; i++) {
+    const seriesTime = vault.series_times[i]
     try {
       const outputs = await aprOracleHook(vault.chain_id, vault.address, {
         abiPath: 'yearn/3/vault',
@@ -90,7 +99,11 @@ async function replayVault(vault: Affected) {
       }
     } catch (error) {
       errors++
-      console.error(`  error ${vault.chain_id}:${vault.address} @ ${seriesTime}:`, error instanceof Error ? error.message : error)
+      console.error(`  ${tag} error @ ${seriesTime}:`, error instanceof Error ? error.message : error)
+    }
+
+    if ((i + 1) % logEvery === 0 || i + 1 === total) {
+      console.log(`  ${tag} progress ${i + 1}/${total} staged=${staged.length} errors=${errors}`)
     }
   }
 
@@ -101,7 +114,7 @@ async function replayVault(vault: Affected) {
     }
   }
 
-  console.log(`  ${vault.chain_id}:${vault.address} series=${vault.series_times.length} staged=${staged.length} errors=${errors}`)
+  console.log(`  ${tag} done series=${total} staged=${staged.length} errors=${errors}`)
   return { staged: staged.length, errors }
 }
 

--- a/packages/scripts/src/backfill-apr-oracle-negative-netapr/upsert.ts
+++ b/packages/scripts/src/backfill-apr-oracle-negative-netapr/upsert.ts
@@ -2,6 +2,7 @@ import 'lib/global'
 
 import db from 'ingest/db'
 import { mq } from 'lib'
+import { promoteTempTable } from '../backfill-shared/upsert'
 
 /**
  * Phase 2: Promote floored netApr/netApy outputs from the temp table into the
@@ -10,101 +11,13 @@ import { mq } from 'lib'
 
 const TEMP_TABLE = 'output_temp_netapr_floor_backfill'
 
-function parseArgs(argv: string[]) {
-  const hasArg = (flag: string) => argv.includes(flag)
-
-  if (hasArg('--help') || hasArg('-h')) {
-    console.log(`usage:
-  bun packages/scripts/src/backfill-apr-oracle-negative-netapr/upsert.ts [--dry-run]
-
-Promotes rows from ${TEMP_TABLE} into the output table and drops the temp table.
-Run compute.ts first to populate the temp table.`)
-    process.exit(0)
-  }
-
-  return {
-    dryRun: hasArg('--dry-run'),
-  }
-}
-
 async function main() {
-  const args = parseArgs(process.argv.slice(2))
-
-  console.log(args.dryRun ? 'DRY RUN mode' : 'UPSERT mode')
-
   try {
-    const count = await db.query(`SELECT COUNT(*) FROM ${TEMP_TABLE}`)
-    const rowCount = Number(count.rows[0].count)
-    console.log(`found ${rowCount} rows in ${TEMP_TABLE}`)
-
-    if (rowCount === 0) {
-      console.log('nothing to upsert. Run compute.ts first.')
-      await mq.down()
-      await db.end()
-      return
-    }
-
-    const sample = await db.query(`
-      SELECT chain_id, address, component, value, series_time
-      FROM ${TEMP_TABLE}
-      ORDER BY chain_id, address, component, series_time
-      LIMIT 20
-    `)
-    console.log('\nsample rows:')
-    for (const row of sample.rows) {
-      console.log(`  ${row.chain_id}:${row.address} ${row.component}=${Number(row.value).toFixed(6)} @ ${row.series_time.toISOString()}`)
-    }
-
-    const vaultCount = await db.query(`
-      SELECT COUNT(DISTINCT (chain_id, address)) FROM ${TEMP_TABLE}
-    `)
-    console.log(`\ndistinct vaults: ${vaultCount.rows[0].count}`)
-
-    if (args.dryRun) {
-      console.log('\nDRY RUN: no changes made.')
-      await mq.down()
-      await db.end()
-      return
-    }
-
-    console.log('\nupserting...')
-    const client = await db.connect()
-    try {
-      await client.query('BEGIN')
-
-      const result = await client.query(`
-        INSERT INTO output (chain_id, address, label, component, value, block_number, block_time, series_time)
-        SELECT chain_id, address, label, component, value, block_number, block_time, series_time
-        FROM ${TEMP_TABLE}
-        ON CONFLICT (chain_id, address, label, component, series_time)
-        DO UPDATE SET
-          value = EXCLUDED.value,
-          block_number = EXCLUDED.block_number,
-          block_time = EXCLUDED.block_time
-      `)
-      console.log(`upserted ${result.rowCount} rows`)
-
-      await client.query(`DROP TABLE ${TEMP_TABLE}`)
-      console.log(`dropped ${TEMP_TABLE}`)
-
-      await client.query('COMMIT')
-      console.log('done.')
-    } catch (err) {
-      await client.query('ROLLBACK')
-      throw err
-    } finally {
-      client.release()
-    }
-  } catch (err) {
-    if (err instanceof Error && 'code' in err && (err as { code: string }).code === '42P01') {
-      console.error(`table ${TEMP_TABLE} does not exist. Run compute.ts first.`)
-    } else {
-      throw err
-    }
+    await promoteTempTable(TEMP_TABLE)
+  } finally {
+    await mq.down()
+    await db.end()
   }
-
-  await mq.down()
-  await db.end()
 }
 
 main().catch(error => {

--- a/packages/scripts/src/backfill-apr-oracle-negative-netapr/upsert.ts
+++ b/packages/scripts/src/backfill-apr-oracle-negative-netapr/upsert.ts
@@ -2,7 +2,7 @@ import 'lib/global'
 
 import db from 'ingest/db'
 import { mq } from 'lib'
-import { parsePromoteArgs, promoteTempTable } from '../backfill-shared/upsert'
+import { promoteTempTable } from '../backfill-shared/upsert'
 
 /**
  * Phase 2: Promote floored netApr/netApy outputs from the temp table into the
@@ -10,12 +10,10 @@ import { parsePromoteArgs, promoteTempTable } from '../backfill-shared/upsert'
  */
 
 const TEMP_TABLE = 'output_temp_netapr_floor_backfill'
-const SCRIPT_PATH = 'packages/scripts/src/backfill-apr-oracle-negative-netapr/upsert.ts'
 
 async function main() {
-  const options = parsePromoteArgs(process.argv.slice(2), SCRIPT_PATH, TEMP_TABLE)
   try {
-    await promoteTempTable(TEMP_TABLE, options)
+    await promoteTempTable(TEMP_TABLE)
   } finally {
     await mq.down()
     await db.end()

--- a/packages/scripts/src/backfill-apr-oracle-negative-netapr/upsert.ts
+++ b/packages/scripts/src/backfill-apr-oracle-negative-netapr/upsert.ts
@@ -2,7 +2,7 @@ import 'lib/global'
 
 import db from 'ingest/db'
 import { mq } from 'lib'
-import { promoteTempTable } from '../backfill-shared/upsert'
+import { parsePromoteArgs, promoteTempTable } from '../backfill-shared/upsert'
 
 /**
  * Phase 2: Promote floored netApr/netApy outputs from the temp table into the
@@ -10,10 +10,12 @@ import { promoteTempTable } from '../backfill-shared/upsert'
  */
 
 const TEMP_TABLE = 'output_temp_netapr_floor_backfill'
+const SCRIPT_PATH = 'packages/scripts/src/backfill-apr-oracle-negative-netapr/upsert.ts'
 
 async function main() {
+  const options = parsePromoteArgs(process.argv.slice(2), SCRIPT_PATH, TEMP_TABLE)
   try {
-    await promoteTempTable(TEMP_TABLE)
+    await promoteTempTable(TEMP_TABLE, options)
   } finally {
     await mq.down()
     await db.end()

--- a/packages/scripts/src/backfill-apr-oracle-negative-netapr/upsert.ts
+++ b/packages/scripts/src/backfill-apr-oracle-negative-netapr/upsert.ts
@@ -1,7 +1,6 @@
 import 'lib/global'
 
 import db from 'ingest/db'
-import { mq } from 'lib'
 import { promoteTempTable } from '../backfill-shared/upsert'
 
 /**
@@ -15,7 +14,6 @@ async function main() {
   try {
     await promoteTempTable(TEMP_TABLE)
   } finally {
-    await mq.down()
     await db.end()
   }
 }

--- a/packages/scripts/src/backfill-apr-oracle-negative-netapr/upsert.ts
+++ b/packages/scripts/src/backfill-apr-oracle-negative-netapr/upsert.ts
@@ -1,0 +1,113 @@
+import 'lib/global'
+
+import db from 'ingest/db'
+import { mq } from 'lib'
+
+/**
+ * Phase 2: Promote floored netApr/netApy outputs from the temp table into the
+ * production output table. Run compute.ts first.
+ */
+
+const TEMP_TABLE = 'output_temp_netapr_floor_backfill'
+
+function parseArgs(argv: string[]) {
+  const hasArg = (flag: string) => argv.includes(flag)
+
+  if (hasArg('--help') || hasArg('-h')) {
+    console.log(`usage:
+  bun packages/scripts/src/backfill-apr-oracle-negative-netapr/upsert.ts [--dry-run]
+
+Promotes rows from ${TEMP_TABLE} into the output table and drops the temp table.
+Run compute.ts first to populate the temp table.`)
+    process.exit(0)
+  }
+
+  return {
+    dryRun: hasArg('--dry-run'),
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2))
+
+  console.log(args.dryRun ? 'DRY RUN mode' : 'UPSERT mode')
+
+  try {
+    const count = await db.query(`SELECT COUNT(*) FROM ${TEMP_TABLE}`)
+    const rowCount = Number(count.rows[0].count)
+    console.log(`found ${rowCount} rows in ${TEMP_TABLE}`)
+
+    if (rowCount === 0) {
+      console.log('nothing to upsert. Run compute.ts first.')
+      await mq.down()
+      await db.end()
+      return
+    }
+
+    const sample = await db.query(`
+      SELECT chain_id, address, component, value, series_time
+      FROM ${TEMP_TABLE}
+      ORDER BY chain_id, address, component, series_time
+      LIMIT 20
+    `)
+    console.log('\nsample rows:')
+    for (const row of sample.rows) {
+      console.log(`  ${row.chain_id}:${row.address} ${row.component}=${Number(row.value).toFixed(6)} @ ${row.series_time.toISOString()}`)
+    }
+
+    const vaultCount = await db.query(`
+      SELECT COUNT(DISTINCT (chain_id, address)) FROM ${TEMP_TABLE}
+    `)
+    console.log(`\ndistinct vaults: ${vaultCount.rows[0].count}`)
+
+    if (args.dryRun) {
+      console.log('\nDRY RUN: no changes made.')
+      await mq.down()
+      await db.end()
+      return
+    }
+
+    console.log('\nupserting...')
+    const client = await db.connect()
+    try {
+      await client.query('BEGIN')
+
+      const result = await client.query(`
+        INSERT INTO output (chain_id, address, label, component, value, block_number, block_time, series_time)
+        SELECT chain_id, address, label, component, value, block_number, block_time, series_time
+        FROM ${TEMP_TABLE}
+        ON CONFLICT (chain_id, address, label, component, series_time)
+        DO UPDATE SET
+          value = EXCLUDED.value,
+          block_number = EXCLUDED.block_number,
+          block_time = EXCLUDED.block_time
+      `)
+      console.log(`upserted ${result.rowCount} rows`)
+
+      await client.query(`DROP TABLE ${TEMP_TABLE}`)
+      console.log(`dropped ${TEMP_TABLE}`)
+
+      await client.query('COMMIT')
+      console.log('done.')
+    } catch (err) {
+      await client.query('ROLLBACK')
+      throw err
+    } finally {
+      client.release()
+    }
+  } catch (err) {
+    if (err instanceof Error && 'code' in err && (err as { code: string }).code === '42P01') {
+      console.error(`table ${TEMP_TABLE} does not exist. Run compute.ts first.`)
+    } else {
+      throw err
+    }
+  }
+
+  await mq.down()
+  await db.end()
+}
+
+main().catch(error => {
+  console.error('Fatal error:', error)
+  process.exit(1)
+})

--- a/packages/scripts/src/backfill-shared/tempTable.ts
+++ b/packages/scripts/src/backfill-shared/tempTable.ts
@@ -2,6 +2,9 @@ import 'lib/global'
 
 import db from 'ingest/db'
 
+// NOTE: `name` is interpolated directly into SQL and must be a hardcoded
+// identifier from the caller — never user input.
+
 export type TempRow = {
   chain_id: number
   address: string

--- a/packages/scripts/src/backfill-shared/tempTable.ts
+++ b/packages/scripts/src/backfill-shared/tempTable.ts
@@ -1,0 +1,56 @@
+import 'lib/global'
+
+import db from 'ingest/db'
+
+export type TempRow = {
+  chain_id: number
+  address: string
+  label: string
+  component: string
+  value: number
+  block_number: string | bigint
+  block_time: Date
+  series_time: Date
+}
+
+export async function resetTempTable(name: string): Promise<void> {
+  await db.query(`
+    CREATE TABLE IF NOT EXISTS ${name} (
+      chain_id     integer NOT NULL,
+      address      text NOT NULL,
+      label        text NOT NULL,
+      component    text NOT NULL,
+      value        numeric,
+      block_number bigint NOT NULL,
+      block_time   timestamptz NOT NULL,
+      series_time  timestamptz NOT NULL,
+      PRIMARY KEY  (chain_id, address, label, component, series_time)
+    )
+  `)
+  await db.query(`TRUNCATE TABLE ${name}`)
+}
+
+export async function insertTempBatch(name: string, rows: TempRow[]): Promise<void> {
+  if (rows.length === 0) return
+
+  const values: string[] = []
+  const params: (string | number | bigint | Date)[] = []
+  let idx = 1
+
+  for (const row of rows) {
+    values.push(`($${idx}, $${idx + 1}, $${idx + 2}, $${idx + 3}, $${idx + 4}, $${idx + 5}, $${idx + 6}, $${idx + 7})`)
+    params.push(
+      row.chain_id, row.address, row.label, row.component, row.value,
+      typeof row.block_number === 'bigint' ? row.block_number.toString() : row.block_number,
+      row.block_time, row.series_time,
+    )
+    idx += 8
+  }
+
+  await db.query(`
+    INSERT INTO ${name} (chain_id, address, label, component, value, block_number, block_time, series_time)
+    VALUES ${values.join(', ')}
+    ON CONFLICT (chain_id, address, label, component, series_time)
+    DO UPDATE SET value = EXCLUDED.value, block_number = EXCLUDED.block_number, block_time = EXCLUDED.block_time
+  `, params)
+}

--- a/packages/scripts/src/backfill-shared/upsert.ts
+++ b/packages/scripts/src/backfill-shared/upsert.ts
@@ -31,15 +31,16 @@ export async function promoteTempTable(tempTable: string): Promise<void> {
     const client = await db.connect()
     try {
       await client.query('BEGIN')
+      // On conflict we only update `value`. block_time and block_number on the
+      // existing row are left untouched so downstream bucketing/filtering (which
+      // uses block_time, not series_time) stays aligned with the original block.
       const result = await client.query(`
         INSERT INTO output (chain_id, address, label, component, value, block_number, block_time, series_time)
         SELECT chain_id, address, label, component, value, block_number, block_time, series_time
         FROM ${tempTable}
         ON CONFLICT (chain_id, address, label, component, series_time)
         DO UPDATE SET
-          value = EXCLUDED.value,
-          block_number = EXCLUDED.block_number,
-          block_time = EXCLUDED.block_time
+          value = EXCLUDED.value
       `)
       console.log(`upserted ${result.rowCount} rows`)
 

--- a/packages/scripts/src/backfill-shared/upsert.ts
+++ b/packages/scripts/src/backfill-shared/upsert.ts
@@ -2,7 +2,29 @@ import 'lib/global'
 
 import db from 'ingest/db'
 
-export async function promoteTempTable(tempTable: string): Promise<void> {
+export type PromoteOptions = {
+  dryRun?: boolean
+}
+
+export function parsePromoteArgs(argv: string[], scriptPath: string, tempTable: string): PromoteOptions {
+  const hasArg = (flag: string) => argv.includes(flag)
+
+  if (hasArg('--help') || hasArg('-h')) {
+    console.log(`usage:
+  bun ${scriptPath} [--dry-run]
+
+Promotes rows from ${tempTable} into the output table and drops the temp table.
+Run compute.ts first to populate the temp table.`)
+    process.exit(0)
+  }
+
+  return { dryRun: hasArg('--dry-run') }
+}
+
+export async function promoteTempTable(tempTable: string, options: PromoteOptions = {}): Promise<void> {
+  const { dryRun = false } = options
+  console.log(dryRun ? 'DRY RUN mode' : 'UPSERT mode')
+
   try {
     const count = await db.query(`SELECT COUNT(*) FROM ${tempTable}`)
     const rowCount = Number(count.rows[0].count)
@@ -26,6 +48,11 @@ export async function promoteTempTable(tempTable: string): Promise<void> {
 
     const vaultCount = await db.query(`SELECT COUNT(DISTINCT (chain_id, address)) FROM ${tempTable}`)
     console.log(`\ndistinct vaults: ${vaultCount.rows[0].count}`)
+
+    if (dryRun) {
+      console.log('\nDRY RUN: no changes made.')
+      return
+    }
 
     console.log('\nupserting...')
     const client = await db.connect()

--- a/packages/scripts/src/backfill-shared/upsert.ts
+++ b/packages/scripts/src/backfill-shared/upsert.ts
@@ -2,29 +2,7 @@ import 'lib/global'
 
 import db from 'ingest/db'
 
-export type PromoteOptions = {
-  dryRun?: boolean
-}
-
-export function parsePromoteArgs(argv: string[], scriptPath: string, tempTable: string): PromoteOptions {
-  const hasArg = (flag: string) => argv.includes(flag)
-
-  if (hasArg('--help') || hasArg('-h')) {
-    console.log(`usage:
-  bun ${scriptPath} [--dry-run]
-
-Promotes rows from ${tempTable} into the output table and drops the temp table.
-Run compute.ts first to populate the temp table.`)
-    process.exit(0)
-  }
-
-  return { dryRun: hasArg('--dry-run') }
-}
-
-export async function promoteTempTable(tempTable: string, options: PromoteOptions = {}): Promise<void> {
-  const { dryRun = false } = options
-  console.log(dryRun ? 'DRY RUN mode' : 'UPSERT mode')
-
+export async function promoteTempTable(tempTable: string): Promise<void> {
   try {
     const count = await db.query(`SELECT COUNT(*)::int AS n FROM ${tempTable}`)
     const rowCount = count.rows[0].n
@@ -48,11 +26,6 @@ export async function promoteTempTable(tempTable: string, options: PromoteOption
 
     const vaultCount = await db.query(`SELECT COUNT(DISTINCT (chain_id, address)) FROM ${tempTable}`)
     console.log(`\ndistinct vaults: ${vaultCount.rows[0].count}`)
-
-    if (dryRun) {
-      console.log('\nDRY RUN: no changes made.')
-      return
-    }
 
     console.log('\nupserting...')
     const client = await db.connect()

--- a/packages/scripts/src/backfill-shared/upsert.ts
+++ b/packages/scripts/src/backfill-shared/upsert.ts
@@ -1,0 +1,64 @@
+import 'lib/global'
+
+import db from 'ingest/db'
+
+export async function promoteTempTable(tempTable: string): Promise<void> {
+  try {
+    const count = await db.query(`SELECT COUNT(*) FROM ${tempTable}`)
+    const rowCount = Number(count.rows[0].count)
+    console.log(`found ${rowCount} rows in ${tempTable}`)
+
+    if (rowCount === 0) {
+      console.log('nothing to upsert. Run compute.ts first.')
+      return
+    }
+
+    const sample = await db.query(`
+      SELECT chain_id, address, component, value, series_time
+      FROM ${tempTable}
+      ORDER BY chain_id, address, component, series_time
+      LIMIT 20
+    `)
+    console.log('\nsample rows:')
+    for (const row of sample.rows) {
+      console.log(`  ${row.chain_id}:${row.address} ${row.component}=${Number(row.value).toFixed(6)} @ ${row.series_time.toISOString()}`)
+    }
+
+    const vaultCount = await db.query(`SELECT COUNT(DISTINCT (chain_id, address)) FROM ${tempTable}`)
+    console.log(`\ndistinct vaults: ${vaultCount.rows[0].count}`)
+
+    console.log('\nupserting...')
+    const client = await db.connect()
+    try {
+      await client.query('BEGIN')
+      const result = await client.query(`
+        INSERT INTO output (chain_id, address, label, component, value, block_number, block_time, series_time)
+        SELECT chain_id, address, label, component, value, block_number, block_time, series_time
+        FROM ${tempTable}
+        ON CONFLICT (chain_id, address, label, component, series_time)
+        DO UPDATE SET
+          value = EXCLUDED.value,
+          block_number = EXCLUDED.block_number,
+          block_time = EXCLUDED.block_time
+      `)
+      console.log(`upserted ${result.rowCount} rows`)
+
+      await client.query(`DROP TABLE ${tempTable}`)
+      console.log(`dropped ${tempTable}`)
+
+      await client.query('COMMIT')
+      console.log('done.')
+    } catch (err) {
+      await client.query('ROLLBACK')
+      throw err
+    } finally {
+      client.release()
+    }
+  } catch (err) {
+    if (err instanceof Error && 'code' in err && (err as { code: string }).code === '42P01') {
+      console.error(`table ${tempTable} does not exist. Run compute.ts first.`)
+      return
+    }
+    throw err
+  }
+}

--- a/packages/scripts/src/backfill-shared/upsert.ts
+++ b/packages/scripts/src/backfill-shared/upsert.ts
@@ -26,8 +26,8 @@ export async function promoteTempTable(tempTable: string, options: PromoteOption
   console.log(dryRun ? 'DRY RUN mode' : 'UPSERT mode')
 
   try {
-    const count = await db.query(`SELECT COUNT(*) FROM ${tempTable}`)
-    const rowCount = Number(count.rows[0].count)
+    const count = await db.query(`SELECT COUNT(*)::int AS n FROM ${tempTable}`)
+    const rowCount = count.rows[0].n
     console.log(`found ${rowCount} rows in ${tempTable}`)
 
     if (rowCount === 0) {


### PR DESCRIPTION
### Summary

Floor `computeNetApr` at `grossApr / 2` to match Yearn's accountant invariant (management + performance fees cap at 50% of profit), and return `0` for non-positive gross (the `grossApr / 2` floor can't meaningfully be negative). Previously the hook returned `(gross - mgmt) * (1 - perf)` unconditionally, which went negative whenever the management fee (charged on TVL) exceeded a very small gross APR. Historical rows stored with below-floor `netApr` / `netApy` are rewritten by a new backfill script.

### How to review

- Core change: `packages/ingest/abis/yearn/lib/apy.ts` — `computeNetApr` now guards non-positive gross with `return 0` and floors otherwise at `grossApr / 2`.
- Unit tests: `packages/ingest/abis/yearn/lib/apy.spec.ts` — existing `100% performance fee` case updated (now returns `gross / 2`, not `0`), plus new cases for the real-world `0xAa0362…` / katana inputs and for negative gross.
- Historical cleanup: `packages/scripts/src/backfill-apr-oracle-negative-netapr/` — `compute.ts` stages rewrites to a temp table (only `netApr` / `netApy` rows; companion `apr` / `apy` rows are left untouched), `upsert.ts` promotes them and drops the temp.
- Shared helper: `packages/scripts/src/backfill-shared/upsert.ts` centralizes the preview + upsert + drop flow. The sibling `backfill-apr-oracle-getCurrentApr/upsert.ts` was migrated onto it.

Production scope of the backfill (from Neon):

Around 653 addresses spread across `mainnet`, `katana`, `arbitrum` and 80094 

### Test plan

- [x] e2e on a real vault — paste the following into the three local YAML files (all gitignored), then `make dev`, and in the terminal UI: `Ingest → fanout abis → yes` and `Ingest → fanout replays → yes`.

`config/chains.local.yaml`
```yaml
chains: [
  'mainnet',
  'katana',
]
```

`config/abis.local.yaml`
```yaml
cron:
  name: AbiFanout
  queue: fanout
  job: abis
  schedule: '*/15 * * * *'
  start: false

abis:
  - abiPath: 'yearn/3/vault'
    sources: [
      { chainId: 747474, address: '0xAa0362eCC584B985056E47812931270b99C91f9d', inceptBlock: 4222239 }
    ]
```

`config/manuals.local.yaml`
```yaml
manuals:
  - chainId: 747474
    address: '0xAa0362eCC584B985056E47812931270b99C91f9d'
    label: 'vault'
    defaults: {
      erc4626: true,
      v3: true,
      yearn: true,
      inceptBlock: 4222239,
    }
```

- [x] verify no negatives in the katana vault's timeseries
```
PGPASSWORD=password psql -h localhost -p 5432 -U user -d user -c "SELECT component, count(*), min(value)::float, max(value)::float FROM output WHERE chain_id=747474 AND lower(address)=lower('0xAa0362eCC584B985056E47812931270b99C91f9d') AND label='apr-oracle' GROUP BY component ORDER BY component; "
```
Expected: `netApr` and `netApy` rows all `≥ 0` (in my run: 31 rows each, all equal to `gross / 2` ≈ `1.4e-6 … 5.6e-4`).

- [x] backfill — compute (stages rewrites, prod DB creds in `.env`)
```
bun packages/scripts/src/backfill-apr-oracle-negative-netapr/compute.ts
```

- [ ] backfill — apply
```
bun packages/scripts/src/backfill-apr-oracle-negative-netapr/upsert.ts
```
Expected: `found 184 rows in output_temp_netapr_floor_backfill`, `distinct vaults: 4`, `upserted 184 rows`, `dropped output_temp_netapr_floor_backfill`, `done.`

- [ ] verify no negatives remain in prod
```
PGPASSWORD="$POSTGRES_PASSWORD" PGSSLMODE=require psql -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" -U "$POSTGRES_USER" -d "$POSTGRES_DATABASE" -c "SELECT count(*) FROM public.output WHERE label='apr-oracle' AND component IN ('netApr','netApy') AND value < 0; "
```
Expected: `0`.

### Risk / impact

- **Behavioral change**: the `100% performance fee` edge case previously returned `0`; now it returns `gross / 2`. This matches accountant reality (fees cap at 50% of profit) so the old `0` was the bug, but anything downstream that explicitly relied on the old zero will see a non-zero value. `computeNetApr` also now returns `0` instead of a negative for non-positive gross.
- **Rollout order**:
  1. Create a DB snapshot (Neon branch/backup).
  2. Stop the indexer.
  3. Run `bun packages/scripts/src/backfill-apr-oracle-negative-netapr/compute.ts` (writes staged rows to the temp table).
  4. Run `bun packages/scripts/src/backfill-apr-oracle-negative-netapr/upsert.ts` to promote the staged rows and drop the temp table. Note: `upsert.ts` always drops the temp table on success, so any retry requires re-running `compute.ts` first.
  5. Trigger `fanout abis` so the indexer picks up the merged `computeNetApr` floor for future rows.
  6. Restart the indexer.
  7. Trigger the `refresh snapshot` and `refresh list` GitHub Actions workflows so the REST caches pick up the new values.

- **Rollback**: restore the pre-backfill DB snapshot and revert this commit. The old formula would re-introduce negatives for newly ingested rows but the snapshot restore returns historical data to its prior state.
