### PR TITLE
Update staking registries and add manual staking pools

### DIFF
--- a/config/abis.yaml
+++ b/config/abis.yaml
@@ -23,15 +23,13 @@ abis:
   - abiPath: 'yearn/staking/registry/juiced'
     sources: [
       { chainId: 1, address: '0x85d324Bc55D1143B6a0f6310CE18A07dCF779f53', inceptBlock: 19265999 },
-      { chainId: 42161, address: '0x0BA5E8eAAb5F17318dB93292BA394F87EF7C3c54', inceptBlock: 208888788 },
-      { chainId: 137, address: '0xfA98eF08d2f75BF24c01a5DF906b0E8fC8f0c139', inceptBlock: 59619068 }
+      { chainId: 100, address: '0x776779de45D947B30A5D929C305Dc35eeE1F23be', inceptBlock: 33343074 },
     ]
 
   - abiPath: 'yearn/staking/registry/v3'
     sources: [
       { chainId: 1, address: '0x7D8DAc450dF7E222aE1d591046Eb7b5324C9d44f', inceptBlock: 20573647 },
-      { chainId: 42161, address: '0xB6bdd1DbB9961F12e73aC3692ea24cdBA36A0B6C', inceptBlock: 260251048 },
-      { chainId: 137, address: '0xD14A919aa62a64052F4ff8702d0f5cda6fF8f9F6', inceptBlock: 63749548 }
+      { chainId: 42161, address: '0x26d8ea1d8759d0f9abbcf8181b1fd5d3635dad69', inceptBlock: 226134032 },
     ]
 
   - abiPath: 'yearn/staking/registry/opboost'

--- a/config/manuals.yaml
+++ b/config/manuals.yaml
@@ -174,3 +174,33 @@ manuals:
       inceptBlock: 24329199,
       inceptTime: 1769553431
     }
+
+  - chainId: 137
+    address: '0x602920E7e0a335137E02DF139CdF8D1381DAdBfD'
+    label: 'stakingPool'
+    defaults: {
+      vault: '0xF54a15F6da443041Bb075959EA66EE47655DDFcA',
+      source: 'Juiced',
+      inceptBlock: 52593972,
+      inceptTime: 1705867685
+    }
+
+  - chainId: 1
+    address: '0x54C6b2b293297e65b1d163C3E8dbc45338bfE443'
+    label: 'stakingPool'
+    defaults: {
+      vault: '0xe24BA27551aBE96Ca401D39761cA2319Ea14e3CB',
+      source: 'Juiced',
+      inceptBlock: 18981432,
+      inceptTime: 1704948755
+    }
+
+  - chainId: 100
+    address: '0xd4263aBDdD2afdaAE0A0a69Eb09Deb8000dd642e'
+    label: 'stakingPool'
+    defaults: {
+      vault: '0x39b68451f05aaa020611cf887a7338f0991ffd60',
+      source: 'Juiced',
+      inceptBlock: 33344574,
+      inceptTime: 1712609130
+    }


### PR DESCRIPTION
Fix Missing Staking Contracts

### Summary
A bug was reported on the yearn.fi site about missing staking contracts. upon research, it was discovered that the `abis.yaml` file contained contracts that did not exist and was missing others. I have now ported the contracts from yDaemon directly and added manual contracts that existed in yDaemon as well to the manuals.yaml.

### How to review
- Confirm that all staking contracts in the abis.yaml exist on the listed chain.
- compare them to the contracts listed in the yDaemon repo in the `chain.<chainName>.go` files under the `StakingRewardRegistry` field.
- Confirm the contracts added to manuals.yaml exist and compare them to the contracts listed in the yDaemon repo in the same `chain.<chainName>.go` file as above under the `ExtraStakingContracts` field.
- confirm the removed contracts are empty.
- Update and back fill the database and confirm that contracts with staking correctly show that they have staking contracts. I'm not sure what all the vaults are, but the one that was flagged was [0x9FA306b1F4a6a83FEC98d8eBbaBEDfF78C407f6B](https://yearn.fi/vaults/42161/0x9FA306b1F4a6a83FEC98d8eBbaBEDfF78C407f6B). It currently does not show as having staking active. after the changes it should.

### Test plan
Whatever you normally do.

### Risk / impact
I think pretty harmless
