### PR TITLE
fix: test runner cleanup + fanout timestamp bounded discovery

### DIFF
--- a/packages/ingest/abis/yearn/2/strategy/snapshot/hook.spec.ts
+++ b/packages/ingest/abis/yearn/2/strategy/snapshot/hook.spec.ts
@@ -27,7 +27,8 @@ describe('abis/yearn/2/strategy/snapshot/hook', function() {
   it('extracts estimated apr', async function() {
     const chainId = 1337
     const address = '0x1000000000000000000000000000000000000000'
-    const blockTime = 1000n
+    // must be recent: getLatestEstimatedApr filters block_time > NOW() - 7 days
+    const blockTime = BigInt(Math.floor(Date.now() / 1000))
     const blockNumber = 1000n
 
     const outputData = {

--- a/packages/ingest/fanout/timeseries.ts
+++ b/packages/ingest/fanout/timeseries.ts
@@ -28,12 +28,13 @@ export default class TimeseriesFanout {
       const end = endOfDay(await getBlockTime(chainId, to))
 
       const computed = (await db.query(`
-      SELECT DISTINCT block_time
+      SELECT DISTINCT FLOOR(EXTRACT(EPOCH FROM series_time))::bigint AS series_time
       FROM output
       WHERE chain_id = $1 AND address = $2 AND label = $3
-      ORDER BY block_time ASC`,
-      [chainId, address, outputLabel]))
-        .rows.map(row => BigInt(row.block_time))
+        AND series_time BETWEEN to_timestamp($4::double precision) AND to_timestamp($5::double precision)
+      ORDER BY series_time ASC`,
+      [chainId, address, outputLabel, Number(start), Number(end)]))
+        .rows.map(row => BigInt(row.series_time))
 
       const missing = findMissingTimestamps(start, end, computed)
       if (missing.length === 0 || missing[missing.length - 1] !== end) {

--- a/packages/lib/run-tests.ts
+++ b/packages/lib/run-tests.ts
@@ -33,8 +33,9 @@ spawnTestContainersAndRun().then((env) => {
   }
 
   const mochaBin = path.resolve(__dirname, '../../node_modules/.bin/mocha')
-
-  mochaProcess = spawn(mochaBin, ['--timeout 5000', '--exit', ...(process.argv.slice(2) || [])], {
+  const userArgs = process.argv.slice(2).filter(a => a !== '--')
+  const specArgs = userArgs.length > 0 ? userArgs : ['**/*.spec.ts']
+  mochaProcess = spawn(mochaBin, ['--timeout', '5000', '--exit', ...specArgs], {
     // @ts-expect-error env is not typed
     env: {
       ...customEnv,

--- a/packages/lib/strider.spec.ts
+++ b/packages/lib/strider.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai'
 import { add, contains, plan, remove, rollback } from './strider'
 
-describe.only('strider', function() {
+describe('strider', function() {
   it('plans new strides', async function() {
     expect(plan(0n, 100n, undefined)).to.deep.equal([{ from: 0n, to: 100n }])
     expect(plan(0n, 100n, [])).to.deep.equal([{ from: 0n, to: 100n }])
@@ -49,7 +49,7 @@ describe.only('strider', function() {
     expect(contains({ from: 0n, to: 10n }, { from: 0n, to: 12n })).to.be.false
   })
 
-  it.only('rolls back ending blocks', async function() {
+  it('rolls back ending blocks', async function() {
     expect(rollback([], 9n)).to.deep.equal([])
     expect(rollback([{ from: 0n, to: 10n }], 9n)).to.deep.equal([{ from: 0n, to: 9n }])
     expect(rollback([{ from: 0n, to: 4n }, { from: 6n, to: 10n }], 9n)).to.deep.equal([{ from: 0n, to: 4n }, { from: 6n, to: 9n }])


### PR DESCRIPTION
## Summary

Split from #400 per review feedback — smaller, independently measurable changes.

### Test runner cleanup
- Fix mocha arg parsing (split `--timeout` from value)
- Default to `**/*.spec.ts` when no spec args provided
- Remove `describe.only` from `strider.spec.ts` (was still there on the old branch)
- Remove `it.only` from strider rollback test
- Fix `hook.spec.ts` blockTime to be recent (within 7-day lookback window)

### Fanout timestamp discovery
- Replace unbounded `DISTINCT block_time` scan with `series_time` bounded query on the output table, scoped to the fanout window
- Maps to the top `pg_stat_statements` offender — the 99%+ row-reduction win
- Deploy and measure before adding more changes

## From
Split from #400 (PR 1+2 per review request)

## Follow-ups (surfaced during review)
- #415 — broken `types.spec.ts` fixture (pre-existing, unmasked by the `.only` removal)
- #416 — `bun --filter ingest test` silently skips most specs (shell globstar default-off; pre-existing in `packages/ingest/run-tests.ts`)