### PR TITLE
feat: test containers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+packages/**/node_modules
+.next
+packages/**/.next
+.env
+.env.*
+.git
+*.spec.ts
+run-tests.ts
+test.fixture.ts

--- a/docker/ingest.Dockerfile
+++ b/docker/ingest.Dockerfile
@@ -1,0 +1,24 @@
+FROM node:20-slim
+
+RUN npm install -g bun
+
+WORKDIR /app
+
+COPY package.json bun.lock ./
+COPY packages/ingest/package.json ./packages/ingest/
+COPY packages/lib/package.json ./packages/lib/
+COPY packages/db/package.json ./packages/db/
+COPY packages/scripts/package.json ./packages/scripts/
+COPY packages/terminal/package.json ./packages/terminal/
+COPY packages/web/package.json ./packages/web/
+
+RUN bun install --frozen-lockfile
+
+COPY packages/ingest ./packages/ingest
+COPY packages/lib ./packages/lib
+COPY packages/db ./packages/db
+COPY config ./config
+
+WORKDIR /app/packages/ingest
+
+CMD ["../../node_modules/.bin/ts-node", "--transpile-only", "index.ts"]

--- a/docker/web.Dockerfile
+++ b/docker/web.Dockerfile
@@ -1,0 +1,26 @@
+FROM node:20-slim
+
+RUN npm install -g bun
+
+WORKDIR /app
+
+COPY package.json bun.lock ./
+COPY packages/web/package.json ./packages/web/
+COPY packages/lib/package.json ./packages/lib/
+COPY packages/ingest/package.json ./packages/ingest/
+COPY packages/db/package.json ./packages/db/
+COPY packages/scripts/package.json ./packages/scripts/
+COPY packages/terminal/package.json ./packages/terminal/
+
+RUN bun install --frozen-lockfile
+
+COPY packages/web ./packages/web
+COPY packages/lib ./packages/lib
+COPY packages/ingest ./packages/ingest
+COPY config ./config
+
+EXPOSE 3001
+
+WORKDIR /app/packages/web
+
+CMD ["../../node_modules/.bin/next", "dev", "-p", "3001"]

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,149 @@
+# Testing
+
+## Unit tests
+
+Run unit tests for `lib` and `ingest`:
+
+```bash
+bun --filter lib test
+bun --filter ingest test
+```
+
+Both spin up isolated Postgres and Redis via Testcontainers automatically.
+
+---
+
+## E2E tests
+
+E2E tests use `TestEnvironment` from `lib/helpers/containers` to run the full stack — ingest indexer + web API — as Docker containers sharing a network with the test Postgres and Redis.
+
+### Prerequisites
+
+- Docker running
+- `.env` at repo root with RPC endpoints (`HTTP_ARCHIVE_*`, `HTTP_FULLNODE_*`, `YDAEMON_API`, etc.)
+
+### Running
+
+```bash
+node_modules/.bin/ts-node packages/ingest/run-e2e.ts
+```
+
+---
+
+## TestEnvironment API
+
+### Basic usage
+
+```typescript
+import {
+  TestEnvironment,
+  createTestPool,
+  pollForRow,
+  triggerFanout,
+} from 'lib/helpers/containers'
+
+const env = new TestEnvironment({
+  configs: {
+    chains: ['mainnet'],
+    abis: [{
+      abiPath: 'yearn/3/vault',
+      sources: [{ chainId: 1, address: '0x...', inceptBlock: 24271831 }],
+    }],
+    manuals: [{
+      chainId: 1,
+      address: '0x...',
+      label: 'vault',
+      defaults: { inceptBlock: 24271831, origin: 'yearn', apiVersion: '3.0.4' },
+    }],
+  },
+  ingest: true,
+  web: true,
+})
+
+const { webUrl } = await env.start()
+// ... test ...
+await env.stop()
+```
+
+### Options
+
+| Field | Type | Description |
+|---|---|---|
+| `configs.chains` | `string[]` | Chain names to enable (e.g. `['mainnet', 'arbitrum']`) |
+| `configs.abis` | `AbiEntry[]` | ABI sources to index |
+| `configs.manuals` | `ManualEntry[]` | Manual vault definitions |
+| `ingest` | `boolean \| IngestContainerOptions` | Start ingest container |
+| `web` | `boolean \| WebContainerOptions` | Start web container |
+
+`configs` is injected as `.local.yaml` files into the containers at startup — same as placing files in `config/` locally.
+
+RPC endpoints (`HTTP_ARCHIVE_*`, `HTTP_FULLNODE_*`, etc.) are read automatically from `.env`.
+
+### Helpers
+
+**`createTestPool()`** — creates a `pg.Pool` pointed at the test Postgres (env vars set by `env.start()`).
+
+**`pollForRow(pool, sql, params, timeoutMs?)`** — polls every 3s until the query returns at least one row, or throws after `timeoutMs` (default 120s).
+
+**`triggerFanout(jobName, data, jobId?)`** — adds a BullMQ job to the `fanout` queue on the test Redis. Use to kick off indexing without waiting for the cron.
+
+**`env.runScript(scriptPath)`** — runs a TypeScript script from the repo root as a child process, inheriting the test env vars (Postgres host/port, Redis URL, etc.). Use to run refresh scripts against the test containers:
+
+```typescript
+await env.runScript('packages/web/app/api/rest/snapshot/refresh-snapshot.ts')
+```
+
+### Full example
+
+```typescript
+describe('e2e: ingest → web snapshot', function() {
+  this.timeout(8 * 60_000)
+
+  let env: TestEnvironment
+  let pool: Pool
+
+  before(async function() {
+    env = new TestEnvironment({
+      configs: {
+        chains: ['mainnet'],
+        abis: [{
+          abiPath: 'yearn/3/vault',
+          sources: [{ chainId: 1, address: VAULT_ADDRESS, inceptBlock: 24271831 }],
+        }],
+        manuals: [{
+          chainId: 1, address: VAULT_ADDRESS, label: 'vault',
+          defaults: { inceptBlock: 24271831, origin: 'yearn', apiVersion: '3.0.4' },
+        }],
+      },
+      ingest: true,
+      web: true,
+    })
+
+    const { webUrl } = await env.start()
+    pool = createTestPool()
+
+    // trigger indexing
+    await triggerFanout('abis', { id: 'test' }, 'test-fanout')
+
+    // wait for snapshot in DB
+    await pollForRow(pool, `
+      SELECT 1 FROM thing t
+      JOIN snapshot s ON t.chain_id = s.chain_id AND t.address = s.address
+      WHERE t.chain_id = $1 AND lower(t.address) = lower($2) AND t.label = 'vault'
+    `, [1, VAULT_ADDRESS])
+
+    // populate Redis cache
+    await env.runScript('packages/web/app/api/rest/snapshot/refresh-snapshot.ts')
+  })
+
+  after(async function() {
+    await pool?.end()
+    await env?.stop()
+  })
+
+  it('serves snapshot', async function() {
+    const res = await fetch(`${webUrl}/api/rest/snapshot/1/${VAULT_ADDRESS.toLowerCase()}`)
+    expect(res.status).to.equal(200)
+  })
+})
+```

