### PR TITLE
fix: prefer on-chain strategy name over meta displayName

### DIFF
--- a/packages/ingest/abis/yearn/2/vault/snapshot/hook.ts
+++ b/packages/ingest/abis/yearn/2/vault/snapshot/hook.ts
@@ -1,16 +1,16 @@
-import { z } from 'zod'
-import { parseAbi, toEventSelector, zeroAddress } from 'viem'
-import { rpcs } from '../../../../../rpcs'
-import { EstimatedAprSchema, ThingSchema, TokenMetaSchema, VaultMetaSchema, zhexstring } from 'lib/types'
-import db, { getSparkline } from '../../../../../db'
-import { fetchErc20PriceUsd } from '../../../../../prices'
-import { priced } from 'lib/math'
-import { getRiskScore } from '../../../lib/risk'
-import { getTokenMeta, getVaultMeta, getStrategyMeta } from '../../../lib/meta'
-import { fetchOrExtractErc20, throwOnMulticallError } from '../../../lib'
-import { mq } from 'lib'
 import { compare } from 'compare-versions'
+import { mq } from 'lib'
+import { priced } from 'lib/math'
+import { EstimatedAprSchema, ThingSchema, TokenMetaSchema, VaultMetaSchema, zhexstring } from 'lib/types'
+import { parseAbi, toEventSelector, zeroAddress } from 'viem'
+import { z } from 'zod'
+import db, { getSparkline } from '../../../../../db'
 import { getLatestApy, getLatestEstimatedApr } from '../../../../../helpers/apy-apr'
+import { fetchErc20PriceUsd } from '../../../../../prices'
+import { rpcs } from '../../../../../rpcs'
+import { fetchOrExtractErc20, throwOnMulticallError } from '../../../lib'
+import { getStrategyMeta, getTokenMeta, getVaultMeta } from '../../../lib/meta'
+import { getRiskScore } from '../../../lib/risk'
 
 export const CompositionSchema = z.object({
   address: zhexstring,
@@ -326,7 +326,7 @@ export async function extractComposition(
     const meta = vaultMeta?.displayName ? vaultMeta : await getStrategyMeta(chainId, strategy)
 
     // Coalesce name: meta.name → snapshot.name → "Unknown"
-    const name = meta?.displayName || snapshot?.name || 'Unknown'
+    const name =  snapshot?.name || meta?.displayName || 'Unknown'
 
     // Parse latestReportApr
     const latestReportApr = snapshot?.latestReportApr ? parseFloat(snapshot.latestReportApr) : null

--- a/packages/ingest/abis/yearn/2/vault/snapshot/hook.ts
+++ b/packages/ingest/abis/yearn/2/vault/snapshot/hook.ts
@@ -325,7 +325,7 @@ export async function extractComposition(
     const vaultMeta = await getVaultMeta(chainId, strategy)
     const meta = vaultMeta?.displayName ? vaultMeta : await getStrategyMeta(chainId, strategy)
 
-    // Coalesce name: meta.name → snapshot.name → "Unknown"
+    // Coalesce name: snapshot.name → meta.name → "Unknown"
     const name =  snapshot?.name || meta?.displayName || 'Unknown'
 
     // Parse latestReportApr

--- a/packages/ingest/abis/yearn/3/vault/snapshot/hook.ts
+++ b/packages/ingest/abis/yearn/3/vault/snapshot/hook.ts
@@ -10,8 +10,8 @@ import { getLatestApy, getLatestEstimatedAprV3, getLatestOracleApr } from '../..
 import { fetchErc20PriceUsd } from '../../../../../prices'
 import { rpcs } from '../../../../../rpcs'
 import * as things from '../../../../../things'
-import { computeApy, computeNetApr } from '../../../lib/apy'
 import { fetchOrExtractErc20 } from '../../../lib'
+import { computeApy, computeNetApr } from '../../../lib/apy'
 import { getStrategyMeta, getTokenMeta, getVaultMeta } from '../../../lib/meta'
 import { getRiskScore } from '../../../lib/risk'
 import { Roles } from '../../../lib/types'
@@ -481,7 +481,7 @@ export async function extractComposition(
     const meta = vaultMeta?.displayName ? vaultMeta : await getStrategyMeta(chainId, strategy)
 
     // Coalesce name: meta.name → snapshot.name → "Unknown"
-    const name = meta?.displayName || snapshot?.name || 'Unknown'
+    const name = snapshot?.name || meta?.displayName || 'Unknown'
 
     // Parse latestReportApr
     const latestReportApr = snapshot?.latestReportApr ? parseFloat(snapshot.latestReportApr) : null

--- a/packages/ingest/abis/yearn/3/vault/snapshot/hook.ts
+++ b/packages/ingest/abis/yearn/3/vault/snapshot/hook.ts
@@ -480,7 +480,7 @@ export async function extractComposition(
     const vaultMeta = await getVaultMeta(chainId, strategy)
     const meta = vaultMeta?.displayName ? vaultMeta : await getStrategyMeta(chainId, strategy)
 
-    // Coalesce name: meta.name → snapshot.name → "Unknown"
+    // Coalesce name: snapshot.name → meta.name → "Unknown"
     const name = snapshot?.name || meta?.displayName || 'Unknown'
 
     // Parse latestReportApr


### PR DESCRIPTION
### Summary
Reorders the name fallback in strategy composition to prefer the on-chain `snapshot.name` over `meta.displayName`, so strategies show their canonical contract name first and only fall back to curated metadata when the snapshot name is missing.

### How to review
Single hunk in `packages/ingest/abis/yearn/3/vault/snapshot/hook.ts` around `extractComposition`. The import reorder is cosmetic; the behavioral change is the `name` coalesce.

Note: the inline comment above the line (`meta.name → snapshot.name → "Unknown"`) is now stale relative to the new order.

### Test plan

- [ ] update `config/chains.local.yaml` to contain only mainnet
```yaml
chains: [
  'mainnet'
]
```

- [ ] add the test vault to `config/abis.local.yaml` (yearn/3/vault on chain 1)
```yaml
abis:
  - abiPath: 'yearn/3/vault'
    sources: [
      { chainId: 1, address: '0xAe7d8Db82480E6d8e3873ecbF22cf17b3D8A7308', inceptBlock: 19677237 }
    ]
```

- [ ] add the same vault to `config/manuals.local.yaml`
```yaml
manuals:
  - chainId: 1
    address: '0xAe7d8Db82480E6d8e3873ecbF22cf17b3D8A7308'
    label: 'vault'
    defaults: {
      erc4626: true,
      v3: true,
      yearn: true,
      inceptBlock: 19677237,
    }
```

- [ ] start the dev environment
```
make dev
```

- [ ] in the terminal pane, trigger the fanout and let it run to completion
```
Ingest → fanout abis → Confirm
```
Expected: jobs dispatched and processed without errors; strategies for the vault are extracted into `snapshot`.

- [ ] query the snapshot row for the vault and inspect the composition
```
psql "$POSTGRES_URL" -c "SELECT chain_id, address, hook->'composition' AS composition FROM snapshot WHERE chain_id = 1 AND address = '0xAe7d8Db82480E6d8e3873ecbF22cf17b3D8A7308'; "
```
Expected: first entry of the composition should have name of `USDC-1`

### Risk / impact
Low. Display-only field used in strategy composition output. No funds, auth, migrations, or rate limits affected. Rollback by reverting the single commit; no data backfill needed since composition is recomputed on each fanout/replay.