### PR TITLE
Fix lib workspace spec and switch Render back to bun

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "kong",
@@ -31,7 +32,7 @@
         "cross-env": "5.0.5",
         "dotenv": "16.4.7",
         "js-yaml": "4.1.0",
-        "lib": "workspace:packages/lib",
+        "lib": "workspace:*",
         "pg": "8.13.1",
         "redis-info": "3.1.0",
         "ts-node": "10.9.2",
@@ -117,7 +118,7 @@
         "cross-env": "5.0.5",
         "dotenv": "16.4.7",
         "figlet": "1.8.0",
-        "lib": "workspace:packages/lib",
+        "lib": "workspace:*",
         "pg": "8.13.1",
         "prompts": "2.4.2",
         "redis": "4.7.0",

--- a/packages/ingest/package.json
+++ b/packages/ingest/package.json
@@ -18,7 +18,7 @@
     "cross-env": "5.0.5",
     "dotenv": "16.4.7",
     "js-yaml": "4.1.0",
-    "lib": "workspace:packages/lib",
+    "lib": "workspace:*",
     "pg": "8.13.1",
     "redis-info": "3.1.0",
     "ts-node": "10.9.2",

--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -19,7 +19,7 @@
     "cross-env": "5.0.5",
     "dotenv": "16.4.7",
     "figlet": "1.8.0",
-    "lib": "workspace:packages/lib",
+    "lib": "workspace:*",
     "pg": "8.13.1",
     "prompts": "2.4.2",
     "redis": "4.7.0",

--- a/render.yaml
+++ b/render.yaml
@@ -15,8 +15,8 @@ services:
     region: ohio
     runtime: node
     plan: standard
-    buildCommand: yarn
-    startCommand: yarn workspace ingest production
+    buildCommand: bun install --frozen-lockfile
+    startCommand: bun run --filter ingest production
     envVars:
       - fromGroup: kong
       - key: NODE_VERSION


### PR DESCRIPTION
PR #405 changed lib's workspace dep in ingest/terminal from "^1.0.0" to "workspace:packages/lib", which is not valid workspace-protocol syntax. Render's yarn install fails with "Couldn't find any versions for lib that matches
workspace:packages/lib".

- packages/ingest/package.json, packages/terminal/package.json: lib spec changed to "workspace:*" (matches packages/scripts)
- bun.lock: aligned the cached request strings
- render.yaml: build/start commands switched from yarn back to bun. The original revert to yarn (d7c5654) was driven by a cpu-features postinstall script failing on Render; PR #405 set ignoreScripts=true in bunfig.toml, so that failure mode is gone. Using bun also keeps the minimumReleaseAge and ignoreScripts supply-chain guardrails active in production, which yarn would silently bypass.