--- a/packages/ingest/abis/yearn/2/strategy/snapshot/hook.spec.ts
+++ b/packages/ingest/abis/yearn/2/strategy/snapshot/hook.spec.ts
@@ -27,7 +27,7 @@ describe('abis/yearn/2/strategy/snapshot/hook', function() {
   it('extracts estimated apr', async function() {
     const chainId = 1337
     const address = '0x1000000000000000000000000000000000000000'
-    const blockTime = 1000n
+    const blockTime = BigInt(Math.floor(Date.now() / 1000))
     const blockNumber = 1000n
 
     const outputData = {

--- a/packages/ingest/containers.spec.ts
+++ b/packages/ingest/containers.spec.ts
@@ -1,0 +1,138 @@
+import { expect } from 'chai'
+import { Queue } from 'bullmq'
+import { Pool } from 'pg'
+import IORedis from 'ioredis'
+import { TestEnvironment } from 'lib/helpers/containers'
+
+const VAULT_ADDRESS = '0x696d02Db93291651ED510704c9b286841d506987'
+const CHAIN_ID = 1
+
+const CHAINS_YAML = `
+chains:
+  - mainnet
+`.trim()
+
+const ABIS_YAML = `
+cron:
+  name: AbiFanout
+  queue: fanout
+  job: abis
+  schedule: '*/15 * * * *'
+  start: false
+abis:
+  - abiPath: yearn/3/vault
+    sources:
+      - chainId: 1
+        address: '${VAULT_ADDRESS}'
+        inceptBlock: 24271831
+`.trim()
+
+const MANUALS_YAML = `
+manuals:
+  - chainId: 1
+    address: '${VAULT_ADDRESS}'
+    label: vault
+    defaults:
+      inceptBlock: 24271831
+      origin: yearn
+      apiVersion: 3.0.4
+`.trim()
+
+async function pollForSnapshot(pool: Pool, timeoutMs = 120_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    const { rows } = await pool.query(`
+      SELECT 1 FROM thing t
+      JOIN snapshot s ON t.chain_id = s.chain_id AND t.address = s.address
+      WHERE t.chain_id = $1 AND lower(t.address) = lower($2) AND t.label = 'vault'
+    `, [CHAIN_ID, VAULT_ADDRESS])
+    if (rows.length > 0) return
+    await new Promise(r => setTimeout(r, 3_000))
+  }
+  throw new Error(`snapshot not found in DB after ${timeoutMs}ms`)
+}
+
+describe('e2e: ingest → web snapshot', function() {
+  this.timeout(8 * 60_000)
+
+  let env: TestEnvironment
+  let webUrl: string
+  let pool: Pool
+
+  before(async function() {
+    env = new TestEnvironment({
+      configs: { chains: CHAINS_YAML, abis: ABIS_YAML, manuals: MANUALS_YAML },
+      ingest: {
+        env: {
+          HTTP_ARCHIVE_1: process.env.HTTP_ARCHIVE_1 || '',
+          HTTP_FULLNODE_1: process.env.HTTP_FULLNODE_1 || '',
+          YDAEMON_API: process.env.YDAEMON_API || '',
+        }
+      },
+      web: true,
+    })
+
+    const result = await env.start()
+    webUrl = result.webUrl
+
+    pool = new Pool({
+      host: process.env.POSTGRES_HOST,
+      port: Number(process.env.POSTGRES_PORT),
+      user: process.env.POSTGRES_USER,
+      password: process.env.POSTGRES_PASSWORD,
+      database: process.env.POSTGRES_DATABASE,
+    })
+
+    // trigger one-shot fanout so ingest indexes the vault
+    const fanoutQueue = new Queue('fanout', {
+      connection: {
+        host: process.env.REDIS_HOST || 'localhost',
+        port: Number(process.env.REDIS_PORT || 6379),
+      }
+    })
+    await fanoutQueue.add('abis', { id: 'e2e-test' }, { jobId: 'e2e-test-fanout' })
+    await fanoutQueue.close()
+
+    // wait for ingest to write thing + snapshot to postgres
+    await pollForSnapshot(pool)
+
+    // refresh: read snapshot from postgres, write to redis (same logic as refresh-snapshot.ts)
+    const { rows } = await pool.query(`
+      SELECT
+        t.chain_id AS "chainId",
+        t.address,
+        t.defaults,
+        s.snapshot,
+        s.hook
+      FROM thing t
+      JOIN snapshot s ON t.chain_id = s.chain_id AND t.address = s.address
+      WHERE t.chain_id = $1 AND lower(t.address) = lower($2) AND t.label = 'vault'
+    `, [CHAIN_ID, VAULT_ADDRESS])
+
+    if (rows.length === 0) throw new Error('snapshot row missing after poll')
+
+    const row = rows[0]
+    const vaultSnapshot = { chainId: row.chainId, address: row.address, ...row.defaults, ...row.snapshot, ...row.hook }
+    const redisKey = `rest:snapshot:${CHAIN_ID}:${VAULT_ADDRESS.toLowerCase()}`
+
+    const redis = new IORedis({
+      host: process.env.REDIS_HOST || 'localhost',
+      port: Number(process.env.REDIS_PORT || 6379),
+    })
+    await redis.set(redisKey, JSON.stringify({ value: vaultSnapshot }))
+    await redis.quit()
+  })
+
+  after(async function() {
+    await pool?.end()
+    await env?.stop()
+  })
+
+  it('web serves snapshot for vault', async function() {
+    const res = await fetch(`${webUrl}/api/rest/snapshot/${CHAIN_ID}/${VAULT_ADDRESS.toLowerCase()}`)
+    expect(res.status).to.equal(200)
+    const body = await res.json() as Record<string, unknown>
+    expect(body).to.have.property('chainId', CHAIN_ID)
+    expect(String(body.address).toLowerCase()).to.equal(VAULT_ADDRESS.toLowerCase())
+  })
+})

--- a/packages/ingest/containers.spec.ts
+++ b/packages/ingest/containers.spec.ts
@@ -1,56 +1,9 @@
 import { expect } from 'chai'
-import { Queue } from 'bullmq'
 import { Pool } from 'pg'
-import IORedis from 'ioredis'
-import { TestEnvironment } from 'lib/helpers/containers'
+import { TestEnvironment, createTestPool, pollForRow, triggerFanout } from 'lib/helpers/containers'
 
 const VAULT_ADDRESS = '0x696d02Db93291651ED510704c9b286841d506987'
 const CHAIN_ID = 1
-
-const CHAINS_YAML = `
-chains:
-  - mainnet
-`.trim()
-
-const ABIS_YAML = `
-cron:
-  name: AbiFanout
-  queue: fanout
-  job: abis
-  schedule: '*/15 * * * *'
-  start: false
-abis:
-  - abiPath: yearn/3/vault
-    sources:
-      - chainId: 1
-        address: '${VAULT_ADDRESS}'
-        inceptBlock: 24271831
-`.trim()
-
-const MANUALS_YAML = `
-manuals:
-  - chainId: 1
-    address: '${VAULT_ADDRESS}'
-    label: vault
-    defaults:
-      inceptBlock: 24271831
-      origin: yearn
-      apiVersion: 3.0.4
-`.trim()
-
-async function pollForSnapshot(pool: Pool, timeoutMs = 120_000): Promise<void> {
-  const deadline = Date.now() + timeoutMs
-  while (Date.now() < deadline) {
-    const { rows } = await pool.query(`
-      SELECT 1 FROM thing t
-      JOIN snapshot s ON t.chain_id = s.chain_id AND t.address = s.address
-      WHERE t.chain_id = $1 AND lower(t.address) = lower($2) AND t.label = 'vault'
-    `, [CHAIN_ID, VAULT_ADDRESS])
-    if (rows.length > 0) return
-    await new Promise(r => setTimeout(r, 3_000))
-  }
-  throw new Error(`snapshot not found in DB after ${timeoutMs}ms`)
-}
 
 describe('e2e: ingest → web snapshot', function() {
   this.timeout(8 * 60_000)
@@ -61,66 +14,36 @@ describe('e2e: ingest → web snapshot', function() {
 
   before(async function() {
     env = new TestEnvironment({
-      configs: { chains: CHAINS_YAML, abis: ABIS_YAML, manuals: MANUALS_YAML },
-      ingest: {
-        env: {
-          HTTP_ARCHIVE_1: process.env.HTTP_ARCHIVE_1 || '',
-          HTTP_FULLNODE_1: process.env.HTTP_FULLNODE_1 || '',
-          YDAEMON_API: process.env.YDAEMON_API || '',
-        }
+      configs: {
+        chains: ['mainnet'],
+        abis: [{
+          abiPath: 'yearn/3/vault',
+          sources: [{ chainId: CHAIN_ID, address: VAULT_ADDRESS, inceptBlock: 24271831 }],
+        }],
+        manuals: [{
+          chainId: CHAIN_ID,
+          address: VAULT_ADDRESS,
+          label: 'vault',
+          defaults: { inceptBlock: 24271831, origin: 'yearn', apiVersion: '3.0.4' },
+        }],
       },
+      ingest: true,
       web: true,
     })
 
     const result = await env.start()
     webUrl = result.webUrl
+    pool = createTestPool()
 
-    pool = new Pool({
-      host: process.env.POSTGRES_HOST,
-      port: Number(process.env.POSTGRES_PORT),
-      user: process.env.POSTGRES_USER,
-      password: process.env.POSTGRES_PASSWORD,
-      database: process.env.POSTGRES_DATABASE,
-    })
+    await triggerFanout('abis', { id: 'e2e-test' }, 'e2e-test-fanout')
 
-    // trigger one-shot fanout so ingest indexes the vault
-    const fanoutQueue = new Queue('fanout', {
-      connection: {
-        host: process.env.REDIS_HOST || 'localhost',
-        port: Number(process.env.REDIS_PORT || 6379),
-      }
-    })
-    await fanoutQueue.add('abis', { id: 'e2e-test' }, { jobId: 'e2e-test-fanout' })
-    await fanoutQueue.close()
-
-    // wait for ingest to write thing + snapshot to postgres
-    await pollForSnapshot(pool)
-
-    // refresh: read snapshot from postgres, write to redis (same logic as refresh-snapshot.ts)
-    const { rows } = await pool.query(`
-      SELECT
-        t.chain_id AS "chainId",
-        t.address,
-        t.defaults,
-        s.snapshot,
-        s.hook
-      FROM thing t
+    await pollForRow(pool, `
+      SELECT 1 FROM thing t
       JOIN snapshot s ON t.chain_id = s.chain_id AND t.address = s.address
       WHERE t.chain_id = $1 AND lower(t.address) = lower($2) AND t.label = 'vault'
     `, [CHAIN_ID, VAULT_ADDRESS])
 
-    if (rows.length === 0) throw new Error('snapshot row missing after poll')
-
-    const row = rows[0]
-    const vaultSnapshot = { chainId: row.chainId, address: row.address, ...row.defaults, ...row.snapshot, ...row.hook }
-    const redisKey = `rest:snapshot:${CHAIN_ID}:${VAULT_ADDRESS.toLowerCase()}`
-
-    const redis = new IORedis({
-      host: process.env.REDIS_HOST || 'localhost',
-      port: Number(process.env.REDIS_PORT || 6379),
-    })
-    await redis.set(redisKey, JSON.stringify({ value: vaultSnapshot }))
-    await redis.quit()
+    await env.runScript('packages/web/app/api/rest/snapshot/refresh-snapshot.ts')
   })
 
   after(async function() {

--- a/packages/ingest/run-e2e.ts
+++ b/packages/ingest/run-e2e.ts
@@ -1,0 +1,31 @@
+import { spawn } from 'child_process'
+import path from 'path'
+import dotenv from 'dotenv'
+
+// load .env so RPC URLs reach the ingest container via TestEnvironment
+dotenv.config({ path: path.join(__dirname, '../..', '.env') })
+
+const mochaBin = path.resolve(__dirname, '../../node_modules/.bin/mocha')
+const userArgs = process.argv.slice(2)
+const specArgs = userArgs.length > 0 ? userArgs : ['containers.spec.ts']
+
+const proc = spawn(mochaBin, [
+  '--no-config',
+  '--require', 'ts-node/register',
+  '--extension', 'ts',
+  '--timeout', '600000',
+  '--exit',
+  ...specArgs,
+], {
+  env: process.env,
+  stdio: 'inherit',
+  shell: true,
+  cwd: __dirname,
+})
+
+proc.on('close', (code: number) => process.exit(code))
+proc.on('exit', (code: number) => process.exit(code))
+proc.on('error', () => process.exit(1))
+
+process.on('SIGINT', () => { proc.kill(); process.exit(0) })
+process.on('SIGTERM', () => { proc.kill(); process.exit(0) })

--- a/packages/ingest/run-tests.ts
+++ b/packages/ingest/run-tests.ts
@@ -35,7 +35,7 @@ spawnTestContainersAndRun().then((env) => {
   const mochaBin = path.resolve(__dirname, '../../node_modules/.bin/mocha')
 
   const userArgs = process.argv.slice(2).filter(a => a !== '--')
-  const specArgs = userArgs.length > 0 ? userArgs : ['**/*.spec.ts']
+  const specArgs = userArgs.length > 0 ? userArgs : ['--grep **/*.spec.ts']
   mochaProcess = spawn(mochaBin, ['--timeout', '5000', '--exit', ...specArgs], {
   // @ts-expect-error spawn is not typed
     env: {

--- a/packages/lib/helpers/containers.ts
+++ b/packages/lib/helpers/containers.ts
@@ -1,0 +1,198 @@
+import { GenericContainer, Network, Wait } from 'testcontainers'
+import { PostgreSqlContainer } from '@testcontainers/postgresql'
+import { RedisContainer } from '@testcontainers/redis'
+import type { StartedNetwork } from 'testcontainers'
+import type { StartedTestContainer } from 'testcontainers'
+import { migrate } from 'db'
+import path from 'path'
+import dotenv from 'dotenv'
+
+const REPO_ROOT = path.resolve(__dirname, '../../..')
+const dotenvParsed = dotenv.config({ path: path.join(REPO_ROOT, '.env') }).parsed || {}
+
+function rpcEnv(): Record<string, string> {
+  const merged = { ...dotenvParsed, ...process.env }
+  const result: Record<string, string> = {}
+  const prefixes = ['HTTP_ARCHIVE_', 'HTTP_FULLNODE_', 'YDAEMON_', 'YPRICE_', 'PRICE_SERVICE_']
+  for (const [k, v] of Object.entries(merged)) {
+    if (v && prefixes.some(p => k.startsWith(p))) result[k] = v
+  }
+  return result
+}
+
+export interface ConfigOverrides {
+  abis?: string
+  chains?: string
+  manuals?: string
+}
+
+export interface IngestContainerOptions {
+  configs?: ConfigOverrides
+  env?: Record<string, string>
+}
+
+export interface WebContainerOptions {
+  env?: Record<string, string>
+}
+
+export interface TestEnvironmentOptions {
+  ingest?: boolean | IngestContainerOptions
+  web?: boolean | WebContainerOptions
+  configs?: ConfigOverrides
+}
+
+function contentsToCopy(configs: ConfigOverrides) {
+  const items: { content: string; target: string }[] = []
+  if (configs.abis) items.push({ content: configs.abis, target: '/app/config/abis.local.yaml' })
+  if (configs.chains) items.push({ content: configs.chains, target: '/app/config/chains.local.yaml' })
+  if (configs.manuals) items.push({ content: configs.manuals, target: '/app/config/manuals.local.yaml' })
+  return items
+}
+
+// Build images once per process to leverage Docker layer cache
+let ingestImage: Promise<GenericContainer> | null = null
+let webImage: Promise<GenericContainer> | null = null
+
+function getIngestImage(): Promise<GenericContainer> {
+  return ingestImage ??= GenericContainer
+    .fromDockerfile(REPO_ROOT, 'docker/ingest.Dockerfile')
+    .build()
+}
+
+function getWebImage(): Promise<GenericContainer> {
+  return webImage ??= GenericContainer
+    .fromDockerfile(REPO_ROOT, 'docker/web.Dockerfile')
+    .build()
+}
+
+export class TestEnvironment {
+  private network: StartedNetwork | null = null
+  private postgres: StartedTestContainer | null = null
+  private redis: StartedTestContainer | null = null
+  private ingestContainer: StartedTestContainer | null = null
+  private webContainer: StartedTestContainer | null = null
+
+  webUrl = ''
+
+  constructor(private options: TestEnvironmentOptions = {}) {}
+
+  async start() {
+    this.network = await new Network().start()
+    const net = this.network
+
+    const [postgres, redis] = await Promise.all([
+      new PostgreSqlContainer('timescale/timescaledb:2.1.0-pg11')
+        .withDatabase('user')
+        .withUsername('user')
+        .withPassword('password')
+        .withExposedPorts(5432)
+        .withNetwork(net)
+        .withNetworkAliases('postgres')
+        .start(),
+      new RedisContainer('redis:latest')
+        .withHealthCheck({
+          test: ['CMD', 'redis-cli', 'ping'],
+          interval: 1000,
+          timeout: 5000,
+          retries: 5,
+        })
+        .withWaitStrategy(Wait.forHealthCheck())
+        .withNetwork(net)
+        .withNetworkAliases('redis')
+        .start(),
+    ])
+    this.postgres = postgres
+    this.redis = redis
+
+    await migrate({
+      host: postgres.getHost(),
+      port: postgres.getMappedPort(5432),
+      user: 'user',
+      password: 'password',
+      database: 'user',
+    })
+
+    // Set env for the host test process (for tests that import lib/db directly)
+    process.env.POSTGRES_HOST = postgres.getHost()
+    process.env.POSTGRES_PORT = String(postgres.getMappedPort(5432))
+    process.env.POSTGRES_USER = 'user'
+    process.env.POSTGRES_PASSWORD = 'password'
+    process.env.POSTGRES_DATABASE = 'user'
+    process.env.REDIS_HOST = redis.getHost()
+    process.env.REDIS_PORT = String(redis.getMappedPort(6379))
+
+    // Env for service containers — uses Docker network aliases, not localhost mapped ports
+    const serviceEnv = {
+      POSTGRES_HOST: 'postgres',
+      POSTGRES_PORT: '5432',
+      POSTGRES_USER: 'user',
+      POSTGRES_PASSWORD: 'password',
+      POSTGRES_DATABASE: 'user',
+      REDIS_HOST: 'redis',
+      REDIS_PORT: '6379',
+    }
+
+    const sharedConfigs = this.options.configs || {}
+
+    if (this.options.ingest) {
+      const opts = this.options.ingest === true ? {} : this.options.ingest
+      const configs = { ...sharedConfigs, ...opts.configs }
+      const image = await getIngestImage()
+
+      let container = image
+        .withNetwork(net)
+        .withEnvironment({ ...serviceEnv, ...rpcEnv(), ...(opts.env || {}) })
+        .withLogConsumer(stream => stream.on('data', (chunk: Buffer) => process.stdout.write(`[ingest] ${chunk}`)))
+        .withWaitStrategy(Wait.forLogMessage('cron up SystemProbe'))
+        .withStartupTimeout(240_000)
+
+      const copies = contentsToCopy(configs)
+      if (copies.length) container = container.withCopyContentToContainer(copies)
+
+      this.ingestContainer = await container.start()
+    }
+
+    if (this.options.web) {
+      const opts = this.options.web === true ? {} : this.options.web
+      const configs = { ...sharedConfigs }
+      const image = await getWebImage()
+
+      let container = image
+        .withNetwork(net)
+        .withExposedPorts(3001)
+        .withEnvironment({
+          ...serviceEnv,
+          GQL_CACHE_REDIS_URL: 'redis://redis:6379',
+          REST_CACHE_REDIS_URL: 'redis://redis:6379',
+          ...(opts.env || {}),
+        })
+        .withLogConsumer(stream => stream.on('data', (chunk: Buffer) => process.stdout.write(`[web] ${chunk}`)))
+        .withWaitStrategy(Wait.forLogMessage(/Ready/))
+        .withStartupTimeout(180_000)
+
+      const copies = contentsToCopy(configs)
+      if (copies.length) container = container.withCopyContentToContainer(copies)
+
+      this.webContainer = await container.start()
+      this.webUrl = `http://localhost:${this.webContainer.getMappedPort(3001)}`
+    }
+
+    return {
+      webUrl: this.webUrl,
+      ingestContainer: this.ingestContainer,
+      webContainer: this.webContainer,
+    }
+  }
+
+  async stop() {
+    await Promise.allSettled([
+      this.ingestContainer?.stop(),
+      this.webContainer?.stop(),
+    ])
+    await Promise.allSettled([
+      this.postgres?.stop(),
+      this.redis?.stop(),
+    ])
+    await this.network?.stop()
+  }
+}

--- a/packages/lib/helpers/containers.ts
+++ b/packages/lib/helpers/containers.ts
@@ -6,6 +6,10 @@ import type { StartedTestContainer } from 'testcontainers'
 import { migrate } from 'db'
 import path from 'path'
 import dotenv from 'dotenv'
+import { spawn } from 'child_process'
+import { Pool } from 'pg'
+import { Queue } from 'bullmq'
+import { dump } from 'js-yaml'
 
 const REPO_ROOT = path.resolve(__dirname, '../../..')
 const dotenvParsed = dotenv.config({ path: path.join(REPO_ROOT, '.env') }).parsed || {}
@@ -20,10 +24,28 @@ function rpcEnv(): Record<string, string> {
   return result
 }
 
+export interface AbiSource {
+  chainId: number
+  address: string
+  inceptBlock: number
+}
+
+export interface AbiEntry {
+  abiPath: string
+  sources: AbiSource[]
+}
+
+export interface ManualEntry {
+  chainId: number
+  address: string
+  label: string
+  defaults?: Record<string, unknown>
+}
+
 export interface ConfigOverrides {
-  abis?: string
-  chains?: string
-  manuals?: string
+  chains?: string[]
+  abis?: AbiEntry[]
+  manuals?: ManualEntry[]
 }
 
 export interface IngestContainerOptions {
@@ -43,10 +65,59 @@ export interface TestEnvironmentOptions {
 
 function contentsToCopy(configs: ConfigOverrides) {
   const items: { content: string; target: string }[] = []
-  if (configs.abis) items.push({ content: configs.abis, target: '/app/config/abis.local.yaml' })
-  if (configs.chains) items.push({ content: configs.chains, target: '/app/config/chains.local.yaml' })
-  if (configs.manuals) items.push({ content: configs.manuals, target: '/app/config/manuals.local.yaml' })
+  if (configs.chains)
+    items.push({ content: dump({ chains: configs.chains }), target: '/app/config/chains.local.yaml' })
+  if (configs.abis)
+    items.push({
+      content: dump({
+        cron: { name: 'AbiFanout', queue: 'fanout', job: 'abis', schedule: '*/15 * * * *', start: false },
+        abis: configs.abis,
+      }),
+      target: '/app/config/abis.local.yaml',
+    })
+  if (configs.manuals)
+    items.push({ content: dump({ manuals: configs.manuals }), target: '/app/config/manuals.local.yaml' })
   return items
+}
+
+export function createTestPool(): Pool {
+  return new Pool({
+    host: process.env.POSTGRES_HOST,
+    port: Number(process.env.POSTGRES_PORT),
+    user: process.env.POSTGRES_USER,
+    password: process.env.POSTGRES_PASSWORD,
+    database: process.env.POSTGRES_DATABASE,
+  })
+}
+
+export async function pollForRow(
+  pool: Pool,
+  sql: string,
+  params: unknown[],
+  timeoutMs = 120_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    const { rows } = await pool.query(sql, params)
+    if (rows.length > 0) return
+    await new Promise(r => setTimeout(r, 3_000))
+  }
+  throw new Error(`Row not found after ${timeoutMs}ms`)
+}
+
+export async function triggerFanout(
+  jobName: string,
+  data: Record<string, unknown>,
+  jobId?: string,
+): Promise<void> {
+  const queue = new Queue('fanout', {
+    connection: {
+      host: process.env.REDIS_HOST || 'localhost',
+      port: Number(process.env.REDIS_PORT || 6379),
+    },
+  })
+  await queue.add(jobName, data, jobId ? { jobId } : undefined)
+  await queue.close()
 }
 
 // Build images once per process to leverage Docker layer cache
@@ -81,11 +152,19 @@ export class TestEnvironment {
     const net = this.network
 
     const [postgres, redis] = await Promise.all([
-      new PostgreSqlContainer('timescale/timescaledb:2.1.0-pg11')
+      new PostgreSqlContainer('timescale/timescaledb:latest-pg16')
         .withDatabase('user')
         .withUsername('user')
         .withPassword('password')
         .withExposedPorts(5432)
+        .withHealthCheck({
+          test: ['CMD-SHELL', 'pg_isready -U user || exit 1'],
+          interval: 2000,
+          timeout: 5000,
+          retries: 30,
+          startPeriod: 10000,
+        })
+        .withWaitStrategy(Wait.forHealthCheck())
         .withNetwork(net)
         .withNetworkAliases('postgres')
         .start(),
@@ -118,8 +197,12 @@ export class TestEnvironment {
     process.env.POSTGRES_USER = 'user'
     process.env.POSTGRES_PASSWORD = 'password'
     process.env.POSTGRES_DATABASE = 'user'
+    delete process.env.POSTGRES_SSL
     process.env.REDIS_HOST = redis.getHost()
     process.env.REDIS_PORT = String(redis.getMappedPort(6379))
+    const redisUrl = `redis://${redis.getHost()}:${redis.getMappedPort(6379)}`
+    process.env.REST_CACHE_REDIS_URL = redisUrl
+    process.env.GQL_CACHE_REDIS_URL = redisUrl
 
     // Env for service containers — uses Docker network aliases, not localhost mapped ports
     const serviceEnv = {
@@ -182,6 +265,23 @@ export class TestEnvironment {
       ingestContainer: this.ingestContainer,
       webContainer: this.webContainer,
     }
+  }
+
+  runScript(scriptPath: string): Promise<void> {
+    const abs = path.isAbsolute(scriptPath) ? scriptPath : path.join(REPO_ROOT, scriptPath)
+    const tsNode = path.join(REPO_ROOT, 'node_modules/.bin/ts-node')
+    const compilerOptions = JSON.stringify({ module: 'commonjs', moduleResolution: 'node', esModuleInterop: true })
+    return new Promise((resolve, reject) => {
+      let output = ''
+      const proc = spawn(tsNode, ['--transpile-only', '--skip-project', '--compiler-options', compilerOptions, abs], {
+        env: process.env,
+        cwd: REPO_ROOT,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      })
+      proc.stdout?.on('data', (c: Buffer) => { process.stdout.write(c); output += c })
+      proc.stderr?.on('data', (c: Buffer) => { process.stderr.write(c); output += c })
+      proc.on('close', code => code === 0 ? resolve() : reject(new Error(`runScript(${path.basename(abs)}) exited ${code}:\n${output.slice(-3000)}`)))
+    })
   }
 
   async stop() {

--- a/packages/lib/helpers/containers.ts
+++ b/packages/lib/helpers/containers.ts
@@ -190,6 +190,7 @@ export class TestEnvironment {
       password: 'password',
       database: 'user',
     })
+    console.log('[test-env] ✅ database migrated')
 
     // Set env for the host test process (for tests that import lib/db directly)
     process.env.POSTGRES_HOST = postgres.getHost()
@@ -220,7 +221,9 @@ export class TestEnvironment {
     if (this.options.ingest) {
       const opts = this.options.ingest === true ? {} : this.options.ingest
       const configs = { ...sharedConfigs, ...opts.configs }
+      console.log('[test-env] 🔨 building ingest image (this may take a while on first run)...')
       const image = await getIngestImage()
+      console.log('[test-env] ✅ ingest image ready')
 
       let container = image
         .withNetwork(net)
@@ -233,12 +236,15 @@ export class TestEnvironment {
       if (copies.length) container = container.withCopyContentToContainer(copies)
 
       this.ingestContainer = await container.start()
+      console.log('[test-env] ✅ ingest container started')
     }
 
     if (this.options.web) {
       const opts = this.options.web === true ? {} : this.options.web
       const configs = { ...sharedConfigs }
+      console.log('[test-env] 🔨 building web image...')
       const image = await getWebImage()
+      console.log('[test-env] ✅ web image ready')
 
       let container = image
         .withNetwork(net)
@@ -258,6 +264,7 @@ export class TestEnvironment {
 
       this.webContainer = await container.start()
       this.webUrl = `http://localhost:${this.webContainer.getMappedPort(3001)}`
+      console.log(`[test-env] ✅ web container started at ${this.webUrl}`)
     }
 
     return {

--- a/packages/lib/helpers/tests.ts
+++ b/packages/lib/helpers/tests.ts
@@ -3,11 +3,19 @@ import { RedisContainer, StartedRedisContainer } from '@testcontainers/redis'
 import { Wait } from 'testcontainers'
 import { migrate } from 'db'
 
-export const Postgres = new PostgreSqlContainer('timescale/timescaledb:2.1.0-pg11')
+export const Postgres = new PostgreSqlContainer('timescale/timescaledb:latest-pg16')
   .withDatabase('user')
   .withUsername('user')
   .withPassword('password')
   .withExposedPorts(5432)
+  .withHealthCheck({
+    test: ['CMD-SHELL', 'pg_isready -U user || exit 1'],
+    interval: 2000,
+    timeout: 5000,
+    retries: 30,
+    startPeriod: 10000,
+  })
+  .withWaitStrategy(Wait.forHealthCheck())
 
 export const Redis = new RedisContainer('redis:latest').withHealthCheck({
   test: ['CMD', 'redis-cli', 'ping'],

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -16,6 +16,7 @@
     "cache-manager-redis-yet": "4.2.0",
     "cross-env": "5.0.5",
     "dotenv": "16.4.7",
+    "pg": "8.13.1",
     "js-yaml": "4.1.0",
     "ts-node": "10.9.2",
     "typescript": "5.7.3",

--- a/packages/lib/strider.spec.ts
+++ b/packages/lib/strider.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai'
 import { add, contains, plan, remove, rollback } from './strider'
 
-describe.only('strider', function() {
+describe('strider', function() {
   it('plans new strides', async function() {
     expect(plan(0n, 100n, undefined)).to.deep.equal([{ from: 0n, to: 100n }])
     expect(plan(0n, 100n, [])).to.deep.equal([{ from: 0n, to: 100n }])


### PR DESCRIPTION
### Summary
Adds `TestEnvironment` — a Testcontainers-based E2E harness that spins up the full kong stack (ingest + web + Postgres + Redis) as isolated Docker containers per test run. Tests can inject custom chain/ABI/manual config as plain JS objects, trigger indexing via BullMQ, poll for DB results, run refresh scripts against the live containers, and assert on the web API — all without any external infra.

Also adds a GitHub Actions `test` workflow that runs `lib` and `ingest` unit tests on every PR.

### How to review
- `packages/lib/helpers/containers.ts` — core: `TestEnvironment`, `ConfigOverrides`, `createTestPool`, `pollForRow`, `triggerFanout`, `runScript`
- `packages/ingest/containers.spec.ts` — example E2E test (ingest vault → web snapshot)
- `docker/ingest.Dockerfile` + `docker/web.Dockerfile` — service images built at test time
- `docs/testing.md` — usage reference

Unit test changes (`tests.ts`, `hook.spec.ts`) fix PG11→PG16 compatibility: health-check wait strategy + correct `block_time` for the 7-day filter.

### Test plan
- [ ] Manual: `node_modules/.bin/ts-node packages/ingest/run-e2e.ts` — requires `.env` with `HTTP_ARCHIVE_1`, `HTTP_FULLNODE_1`, `YDAEMON_API`. Expect `1 passing` in ~2–4 min after containers start.
- [ ] Automated: `bun --filter lib test` and `bun --filter ingest test` run in CI via `.github/workflows/test.yml` on every PR.

### Risk / impact
- No production code changed — all new files are test/build infra
- Dockerfiles only used at test time, not in any deploy pipeline
- `tests.ts` image bump (`timescaledb:2.1.0-pg11` → `latest-pg16`) affects all ingest/lib unit tests; migrations validated against PG16