### PR TITLE
fix: use valid checksummed address in types.spec fixture

### DIFF
--- a/packages/lib/types.spec.ts
+++ b/packages/lib/types.spec.ts
@@ -3,7 +3,7 @@ import { OutputSchema } from './types'
 
 const mock = {
   chainId: 1,
-  address: '0x',
+  address: '0x0000000000000000000000000000000000000001',
   label: 'label',
   component: 'component',
   value: 1,


### PR DESCRIPTION
## Problem

`packages/lib/types.spec.ts` mocked `address: '0x'` and ran `OutputSchema.parse(mock)`. `OutputSchema.address` is `EvmAddressSchema`, which calls viem's `getAddress()`; `getAddress('0x')` throws `InvalidAddressError`.

The test was latent-broken on disk. It stayed hidden because `packages/lib/strider.spec.ts` had `describe.only`/`it.only`, so mocha skipped every other file. #413 removed those `.only` calls, so all lib specs now run and this failure surfaces — `bun --filter lib test` exits 1.

## Fix

Replace the fixture address with a real checksummed one: `0x0000000000000000000000000000000000000001`. No alpha hex chars, so `getAddress()` is identity and the `deep.equal(mock)` assertion still holds.

## Verify

`bun --filter lib test` — `types > parses outputs` now passes.

Note: 5 pre-existing `dates.spec.ts` failures remain (timezone-dependent assertions, present on `main`). Out of scope here.

Closes #415
