### PR TITLE
fix: fapy/apr-oracle for plain erc4626 (Morpho) vaults

### DIFF
--- a/packages/ingest/abis/erc4626/lib.ts
+++ b/packages/ingest/abis/erc4626/lib.ts
@@ -1,0 +1,26 @@
+import { ReadContractParameters } from 'viem'
+import { rpcs } from '../../rpcs'
+import abi from './abi'
+
+// pps must be quoted in share units (the vault's own decimals()), not the asset
+// decimals stored in thing.defaults — they differ for vaults like the 18-share /
+// 6-asset Yearn Morpho vaults, where using asset decimals rounds convertToAssets
+// to 0. decimals() is immutable, so read it at latest (avoids archive-node
+// dependency). On a read failure we warn and fall back to the stored decimals,
+// but that fallback is only correct when shares == asset, so it must be loud.
+export async function ppsReadParameters(
+  chainId: number,
+  address: `0x${string}`,
+  fallbackDecimals?: number,
+): Promise<ReadContractParameters> {
+  const shareDecimals = await rpcs.next(chainId).readContract({
+    abi, address, functionName: 'decimals'
+  }).then(d => d as bigint).catch(error => {
+    console.warn('🚨', 'erc4626 decimals() read failed, falling back to stored decimals', chainId, address, error)
+    return BigInt(fallbackDecimals ?? 0)
+  })
+
+  return {
+    abi, address, functionName: 'convertToAssets', args: [10n ** shareDecimals]
+  } as ReadContractParameters
+}

--- a/packages/ingest/abis/erc4626/timeseries/apr-oracle/hook.spec.ts
+++ b/packages/ingest/abis/erc4626/timeseries/apr-oracle/hook.spec.ts
@@ -1,0 +1,43 @@
+import { expect } from 'chai'
+import { mainnet } from 'viem/chains'
+import hook, { outputLabel } from './hook'
+import { Data } from '../../../../extract/timeseries'
+import { computeApy } from '../../../yearn/lib/apy'
+import { readApr } from '../../../yearn/3/vault/timeseries/apr-oracle/hook'
+import { getOracleConfig } from '../../../yearn/3/vault/timeseries/apr-oracle/constants'
+
+describe('abis/erc4626/timeseries/apr-oracle/hook', function() {
+  const morphoUsdt = '0x0963232eB842BAF53E8e517691f81745C1F228a0' as const
+
+  it('prices a plain erc4626 vault via the apr oracle', async function() {
+    // 0x0963 is a bare ERC4626 (no apiVersion/pricePerShare), so it lands on the
+    // erc4626 path. The oracle still prices it via getStrategyApr.
+    const oracle = getOracleConfig(mainnet.id)
+    expect(oracle).to.not.equal(undefined)
+    const apr = await readApr(mainnet.id, morphoUsdt, 25211174n, oracle!.address)
+    expect(apr).to.be.closeTo(0.11878347712984644, 1e-6)
+  })
+
+  it('returns nothing when the chain has no oracle configured', async function() {
+    const data: Data = {
+      abiPath: 'erc4626', chainId: 999999, address: morphoUsdt,
+      outputLabel, blockTime: BigInt(Math.floor(Date.now() / 1000))
+    }
+    expect(await hook(999999, morphoUsdt, data)).to.deep.equal([])
+  })
+
+  it('emits apr and apy outputs', async function() {
+    const data: Data = {
+      abiPath: 'erc4626', chainId: mainnet.id, address: morphoUsdt,
+      outputLabel, blockTime: BigInt(Math.floor(Date.now() / 1000)) + 60n
+    }
+    const outputs = await hook(mainnet.id, morphoUsdt, data)
+    expect(outputs.map(o => o.component).sort()).to.deep.equal(['apr', 'apy'])
+    expect(outputs.every(o => o.label === outputLabel)).to.equal(true)
+
+    const apr = outputs.find(o => o.component === 'apr')!.value as number
+    const apy = outputs.find(o => o.component === 'apy')!.value as number
+    expect(apr).to.be.greaterThan(0)
+    expect(apy).to.be.closeTo(computeApy(apr), 1e-9)
+  })
+})

--- a/packages/ingest/abis/erc4626/timeseries/apr-oracle/hook.ts
+++ b/packages/ingest/abis/erc4626/timeseries/apr-oracle/hook.ts
@@ -1,0 +1,27 @@
+import { Output, OutputSchema } from 'lib/types'
+import { Data } from '../../../../extract/timeseries'
+import { resolveOracleApr } from '../../../yearn/3/vault/timeseries/apr-oracle/hook'
+
+export const outputLabel = 'apr-oracle'
+
+// Plain erc4626 vaults (e.g. Yearn-branded Morpho vaults) aren't classified as
+// yearn/3/vault, so they never ran the apr oracle. The oracle prices them by
+// address all the same. Net apr/apy aren't surfaced for erc4626 vaults, so only
+// emit apr/apy.
+export default async function (
+  chainId: number,
+  address: `0x${string}`,
+  data: Data,
+): Promise<Output[]> {
+  const resolved = await resolveOracleApr(chainId, address, data)
+  if (!resolved) return []
+
+  const output = (component: string, value: number): Output => ({
+    label: outputLabel, component, value, chainId, address, blockNumber: resolved.blockNumber, blockTime: data.blockTime,
+  })
+
+  return OutputSchema.array().parse([
+    output('apr', resolved.apr),
+    output('apy', resolved.apy),
+  ])
+}

--- a/packages/ingest/abis/erc4626/timeseries/apy/hook.ts
+++ b/packages/ingest/abis/erc4626/timeseries/apy/hook.ts
@@ -3,10 +3,9 @@ import { Output, OutputSchema, Thing, ThingSchema } from 'lib/types'
 import { first } from '../../../../db'
 import { estimateHeight, getBlock } from 'lib/blocks'
 import { math, multicall3 } from 'lib'
-import { ReadContractParameters } from 'viem'
 import { mainnet } from 'viem/chains'
 import { rpcs } from '../../../../rpcs'
