### PR TITLE
Workflows

### DIFF
--- a/.github/workflows/reports-refresh-historical.yml
+++ b/.github/workflows/reports-refresh-historical.yml
@@ -1,8 +1,6 @@
 name: reports-refresh-historical
 
 on:
-  schedule:
-    - cron: '0 0 * * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/reports-refresh.yml
+++ b/.github/workflows/reports-refresh.yml
@@ -1,8 +1,6 @@
 name: reports-refresh
 
 on:
-  schedule:
-    - cron: '0 * * * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/snapshot-refresh.yml
+++ b/.github/workflows/snapshot-refresh.yml
@@ -2,7 +2,7 @@ name: snapshot-refresh
 
 on:
   schedule:
-    - cron: '*/15 * * * *'
+    - cron: '*/30 * * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
We're experiences github workflow issues across the org it appears because we've run over our quota. Kong uses a lot of workflow resources updating its REST cache. To make space for workflows in other repos this PR frees up some workflow quota. The two biggest workflow users in kong are the reports and snapshot updates.

- Disable reports updates. We're not using the reports REST endpoint currently
- Lower the snapshot update frequency from every 15 minutes to every 30. We do use snapshot data lot. 
