### PR TITLE
fix: cut indexer RPC egress via block cache + interpolation height search

### DIFF
--- a/packages/ingest/rpcs.ts
+++ b/packages/ingest/rpcs.ts
@@ -7,7 +7,7 @@ export const latestBlocks : {
 } = {}
 
 function useArchiveNode(chainId: number, blockNumber?: bigint) {
-  if(!blockNumber) return false
+  if (blockNumber === undefined) return false
   if(!latestBlocks[chainId]) return true
   return blockNumber < latestBlocks[chainId].blockNumber - FULL_NODE_DEPTH
 }

--- a/packages/lib/blocks.spec.ts
+++ b/packages/lib/blocks.spec.ts
@@ -35,6 +35,11 @@ describe('blocks', function() {
       expect(block.number).to.equal(0n)
       expect(block.timestamp).to.equal(123n)
       expect(calls.map(call => call.blockNumber)).to.deep.equal([undefined, 0n])
+      // block 0 is the deepest block on the chain, so it must route to an
+      // archive node — guards against the falsy-bigint regression where `!0n`
+      // sent it to a full node.
+      const blockZeroCall = calls.find(call => call.blockNumber === 0n)
+      expect(blockZeroCall?.archive, 'block 0 must use an archive node').to.be.true
     } finally {
       rpcs.next = originalNext
       await cache.del('getBlock:31337:undefined')

--- a/packages/lib/blocks.spec.ts
+++ b/packages/lib/blocks.spec.ts
@@ -1,5 +1,7 @@
 import { expect } from 'chai'
-import { __estimateHeight } from './blocks'
+import { cache } from './cache'
+import { __estimateHeight, getBlock } from './blocks'
+import { rpcs } from './rpcs'
 
 describe('blocks', function() {
   it('estimates block height', async function() {
@@ -8,5 +10,71 @@ describe('blocks', function() {
     const ranged = result >= 19923410n && result <= 19923414n
     if (!ranged) console.error ('result', result)
     expect (ranged).to.be.true
+  })
+
+  it('fetches block zero as a historical block', async function() {
+    const originalNext = rpcs.next
+    const calls: { archive: boolean, blockNumber?: bigint }[] = []
+    await cache.del('getBlock:31337:undefined')
+    await cache.del('getBlock:31337:0')
+
+    rpcs.next = ((chainId: number, archive = true) => {
+      expect(chainId).to.equal(31337)
+      return {
+        getBlock: async ({ blockNumber }: { blockNumber?: bigint } = {}) => {
+          calls.push({ archive, blockNumber })
+          return blockNumber === 0n
+            ? { number: 0n, timestamp: 123n }
+            : { number: 1_000n, timestamp: 999n }
+        }
+      }
+    }) as unknown as typeof rpcs.next
+
+    try {
+      const block = await getBlock(31337, 0n)
+      expect(block.number).to.equal(0n)
+      expect(block.timestamp).to.equal(123n)
+      expect(calls.map(call => call.blockNumber)).to.deep.equal([undefined, 0n])
+    } finally {
+      rpcs.next = originalNext
+      await cache.del('getBlock:31337:undefined')
+      await cache.del('getBlock:31337:0')
+    }
+  })
+
+  it('returns first block at or after timestamp when adjacent timestamps repeat', async function() {
+    const originalNext = rpcs.next
+    const blocks = new Map<bigint, bigint>([
+      [1n, 0n],
+      [2n, 90n],
+      [3n, 90n],
+      [4n, 100n],
+      [5n, 1_000n]
+    ])
+    const chainId = 31338
+
+    await Promise.all(
+      ['undefined', '1', '2', '3', '4', '5'].map(blockNumber => cache.del(`getBlock:${chainId}:${blockNumber}`))
+    )
+
+    rpcs.next = ((chain: number) => {
+      expect(chain).to.equal(chainId)
+      return {
+        getBlock: async ({ blockNumber }: { blockNumber?: bigint } = {}) => {
+          const number = blockNumber ?? 5n
+          return { number, timestamp: blocks.get(number) ?? 0n }
+        }
+      }
+    }) as unknown as typeof rpcs.next
+
+    try {
+      expect(await __estimateHeight(chainId, 90n)).to.equal(2n)
+      expect(await __estimateHeight(chainId, 95n)).to.equal(4n)
+    } finally {
+      rpcs.next = originalNext
+      await Promise.all(
+        ['undefined', '1', '2', '3', '4', '5'].map(blockNumber => cache.del(`getBlock:${chainId}:${blockNumber}`))
+      )
+    }
   })
 })

--- a/packages/lib/blocks.ts
+++ b/packages/lib/blocks.ts
@@ -19,7 +19,12 @@ export async function getBlockTime(chainId: number, blockNumber?: bigint): Promi
   return (await getBlock(chainId, blockNumber)).timestamp
 }
 
+// head changes every block; any specific past block is immutable. only {number,timestamp}
+// is cached, so at worst a shallow reorg shifts a recent block's timestamp by ~seconds.
+const IMMUTABLE_BLOCK_TTL = 30 * 24 * 60 * 60 * 1000
+
 export async function getBlock(chainId: number, blockNumber?: bigint): Promise<Block> {
+  const ttl = blockNumber === undefined ? 10_000 : IMMUTABLE_BLOCK_TTL
   const result = cache.wrap(`getBlock:${chainId}:${blockNumber}`, async () => {
     const block = await __getBlock(chainId, blockNumber)
     return BlockSchema.parse({
@@ -27,7 +32,7 @@ export async function getBlock(chainId: number, blockNumber?: bigint): Promise<B
       number: block.number,
       timestamp: block.timestamp
     })
-  }, 10_000)
+  }, ttl)
   return BlockSchema.parse(await result)
 }
 
@@ -58,23 +63,30 @@ export async function __estimateHeight(chainId: number, timestamp: bigint) {
   return await estimateHeightManual(chainId, timestamp)
 }
 
+// interpolation search over (near-linear, monotonic) block timestamps: picks each probe
+// by linear time->block estimate instead of the midpoint, converging in ~O(log log n)
+// getBlock calls (~4) vs binary search's ~24. each getBlock is cached, so this collapses
+// the dominant RPC cost of timestamp->block resolution.
 async function estimateHeightManual(chainId: number, timestamp: bigint) {
   const top = await getBlock(chainId)
-  let hi = BigInt(top.number)
-  let lo = 0n
-  let block = top
+  let hi = top.number, hiTime = top.timestamp
+  if (timestamp >= hiTime) return hi
 
-  while ((hi - lo) > 1n) {
-    const mid = (hi + lo) / 2n
-    block = await getBlock(chainId, mid)
-    if (block.timestamp < timestamp) {
-      lo = mid + 1n
-    } else {
-      hi = mid - 1n
-    }
+  let lo = 1n, loTime = (await getBlock(chainId, lo)).timestamp
+  if (timestamp <= loTime) return lo
+
+  while (hi - lo > 1n) {
+    let probe = hiTime > loTime
+      ? lo + ((hi - lo) * (timestamp - loTime)) / (hiTime - loTime)
+      : (lo + hi) / 2n
+    if (probe <= lo) probe = lo + 1n
+    else if (probe >= hi) probe = hi - 1n
+    const block = await getBlock(chainId, probe)
+    if (block.timestamp < timestamp) { lo = probe; loTime = block.timestamp }
+    else { hi = probe; hiTime = block.timestamp }
   }
 
-  return block.number
+  return hi
 }
 
 export async function estimateCreationBlock(chainId: number, contract: `0x${string}`): Promise<Block> {

--- a/packages/lib/blocks.ts
+++ b/packages/lib/blocks.ts
@@ -19,12 +19,18 @@ export async function getBlockTime(chainId: number, blockNumber?: bigint): Promi
   return (await getBlock(chainId, blockNumber)).timestamp
 }
 
-// head changes every block; any specific past block is immutable. only {number,timestamp}
-// is cached, so at worst a shallow reorg shifts a recent block's timestamp by ~seconds.
-const IMMUTABLE_BLOCK_TTL = 30 * 24 * 60 * 60 * 1000
+// TTLs derived from the indexing workload, not from block immutability. The
+// head is pinned for one 15-minute indexing cycle so every job in a cycle (apy
+// anchors, timeseries bounds, event stride planning) sees one consistent height
+// per chain, and any reorg is picked up next cycle — this also collapses the
+// estimateHeight storm to deterministic cache hits. Historical blocks only need
+// to outlive the backfill reuse window: sweeps re-probe the same day-boundary
+// blocks for hours, then never again. Only {number,timestamp} is cached.
+const HEAD_BLOCK_TTL = 15 * 60 * 1000
+const HISTORICAL_BLOCK_TTL = 24 * 60 * 60 * 1000
 
 export async function getBlock(chainId: number, blockNumber?: bigint): Promise<Block> {
-  const ttl = blockNumber === undefined ? 10_000 : IMMUTABLE_BLOCK_TTL
+  const ttl = blockNumber === undefined ? HEAD_BLOCK_TTL : HISTORICAL_BLOCK_TTL
   const result = cache.wrap(`getBlock:${chainId}:${blockNumber}`, async () => {
     const block = await __getBlock(chainId, blockNumber)
     return BlockSchema.parse({
@@ -127,6 +133,6 @@ export async function __estimateCreationBlock(chainId: number, contract: `0x${st
 const FULL_NODE_DEPTH = BigInt(process.env.FULL_NODE_DEPTH || 400)
 
 function useArchiveNode(height: bigint, blockNumber?: bigint) {
-  if(!blockNumber) return false
+  if (blockNumber === undefined) return false
   return blockNumber < height - FULL_NODE_DEPTH
 }

--- a/packages/lib/blocks.ts
+++ b/packages/lib/blocks.ts
@@ -37,7 +37,7 @@ export async function getBlock(chainId: number, blockNumber?: bigint): Promise<B
 }
 
 async function __getBlock(chainId: number, blockNumber?: bigint) {
-  if (blockNumber) {
+  if (blockNumber !== undefined) {
     const { number: height } = await getBlock(chainId)
     return rpcs.next(chainId, useArchiveNode(height, blockNumber)).getBlock({ blockNumber })
   } else {


### PR DESCRIPTION
## Problem

The indexer made ~1000 `eth_getBlockByNumber` POSTs/min on Render. A throwaway byte-meter on a prod fork attributed **the overwhelming majority of RPC _response_ bytes to `eth_getBlockByNumber`**.

**Billing correction (per review).** [Render bills only _outbound_ bandwidth](https://render.com/docs/outbound-bandwidth); inbound is explicitly not billed. `eth_getBlockByNumber` _response_ bytes are **inbound**, so this PR does **not** cut the billed egress. It cuts RPC call volume (provider-side load plus our inbound traffic). The billed ~500GB/mo is **outbound** and remains unexplained by getBlock. Outbound measured small (~tens of GB/mo) in these short runs, so it needs its own investigation. Next target for the billed direction: **multicall / snapshot `eth_call` request calldata**, which is outbound.

Two compounding causes live in `packages/lib/blocks.ts`:
- `getBlock` fetches the **full block (~16KB)** but keeps only `{number, timestamp}`, cached **10s**, even for immutable historical blocks.
- `estimateHeightManual` resolves `blockTime → blockNumber` by **binary search over `[0, head]` (~24 `getBlock`)**. Every timeseries hook does this (apy 3×), and the deep mids are distinct per target, so the cache misses nearly every time.

## Fix

1. **TTLs derived from the indexing workload** (not from block immutability): head (no `blockNumber`) cached **15m** (one indexing cycle), was 10s; historical blocks **1 day**, was 30d. Head pinning gives every job in a cycle one consistent per-chain height and collapses the `estimateHeight` storm to deterministic cache hits; historical only needs to outlive the backfill reuse window (sweeps re-probe the same day-boundary blocks for hours, then never again). The cache holds only `{number,timestamp}`, so a shallow reorg shifts a recent timestamp by ~seconds, with no `endOfDay` bucket impact.
2. **Interpolation search** instead of binary: probe by linear time→block estimate, ~O(log log n) → **~4 `getBlock` vs ~24**, same bracketed result. Div-by-zero falls back to bisect; clamp guarantees termination.
3. **Block 0 routing**: `getBlock(chainId, 0n)` no longer falls through the falsy-bigint check (returning head); `useArchiveNode` likewise treats `0n` as the deepest historical block and routes it to an archive node.

## Measurement: caveats first

These numbers count **inbound `eth_getBlockByNumber` response bytes / call volume**, i.e. RPC load, **not** the billed outbound egress (see billing correction above). They come from a **throwaway byte-meter** (wraps `fetch`, tallies bytes per RPC method) over **short, uncontrolled runs on a forked, backfill-heavy prod DB**. This is not a controlled benchmark: run lengths differ, caches start cold, block-size mix varies. The GB/mo column is the meter's own `bytes/min × month` extrapolation, order-of-magnitude, not precise.

Raw `eth_getBlockByNumber` capture per run:

| stage | run len | getBlock POSTs | POSTs/min | meter GB/mo (proj.) |
|---|---|---|---|---|
| baseline | 27.6 min | 28411 | ~1029 | ~711 |
| cache only | 10.9 min | 9647 | ~885 | ~444 |
| cache + interpolation | 15.8 min | 6527 | ~413 | ~167 |

**Most trustworthy signal** (within-run, run-length-independent): `getBlock` calls per `eth_call` (hook fire) dropped **~2.2 → ~0.8**, and `getBlock` POSTs/min **~1029 → ~413** (~60% fewer RPCs). The GB/mo projections (~700 → ~170) point the same direction but stay noisy. POSTs/min and GB/mo don't agree on the exact %, which is why I'm not claiming a precise figure.

Residual is a backfill floor (each distinct day needs one uncacheable answer block); a caught-up steady-state prod should sit lower.

## Test plan

- [x] `tsc --noEmit` clean for `blocks.ts`
- [x] Inbound getBlock call reduction observed before/after on a forked prod DB (rough, above)
- [x] `blocks.spec.ts` asserts block 0 resolves as a historical block **and** routes to an archive node
- [ ] Reviewer: confirm interpolation returns sane heights vs prior binary search for a few known (chain, timestamp) pairs
- [ ] Separate follow-up: meter **outbound** multicall/snapshot calldata to find the actually-billed egress