-import abi from '../../abi'
+import { ppsReadParameters } from '../../lib'
 import { APYSchema } from '../../../yearn/lib/apy'
 
 export const outputLabel = 'apy-bwd-delta-pps'
@@ -112,10 +111,7 @@ export async function _compute(vault: Thing, blockNumber: bigint) {
     blockTime: block.timestamp,
   })
 
-  const ppsParameters = {
-    abi, address, functionName: 'convertToAssets',
-    args: [10n ** BigInt(vault.defaults.decimals ?? 0n)]
-  } as ReadContractParameters
+  const ppsParameters = await ppsReadParameters(chainId, address, vault.defaults.decimals)
 
   const day = 24n * 60n * 60n
   result.weeklyBlockNumber = await estimateHeight(chainId, block.timestamp - 7n * day)

--- a/packages/ingest/abis/erc4626/timeseries/pps/hook.spec.ts
+++ b/packages/ingest/abis/erc4626/timeseries/pps/hook.spec.ts
@@ -5,6 +5,8 @@ import { ThingSchema } from 'lib/types'
 
 describe('abis/erc4626/timeseries/pps/hook', function() {
   it('extracts sdai pps', async function() {
+    this.timeout(30_000)
+
     const sdai = '0x83F20F44975D03b1b09e64809B757c47f942BEeA'
     const vault = ThingSchema.parse({
       chainId: mainnet.id,
@@ -17,6 +19,8 @@ describe('abis/erc4626/timeseries/pps/hook', function() {
   })
 
   it('extracts avantis usdc pps', async function() {
+    this.timeout(30_000)
+
     const usdc = '0x944766f715b51967E56aFdE5f0Aa76cEaCc9E7f9'
     const vault = ThingSchema.parse({
       chainId: base.id,
@@ -30,6 +34,8 @@ describe('abis/erc4626/timeseries/pps/hook', function() {
   })
 
   it('uses share decimals when they differ from asset decimals', async function() {
+    this.timeout(30_000)
+
     // Yearn USDT (Morpho): 18-decimal shares, 6-decimal USDT asset.
     // defaults.decimals holds the asset decimals (6); convertToAssets needs the
     // share decimals (18) or it rounds to 0. Pre-fix this returned 0.

--- a/packages/ingest/abis/erc4626/timeseries/pps/hook.spec.ts
+++ b/packages/ingest/abis/erc4626/timeseries/pps/hook.spec.ts
@@ -22,9 +22,25 @@ describe('abis/erc4626/timeseries/pps/hook', function() {
       chainId: base.id,
       address: usdc,
       label: 'vault',
-      defaults: { decimals: 18 }
+      // 6-decimal shares and 6-decimal USDC asset (matches what extraction stores)
+      defaults: { decimals: 6 }
     })
     const pps = await _compute(vault, 37288756n)
     expect(pps.humanized).to.be.closeTo(1.2807073904123205, 1e-5)
+  })
+
+  it('uses share decimals when they differ from asset decimals', async function() {
+    // Yearn USDT (Morpho): 18-decimal shares, 6-decimal USDT asset.
+    // defaults.decimals holds the asset decimals (6); convertToAssets needs the
+    // share decimals (18) or it rounds to 0. Pre-fix this returned 0.
+    const vault = ThingSchema.parse({
+      chainId: mainnet.id,
+      address: '0x0963232eB842BAF53E8e517691f81745C1F228a0',
+      label: 'vault',
+      defaults: { decimals: 6 }
+    })
+    const pps = await _compute(vault, 25211174n)
+    expect(Number(pps.raw)).to.equal(1002039)
+    expect(pps.humanized).to.be.closeTo(1.002039, 1e-5)
   })
 })

--- a/packages/ingest/abis/erc4626/timeseries/pps/hook.ts
+++ b/packages/ingest/abis/erc4626/timeseries/pps/hook.ts
@@ -3,9 +3,8 @@ import { Output, OutputSchema, Thing, ThingSchema } from 'lib/types'
 import { first } from '../../../../db'
 import { estimateHeight, getBlock } from 'lib/blocks'
 import { multicall3 } from 'lib'
-import { ReadContractParameters } from 'viem'
 import { rpcs } from '../../../../rpcs'
-import abi from '../../abi'
+import { ppsReadParameters } from '../../lib'
 import { div } from 'lib/math'
 
 export const outputLabel = 'pps'
@@ -47,10 +46,7 @@ export default async function process(chainId: number, address: `0x${string}`, d
 export async function _compute(vault: Thing, blockNumber: bigint) {
   const { chainId, address } = vault
   const block = await getBlock(chainId, blockNumber)
-  const ppsParameters = {
-    abi, address, functionName: 'convertToAssets',
-    args: [10n ** BigInt(vault.defaults.decimals ?? 0n)]
-  } as ReadContractParameters
+  const ppsParameters = await ppsReadParameters(chainId, address, vault.defaults.decimals)
   const raw = await rpcs.next(chainId, blockNumber).readContract({...ppsParameters, blockNumber}) as bigint
   const humanized = div(raw, 10n ** BigInt(vault.defaults.decimals ?? 0n))
   return { ...block, raw, humanized }

--- a/packages/ingest/abis/yearn/3/vault/timeseries/apr-oracle/hook.ts
+++ b/packages/ingest/abis/yearn/3/vault/timeseries/apr-oracle/hook.ts
@@ -61,32 +61,37 @@ export async function readApr(
   }
 }
 
+// Resolve the oracle apr/apy for any vault address at a given blockTime. Shared
+// with the erc4626 apr-oracle hook — the oracle prices vaults purely by address,
+// so both v3 and plain erc4626 vaults go through here.
+export async function resolveOracleApr(
+  chainId: number,
+  address: `0x${string}`,
+  data: Data,
+): Promise<{ apr: number, apy: number, blockNumber: bigint } | undefined> {
+  const oracleConfig = getOracleConfig(chainId)
+  if (!oracleConfig) return undefined
+
+  const blockNumber = data.blockTime >= BigInt(Math.floor(Date.now() / 1000))
+    ? (await getBlock(chainId)).number
+    : await estimateHeight(chainId, data.blockTime)
+
+  if (blockNumber < oracleConfig.inceptBlock) return undefined
+
+  const apr = await readApr(chainId, address, blockNumber, oracleConfig.address)
+  if (apr === undefined) return undefined
+
+  return { apr, apy: computeApy(apr), blockNumber }
+}
+
 export default async function (
   chainId: number,
   address: `0x${string}`,
   data: Data,
 ): Promise<Output[]> {
-  const oracleConfig = getOracleConfig(chainId)
-  if (!oracleConfig) {
-    return []
-  }
-
-  let blockNumber: bigint
-
-  if (data.blockTime >= BigInt(Math.floor(Date.now() / 1000))) {
-    blockNumber = (await getBlock(chainId)).number
-  } else {
-    blockNumber = await estimateHeight(chainId, data.blockTime)
-  }
-
-  if (blockNumber < oracleConfig.inceptBlock) {
-    return []
-  }
-
-  const apr = await readApr(chainId, address, blockNumber, oracleConfig.address)
-  if (apr === undefined) return []
-
-  const apy = computeApy(apr)
+  const resolved = await resolveOracleApr(chainId, address, data)
+  if (!resolved) return []
+  const { apr, apy, blockNumber } = resolved
 
   let fees = { management: 0, performance: 0 }
   try {
@@ -97,46 +102,15 @@ export default async function (
   }
 
   const netApr = computeNetApr(apr, fees)
-  const netApy = computeApy(netApr)
 
-  const outputs: Output[] = [
-    {
-      label: outputLabel,
-      component: 'apr',
-      value: apr,
-      chainId,
-      address,
-      blockNumber,
-      blockTime: data.blockTime,
-    },
-    {
-      label: outputLabel,
-      component: 'apy',
-      value: apy,
-      chainId,
-      address,
-      blockNumber,
-      blockTime: data.blockTime,
-    },
-    {
-      label: outputLabel,
-      component: 'netApr',
-      value: netApr,
-      chainId,
-      address,
-      blockNumber,
-      blockTime: data.blockTime,
-    },
-    {
-      label: outputLabel,
-      component: 'netApy',
-      value: netApy,
-      chainId,
-      address,
-      blockNumber,
-      blockTime: data.blockTime,
-    },
-  ]
+  const output = (component: string, value: number): Output => ({
+    label: outputLabel, component, value, chainId, address, blockNumber, blockTime: data.blockTime,
+  })
 
-  return OutputSchema.array().parse(outputs)
+  return OutputSchema.array().parse([
+    output('apr', apr),
+    output('apy', apy),
+    output('netApr', netApr),
+    output('netApy', computeApy(netApr)),
+  ])
 }

--- a/packages/scripts/src/issue-225/README.md
+++ b/packages/scripts/src/issue-225/README.md
@@ -1,0 +1,143 @@
+# issue-225 — historical fapy + oracle apy recompute (erc4626)
+
+Recomputes historical APY and historical oracle APY for plain erc4626 vaults
+affected by the share-vs-asset decimals fix in PR #419 (closes #225).
+
+Some external erc4626 vaults (e.g. Yearn-branded Morpho meta-vaults) have a share
+decimal accuracy that differs from their asset (18-share / 6-asset). The old hooks
+quoted `convertToAssets` with the asset decimals, which rounded to `0`, so those
+vaults recorded a `0` price-per-share → `0` historical APY. Plain erc4626 vaults
+also never ran the apr-oracle hook, so they have no historical oracle APY at all.
+
+PR #419 fixes the live hooks. This script backfills the **already-stored, wrong**
+history. Reuses the live erc4626 timeseries hooks (`apy/hook.ts`,
+`apr-oracle/hook.ts`) — no duplicated compute.
+
+## Why not strides + fanout / replay
+
+Recompute here is **timeseries** data, which lives in the `output` table.
+`evmlog_strides` only gates evmlog (event) and snapshot re-indexing — the
+timeseries fanout (`ingest/fanout/timeseries.ts`) decides what to compute by
+looking for **gaps in the `output` table** (`findMissingTimestamps`), not strides.
+
+Consequence:
+- Editing `evmlog_strides` + rerunning fanout does **not** recompute these series —
+  the erc4626 timeseries hooks don't read evmlog.
+- A normal fanout only fills *missing* days. The affected `apy-bwd-delta-pps` rows
+  already exist (as `0`), so fanout skips them and only the latest point is fixed.
+- `apr-oracle` is a brand-new label for erc4626, so it has no rows — a normal
+  fanout **will** backfill its full history on its own. This script also writes it
+  so apy and oracle apy land together in one reviewable upsert.
+
+So: do not use the terminal "fanout replays" command for this. Recompute writes the
+`output` table directly, via a staging table promoted in a single transaction.
+
+## Labels recomputed
+
+| Label | Components | Meaning |
+|---|---|---|
+| `apy-bwd-delta-pps` | net, grossApr, pricePerShare, weekly*, monthly*, inception* | historical APY |
+| `apr-oracle` | apr, apy | historical oracle APY |
+
+Select a subset with `--labels apy` or `--labels oracle` (default: both).
+
+## Scripts
+
+### `compute.ts`
+
+Reads each vault's daily grid from its existing `apy-bwd-delta-pps` output rows,
+recomputes the selected labels at each grid block time with the live hooks, and
+writes results to a staging table (`output_temp_fapy_oracle`).
+
+```bash
+bun packages/scripts/src/issue-225/compute.ts \
+  --vaults 1:0x0963232eB842BAF53E8e517691f81745C1F228a0 \
+  [--labels apy,oracle] \
+  [--start 2025-01-01] \
+  [--end 2026-04-09] \
+  [--dry-run]
+```
+
+| Flag | Description |
+|---|---|
+| `--vaults` | Required. Comma-separated `chainId:address` pairs |
+| `--labels` | Optional. `apy`, `oracle`, or both (default `apy,oracle`) |
+| `--start` | Optional. Only recompute the grid from this date |
+| `--end` | Optional. Only recompute the grid up to this date |
+| `--dry-run` | Run without writing to the staging table |
+
+Runs `CONCURRENCY=25`. The staging table is reset on each run, so re-run with the
+full `--vaults` set you want staged before upserting. Vaults with no
+`apy-bwd-delta-pps` history are skipped (run a normal fanout for those). Use
+`--dry-run` to preview without writing.
+
+### `upsert.ts`
+
+Promotes rows from the staging table into `output` and drops the staging table in a
+single transaction, via the shared `promoteTempTable` helper. On conflict it updates
+`value` only — the existing row's `block_time`/`block_number` are kept so downstream
+block-time bucketing stays aligned. It prints a sample and per-vault counts before
+promoting.
+
+```bash
+bun packages/scripts/src/issue-225/upsert.ts
+```
+
+## Discovering affected vaults
+
+All plain erc4626 vaults (apr-oracle is new for every one of them):
+
+```sql
+SELECT t.chain_id, t.address
+FROM thing t
+WHERE t.label = 'vault'
+  AND t.defaults->>'erc4626' = 'true'
+  AND COALESCE(t.defaults->>'yearn', '') <> 'true';
+```
+
+The decimals-bug subset (all-zero historical APY → needs the `apy` recompute):
+
+```sql
+SELECT t.chain_id, t.address
+FROM thing t
+JOIN output o
+  ON o.chain_id = t.chain_id AND o.address = t.address
+WHERE t.label = 'vault'
+  AND t.defaults->>'erc4626' = 'true'
+  AND COALESCE(t.defaults->>'yearn', '') <> 'true'
+  AND o.label = 'apy-bwd-delta-pps' AND o.component = 'net'
+GROUP BY t.chain_id, t.address
+HAVING bool_and(o.value = 0);
+```
+
+## Morpho first (optional)
+
+To validate Morpho before the rest, run the script for the Morpho subset first,
+verify, then run it for the remaining vaults — `--vaults` scopes each run.
+
+```bash
+# 1. Morpho only (example)
+bun packages/scripts/src/issue-225/compute.ts --vaults 1:0x0963232eB842BAF53E8e517691f81745C1F228a0
+bun packages/scripts/src/issue-225/upsert.ts
+
+# 2. Remaining affected vaults
+bun packages/scripts/src/issue-225/compute.ts --vaults <rest>
+bun packages/scripts/src/issue-225/upsert.ts
+```
+
+## Workflow
+
+```bash
+# 1. Discover affected vaults (queries above)
+psql -c "<discovery query>"
+
+# 2. Compute to staging (dry-run first to sanity-check)
+bun packages/scripts/src/issue-225/compute.ts --vaults <result> --dry-run
+bun packages/scripts/src/issue-225/compute.ts --vaults <result>
+
+# 3. Promote (prints a sample + per-vault counts before upserting)
+bun packages/scripts/src/issue-225/upsert.ts
+
+# 4. Refresh cache
+bun packages/web/app/api/rest/snapshot/refresh-snapshot.ts
+```

--- a/packages/scripts/src/issue-225/README.md
+++ b/packages/scripts/src/issue-225/README.md
@@ -51,7 +51,7 @@ writes results to a staging table (`output_temp_fapy_oracle`).
 
 ```bash
 bun packages/scripts/src/issue-225/compute.ts \
-  --vaults 1:0x0963232eB842BAF53E8e517691f81745C1F228a0 \
+  [--vaults 1:0x0963232eB842BAF53E8e517691f81745C1F228a0] \
   [--labels apy,oracle] \
   [--start 2025-01-01] \
   [--end 2026-04-09] \
@@ -60,16 +60,19 @@ bun packages/scripts/src/issue-225/compute.ts \
 
 | Flag | Description |
 |---|---|
-| `--vaults` | Required. Comma-separated `chainId:address` pairs |
+| `--vaults` | Optional. Comma-separated `chainId:address` pairs. Omit to auto-discover every plain erc4626 vault (`erc4626=true`, `yearn!=true`) — the "all plain erc4626" query below |
 | `--labels` | Optional. `apy`, `oracle`, or both (default `apy,oracle`) |
 | `--start` | Optional. Only recompute the grid from this date |
 | `--end` | Optional. Only recompute the grid up to this date |
 | `--dry-run` | Run without writing to the staging table |
 
-Runs `CONCURRENCY=25`. The staging table is reset on each run, so re-run with the
-full `--vaults` set you want staged before upserting. Vaults with no
-`apy-bwd-delta-pps` history are skipped (run a normal fanout for those). Use
-`--dry-run` to preview without writing.
+All vaults' grid points are flattened into one work list and processed by a single
+pool (default 25 in flight; override with `RECOMPUTE_CONCURRENCY`), so it stays busy
+across vaults instead of running them one at a time. Peak RPC concurrency is still
+the pool size. The staging table is reset on each run, so re-run with the full
+`--vaults` set you want staged before upserting. Vaults with no `apy-bwd-delta-pps`
+history are skipped (run a normal fanout for those). Use `--dry-run` to preview
+without writing.
 
 ### `upsert.ts`
 

--- a/packages/scripts/src/issue-225/compute.ts
+++ b/packages/scripts/src/issue-225/compute.ts
@@ -1,0 +1,202 @@
+import 'lib/global'
+
+import computeApy from 'ingest/abis/erc4626/timeseries/apy/hook'
+import computeOracleApr from 'ingest/abis/erc4626/timeseries/apr-oracle/hook'
+import db from 'ingest/db'
+import type { Data } from 'ingest/extract/timeseries'
+import { rpcs } from 'ingest/rpcs'
+import { endOfDay } from 'lib/dates'
+import type { Output } from 'lib/types'
+import { getAddress } from 'viem'
+import { resetTempTable, insertTempBatch, type TempRow } from '../backfill-shared/tempTable'
+
+const TEMP_TABLE = 'output_temp_fapy_oracle'
+const GRID_LABEL = 'apy-bwd-delta-pps'
+const CONCURRENCY = 25
+
+type HookFn = (chainId: number, address: `0x${string}`, data: Data) => Promise<Output[]>
+
+type LabelKey = 'apy' | 'oracle'
+
+const LABELS: Record<LabelKey, { outputLabel: string, compute: HookFn }> = {
+  apy: { outputLabel: 'apy-bwd-delta-pps', compute: computeApy },
+  oracle: { outputLabel: 'apr-oracle', compute: computeOracleApr },
+}
+
+function parseArgs(argv: string[]) {
+  const getArg = (flag: string) => {
+    const index = argv.indexOf(flag)
+    return index >= 0 ? argv[index + 1] : undefined
+  }
+  const hasArg = (flag: string) => argv.includes(flag)
+
+  if (hasArg('--help') || hasArg('-h')) {
+    console.log(`usage:
+  bun packages/scripts/src/issue-225/compute.ts --vaults chainId:0xABC,... [--labels apy,oracle] [--start 2025-01-01] [--end 2026-04-09] [--dry-run]
+
+Recomputes historical apy (apy-bwd-delta-pps) and historical oracle apy (apr-oracle)
+for plain erc4626 vaults affected by the share-vs-asset decimals fix (issue #225).
+Reuses the live erc4626 timeseries hooks -- no duplicated compute. The daily grid
+is taken from each vault's existing '${GRID_LABEL}' output rows. Results go into
+${TEMP_TABLE} (reset on each run); run upsert.ts to promote them to the output table.`)
+    process.exit(0)
+  }
+
+  const vaultsArg = getArg('--vaults')
+  if (!vaultsArg) {
+    console.error('Required: --vaults chainId:0xABC,chainId:0xDEF,...')
+    process.exit(1)
+  }
+
+  const vaults = vaultsArg.split(',').map(pair => {
+    const [chainIdStr, address] = pair.split(':')
+    return { chainId: Number(chainIdStr), address: getAddress(address as `0x${string}`) }
+  })
+
+  const labelsArg = getArg('--labels')
+  const labels = (labelsArg ? labelsArg.split(',') : ['apy', 'oracle']).map(l => l.trim())
+  for (const label of labels) {
+    if (!(label in LABELS)) {
+      console.error(`Unknown label '${label}'. Valid: ${Object.keys(LABELS).join(', ')}`)
+      process.exit(1)
+    }
+  }
+
+  return {
+    vaults,
+    labels: labels as LabelKey[],
+    start: getArg('--start'),
+    end: getArg('--end'),
+    dryRun: hasArg('--dry-run'),
+  }
+}
+
+async function getGridBlockTimes(
+  chainId: number, address: string, start?: string, end?: string
+): Promise<bigint[]> {
+  const params: (number | string | Date)[] = [chainId, address]
+  let timeFilter = ''
+
+  if (start) {
+    params.push(new Date(start))
+    timeFilter += ` AND series_time >= $${params.length}`
+  }
+  if (end) {
+    params.push(new Date(end))
+    timeFilter += ` AND series_time <= $${params.length}`
+  }
+
+  const result = await db.query(`
+    SELECT DISTINCT EXTRACT(EPOCH FROM block_time)::bigint AS block_time_epoch
+    FROM output
+    WHERE chain_id = $1 AND address = $2 AND label = '${GRID_LABEL}' ${timeFilter}
+    ORDER BY block_time_epoch
+  `, params)
+
+  return result.rows.map((row: { block_time_epoch: string }) => BigInt(row.block_time_epoch))
+}
+
+function toTempRows(outputs: Output[]): TempRow[] {
+  // series_time must be derived exactly as the load path does (load/index.ts:
+  // `series_time: endOfDay(output.blockTime)`) so the upsert's ON CONFLICT keys
+  // match existing rows and overwrite them instead of inserting duplicates.
+  return outputs.map(output => ({
+    chain_id: output.chainId,
+    address: output.address,
+    label: output.label,
+    component: output.component ?? '',
+    value: Number(output.value ?? 0),
+    block_number: output.blockNumber,
+    block_time: new Date(Number(output.blockTime) * 1000),
+    series_time: new Date(Number(endOfDay(output.blockTime)) * 1000),
+  }))
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2))
+  const startTime = Date.now()
+
+  await rpcs.up()
+
+  console.log(args.dryRun ? 'DRY RUN mode' : 'COMPUTE mode')
+  console.log(`Vaults: ${args.vaults.length}`)
+  console.log(`Labels: ${args.labels.join(', ')}`)
+  if (args.start) console.log(`Start: ${args.start}`)
+  if (args.end) console.log(`End: ${args.end}`)
+
+  if (!args.dryRun) await resetTempTable(TEMP_TABLE)
+
+  let totalEntries = 0
+  let totalOutputs = 0
+  let totalErrors = 0
+
+  for (const vault of args.vaults) {
+    const { chainId, address } = vault
+    console.log(`\n--- ${chainId}:${address} ---`)
+
+    const grid = await getGridBlockTimes(chainId, address, args.start, args.end)
+    console.log(`  ${grid.length} grid points (from '${GRID_LABEL}')`)
+    if (grid.length === 0) {
+      console.log(`  skip: no '${GRID_LABEL}' history -- run a normal fanout to backfill this vault`)
+      continue
+    }
+    totalEntries += grid.length
+
+    let processed = 0
+    let errors = 0
+
+    for (let i = 0; i < grid.length; i += CONCURRENCY) {
+      const batch = grid.slice(i, i + CONCURRENCY)
+      const results = await Promise.allSettled(batch.map(async (blockTime) => {
+        const outputs: Output[] = []
+        for (const key of args.labels) {
+          const { outputLabel, compute } = LABELS[key]
+          outputs.push(...await compute(chainId, address, {
+            abiPath: 'erc4626', chainId, address, outputLabel, blockTime,
+          }))
+        }
+        return outputs
+      }))
+
+      for (const result of results) {
+        if (result.status === 'fulfilled') {
+          if (result.value.length > 0) {
+            if (!args.dryRun) await insertTempBatch(TEMP_TABLE, toTempRows(result.value))
+            totalOutputs += result.value.length
+          }
+          processed++
+        } else {
+          errors++
+          totalErrors++
+          console.error('  Error:', result.reason instanceof Error ? result.reason.message : String(result.reason))
+        }
+      }
+
+      process.stdout.write(`\r  ${processed}/${grid.length} processed, ${errors} errors`)
+    }
+
+    console.log()
+  }
+
+  const duration = ((Date.now() - startTime) / 1000).toFixed(2)
+  console.log('\n=== Summary ===')
+  console.log(`Vaults:     ${args.vaults.length}`)
+  console.log(`Grid pts:   ${totalEntries}`)
+  console.log(`Outputs:    ${totalOutputs}`)
+  console.log(`Errors:     ${totalErrors}`)
+  console.log(`Duration:   ${duration}s`)
+
+  if (!args.dryRun) {
+    const count = await db.query(`SELECT COUNT(*) FROM ${TEMP_TABLE}`)
+    console.log(`Temp table: ${count.rows[0].count} rows in ${TEMP_TABLE}`)
+    console.log('\nRun upsert.ts to promote to the output table.')
+  }
+
+  await rpcs.down()
+  await db.end()
+}
+
+main().catch(error => {
+  console.error('Fatal error:', error)
+  process.exit(1)
+})

--- a/packages/scripts/src/issue-225/compute.ts
+++ b/packages/scripts/src/issue-225/compute.ts
@@ -12,7 +12,7 @@ import { resetTempTable, insertTempBatch, type TempRow } from '../backfill-share
 
 const TEMP_TABLE = 'output_temp_fapy_oracle'
 const GRID_LABEL = 'apy-bwd-delta-pps'
-const CONCURRENCY = 25
+const CONCURRENCY = Number(process.env.RECOMPUTE_CONCURRENCY ?? 25)
 
 type HookFn = (chainId: number, address: `0x${string}`, data: Data) => Promise<Output[]>
 
@@ -32,7 +32,10 @@ function parseArgs(argv: string[]) {
 
   if (hasArg('--help') || hasArg('-h')) {
     console.log(`usage:
-  bun packages/scripts/src/issue-225/compute.ts --vaults chainId:0xABC,... [--labels apy,oracle] [--start 2025-01-01] [--end 2026-04-09] [--dry-run]
+  bun packages/scripts/src/issue-225/compute.ts [--vaults chainId:0xABC,...] [--labels apy,oracle] [--start 2025-01-01] [--end 2026-04-09] [--dry-run]
+
+Omit --vaults to auto-discover every plain erc4626 vault from the thing table
+(defaults erc4626=true, yearn!=true).
 
 Recomputes historical apy (apy-bwd-delta-pps) and historical oracle apy (apr-oracle)
 for plain erc4626 vaults affected by the share-vs-asset decimals fix (issue #225).
@@ -43,15 +46,12 @@ ${TEMP_TABLE} (reset on each run); run upsert.ts to promote them to the output t
   }
 
   const vaultsArg = getArg('--vaults')
-  if (!vaultsArg) {
-    console.error('Required: --vaults chainId:0xABC,chainId:0xDEF,...')
-    process.exit(1)
-  }
-
-  const vaults = vaultsArg.split(',').map(pair => {
-    const [chainIdStr, address] = pair.split(':')
-    return { chainId: Number(chainIdStr), address: getAddress(address as `0x${string}`) }
-  })
+  const vaults = vaultsArg
+    ? vaultsArg.split(',').map(pair => {
+      const [chainIdStr, address] = pair.split(':')
+      return { chainId: Number(chainIdStr), address: getAddress(address as `0x${string}`) }
+    })
+    : undefined
 
   const labelsArg = getArg('--labels')
   const labels = (labelsArg ? labelsArg.split(',') : ['apy', 'oracle']).map(l => l.trim())
@@ -69,6 +69,22 @@ ${TEMP_TABLE} (reset on each run); run upsert.ts to promote them to the output t
     end: getArg('--end'),
     dryRun: hasArg('--dry-run'),
   }
+}
+
+async function discoverVaults(): Promise<{ chainId: number, address: `0x${string}` }[]> {
+  // every plain erc4626 vault (apr-oracle is new for all of them); same set
+  // as the README "Discovering affected vaults" query
+  const result = await db.query(`
+    SELECT chain_id AS "chainId", address
+    FROM thing
+    WHERE label = 'vault'
+      AND defaults->>'erc4626' = 'true'
+      AND COALESCE(defaults->>'yearn', '') <> 'true'
+    ORDER BY chain_id, address
+  `)
+  return result.rows.map((row: { chainId: number, address: string }) => ({
+    chainId: row.chainId, address: getAddress(row.address as `0x${string}`),
+  }))
 }
 
 async function getGridBlockTimes(
@@ -112,14 +128,34 @@ function toTempRows(outputs: Output[]): TempRow[] {
   }))
 }
 
+async function runPool<T>(items: T[], limit: number, worker: (item: T) => Promise<void>): Promise<void> {
+  let cursor = 0
+  const size = Math.max(1, Math.min(limit, items.length))
+  await Promise.all(Array.from({ length: size }, async () => {
+    while (cursor < items.length) {
+      await worker(items[cursor++])
+    }
+  }))
+}
+
+function fmtDuration(seconds: number): string {
+  if (!isFinite(seconds) || seconds < 0) return '?'
+  const m = Math.floor(seconds / 60)
+  const s = Math.round(seconds % 60)
+  return m > 0 ? `${m}m${s.toString().padStart(2, '0')}s` : `${s}s`
+}
+
 async function main() {
   const args = parseArgs(process.argv.slice(2))
   const startTime = Date.now()
 
   await rpcs.up()
 
+  const vaults = args.vaults ?? await discoverVaults()
+  if (!args.vaults) console.log(`Discovered ${vaults.length} plain erc4626 vaults from thing (erc4626=true, yearn!=true)`)
+
   console.log(args.dryRun ? 'DRY RUN mode' : 'COMPUTE mode')
-  console.log(`Vaults: ${args.vaults.length}`)
+  console.log(`Vaults: ${vaults.length}`)
   console.log(`Labels: ${args.labels.join(', ')}`)
   if (args.start) console.log(`Start: ${args.start}`)
   if (args.end) console.log(`End: ${args.end}`)
@@ -130,61 +166,76 @@ async function main() {
   let totalOutputs = 0
   let totalErrors = 0
 
-  for (const vault of args.vaults) {
-    const { chainId, address } = vault
-    console.log(`\n--- ${chainId}:${address} ---`)
+  // resolve every vault's daily grid first (cheap DB reads), then flatten into one
+  // work list so a single global pool keeps the RPC pipe full across vaults instead
+  // of stalling between them. peak concurrency stays CONCURRENCY (same RPC ceiling
+  // the per-vault batch had before), it just no longer idles between vaults.
+  type Task = { chainId: number, address: `0x${string}`, blockTime: bigint }
+  const tasks: Task[] = []
+  let skipped = 0
 
+  console.log(`\nResolving grids for ${vaults.length} vaults...`)
+  let resolved = 0
+  await runPool(vaults, 10, async ({ chainId, address }) => {
     const grid = await getGridBlockTimes(chainId, address, args.start, args.end)
-    console.log(`  ${grid.length} grid points (from '${GRID_LABEL}')`)
+    resolved++
     if (grid.length === 0) {
-      console.log(`  skip: no '${GRID_LABEL}' history -- run a normal fanout to backfill this vault`)
-      continue
+      skipped++
+      console.log(`  [${resolved}/${vaults.length}] skip ${chainId}:${address} -- no '${GRID_LABEL}' history (run a normal fanout)`)
+      return
     }
-    totalEntries += grid.length
+    console.log(`  [${resolved}/${vaults.length}] ${chainId}:${address} -> ${grid.length} pts`)
+    for (const blockTime of grid) tasks.push({ chainId, address, blockTime })
+  })
 
-    let processed = 0
-    let errors = 0
+  totalEntries = tasks.length
+  console.log(`\nGrid resolved: ${tasks.length} points across ${vaults.length - skipped} vaults (${skipped} skipped)`)
 
-    for (let i = 0; i < grid.length; i += CONCURRENCY) {
-      const batch = grid.slice(i, i + CONCURRENCY)
-      const results = await Promise.allSettled(batch.map(async (blockTime) => {
-        const outputs: Output[] = []
-        for (const key of args.labels) {
-          const { outputLabel, compute } = LABELS[key]
-          outputs.push(...await compute(chainId, address, {
-            abiPath: 'erc4626', chainId, address, outputLabel, blockTime,
-          }))
-        }
-        return outputs
-      }))
-
-      for (const result of results) {
-        if (result.status === 'fulfilled') {
-          if (result.value.length > 0) {
-            if (!args.dryRun) await insertTempBatch(TEMP_TABLE, toTempRows(result.value))
-            totalOutputs += result.value.length
-          }
-          processed++
-        } else {
-          errors++
-          totalErrors++
-          console.error('  Error:', result.reason instanceof Error ? result.reason.message : String(result.reason))
-        }
-      }
-
-      process.stdout.write(`\r  ${processed}/${grid.length} processed, ${errors} errors`)
-    }
-
-    console.log()
+  if (tasks.length === 0) {
+    console.log('Nothing to recompute -- exiting.')
+    await rpcs.down()
+    await db.end()
+    return
   }
+
+  console.log(`Computing at concurrency ${CONCURRENCY}${args.dryRun ? ' (dry run -- not writing)' : ''}...`)
+  const computeStart = Date.now()
+  let processed = 0
+  await runPool(tasks, CONCURRENCY, async ({ chainId, address, blockTime }) => {
+    try {
+      const outputs: Output[] = []
+      for (const key of args.labels) {
+        const { outputLabel, compute } = LABELS[key]
+        outputs.push(...await compute(chainId, address, {
+          abiPath: 'erc4626', chainId, address, outputLabel, blockTime,
+        }))
+      }
+      if (outputs.length > 0) {
+        if (!args.dryRun) await insertTempBatch(TEMP_TABLE, toTempRows(outputs))
+        totalOutputs += outputs.length
+      }
+    } catch (error) {
+      totalErrors++
+      console.error(`\n  Error ${chainId}:${address} @ ${blockTime}:`, error instanceof Error ? error.message : String(error))
+    }
+    if (++processed % 25 === 0 || processed === tasks.length) {
+      const elapsed = (Date.now() - computeStart) / 1000
+      const rate = processed / elapsed
+      const eta = rate > 0 ? (tasks.length - processed) / rate : 0
+      const pct = ((processed / tasks.length) * 100).toFixed(0)
+      process.stdout.write(`\r  ${processed}/${tasks.length} (${pct}%) | ${rate.toFixed(1)}/s | ${totalOutputs} outputs | ${totalErrors} err | elapsed ${fmtDuration(elapsed)} | ETA ${fmtDuration(eta)}    `)
+    }
+  })
+  console.log()
 
   const duration = ((Date.now() - startTime) / 1000).toFixed(2)
   console.log('\n=== Summary ===')
-  console.log(`Vaults:     ${args.vaults.length}`)
+  console.log(`Vaults:     ${vaults.length}`)
   console.log(`Grid pts:   ${totalEntries}`)
   console.log(`Outputs:    ${totalOutputs}`)
   console.log(`Errors:     ${totalErrors}`)
   console.log(`Duration:   ${duration}s`)
+  console.log(`Rate:       ${(totalEntries / Number(duration)).toFixed(1)} pts/s`)
 
   if (!args.dryRun) {
     const count = await db.query(`SELECT COUNT(*) FROM ${TEMP_TABLE}`)

--- a/packages/scripts/src/issue-225/upsert.ts
+++ b/packages/scripts/src/issue-225/upsert.ts
@@ -1,0 +1,25 @@
+import 'lib/global'
+
+import db from 'ingest/db'
+import { promoteTempTable } from '../backfill-shared/upsert'
+
+/**
+ * Promote recomputed fapy + oracle apy outputs from the temp table into the
+ * production output table (value-only update on conflict; drops the temp table).
+ * Run compute.ts first.
+ */
+
+const TEMP_TABLE = 'output_temp_fapy_oracle'
+
+async function main() {
+  try {
+    await promoteTempTable(TEMP_TABLE)
+  } finally {
+    await db.end()
+  }
+}
+
+main().catch(error => {
+  console.error('Fatal error:', error)
+  process.exit(1)
+})


### PR DESCRIPTION
### Summary
Yearn-branded Morpho meta-vaults (plain ERC4626, no v3 interface) reported `0` for pps/apy and an empty apr-oracle in Kong. Example: `0x0963232eB842BAF53E8e517691f81745C1F228a0` (chain 1), held as a strategy by v3 allocator `0x310B7Ea7475A0B449Cfd73bE81522F1B88eFAFaa`, showed `0` while oracle.yearn.fi returned a non-zero apr.

Closes #225.

Two root causes, both fixed:
1. **pps/apy = 0**: the erc4626 hooks quoted `convertToAssets` with the *asset* decimals from `thing.defaults`. These Morpho vaults are 18-share / 6-asset, so `convertToAssets(10**6)` rounds to `0`. Now we read the vault's own immutable `decimals()` for the share-unit arg and keep asset decimals for the humanize/TVL divisor.
2. **empty apr-oracle**: plain erc4626 vaults are not classified as `yearn/3/vault`, so the apr-oracle timeseries hook never ran for them, though the oracle prices them by address. Added an erc4626 apr-oracle hook that delegates to the shared oracle resolver.

### How to review
- Start with `packages/ingest/abis/erc4626/lib.ts`. The new `ppsReadParameters()` is the single home for the share-vs-asset decimals rule. Note `decimals()` is read at `latest` (immutable, so no archive-node dependency), and a read failure warns before falling back to stored decimals (the fallback holds only when share == asset).
- `yearn/3/vault/timeseries/apr-oracle/hook.ts`: extracted `resolveOracleApr()` (oracle config + block resolution + inceptBlock guard + readApr + computeApy). The default v3 export and the new erc4626 hook both call it. `readApr` stays exported (the backfill script uses it). The v3 hook's behavior is unchanged.
- `erc4626/timeseries/apr-oracle/hook.ts` (new): emits `apr`/`apy` only (net apr/apy aren't surfaced for erc4626 vaults).
- `pps/hook.ts` + `apy/hook.ts`: both now call `ppsReadParameters(chainId, address, vault.defaults.decimals)`.

Smoke test (terminal UI after `make dev`): fanout the erc4626 timeseries hooks (terminal UI → ingest → fanout abis) for `0x0963…` on chain 1, then hit the parent allocator snapshot:
```
https://kong.yearn.fi/api/rest/snapshot/1/0x310B7Ea7475A0B449Cfd73bE81522F1B88eFAFaa
```
Strategy `0x0963…` should show non-zero pps, apy, and a populated apr-oracle (apr/apy) matching oracle.yearn.fi.

### Test plan
- [x] Automated:
  ```
  bun --filter ingest run test abis/erc4626/timeseries/apr-oracle/hook.spec.ts abis/erc4626/timeseries/pps/hook.spec.ts
  ```
  6 passing: new apr-oracle hook (pinned-block apr, no-oracle chain → `[]`, emits apr+apy); pps share≠asset decimals regression test (raw `1002039`, humanized ≈ `1.002039` at block `25211174`). Fixed avantis fixture `decimals` 18→6 (matches on-chain + prod convention).
- [x] Lint/types: `eslint` clean, `tsc --noEmit` clean.
- [ ] Manual: `make dev` → terminal UI → fanout abis → verify `0x0963…` snapshot via the allocator endpoint above.

### Post-merge recompute (#225)
These fixes only correct *new* hook runs. Already-stored history must be recomputed for affected erc4626 vaults: historical apy (`apy-bwd-delta-pps`) and historical oracle apy (`apr-oracle`).

This is timeseries data (the `output` table), not event data. Editing `evmlog_strides` and rerunning a normal fanout does **not** recompute it: the erc4626 timeseries hooks don't read evmlog, and the timeseries fanout only fills *missing* days. The wrong `apy-bwd-delta-pps` rows already exist (as `0`), so a fanout skips them and fixes only the latest point. (`apr-oracle` is a new label for erc4626 with no rows, so a fanout would backfill it on its own; the script writes it too so apy and oracle apy land in one reviewable upsert.) The native "fanout replays" command is not used.

Method: `packages/scripts/src/issue-225`. `compute.ts` recomputes into a staging table (`output_temp_fapy_oracle`), `upsert.ts` promotes it into `output` in one transaction. It reuses the live erc4626 hooks (no duplicated compute) and the shared `backfill-shared` helpers; the upsert updates `value` only on conflict, so each recomputed point matches what a normal fanout would write. `--vaults` scopes each run, `--dry-run` previews compute. Discovery queries and steps are in the script README.

Plan:
1. Merge this PR.
2. Discover affected vaults (queries in the README).
3. **Morpho first**: run compute → upsert for the Morpho subset, verify against oracle.yearn.fi, then run the remaining erc4626 vaults.
4. Refresh snapshot/timeseries caches.

### Risk / impact
- Behavior changes for vaults where `decimals()` (share) ≠ `defaults.decimals` (asset). For every standard vault (share == asset) the convertToAssets arg matches before, so nothing changes. Verified `defaults.decimals` == asset decimals by convention across `manuals.yaml` + event hooks.
- One extra `decimals()` read per pps/apy compute (cheap, at `latest`).
- No migrations, no auth/funds paths, no feature flags. Rollback = revert commit `7559ddd`.
- On a transient `decimals()` read failure the hook warns and falls back to stored decimals (could re-introduce a 0 pps for a share≠asset vault), logged with 🚨 so it's traceable rather than silent.
- Recompute (above) overwrites stored `output` rows for the targeted vaults only. It stages to `output_temp_fapy_oracle` and promotes in a single transaction; `compute.ts --dry-run` previews first; the `--vaults` list bounds the scope. No schema change. Rollback = rerun the script to re-derive the affected series.

