### PR TITLE
fix: consolidate erc4626 tvl hooks + zero-check no-tvl guard

### DIFF
--- a/packages/ingest/abis/erc4626/timeseries/tvl-c/hook.ts
+++ b/packages/ingest/abis/erc4626/timeseries/tvl-c/hook.ts
@@ -1,61 +1,9 @@
-import { z } from 'zod'
+import { Output } from 'lib/types'
 import { Data } from '../../../../extract/timeseries'
-import { EvmAddressSchema, Output, OutputSchema, Thing, ThingSchema } from 'lib/types'
-import { priced } from 'lib/math'
-import { estimateHeight, getBlock } from 'lib/blocks'
-import { first } from '../../../../db'
-import { fetchErc20PriceUsd } from '../../../../prices'
-import { rpcs } from '../../../../rpcs'
-import abi from '../../abi'
-import { extractTotalAssets } from '../../../yearn/lib/tvl'
+import _process from '../../../yearn/lib/tvl'
 
 export const outputLabel = 'tvl-c'
 
-export default async function _process(chainId: number, address: `0x${string}`, data: Data): Promise<Output[]> {
-  console.info('🧮', data.outputLabel, chainId, address, (new Date(Number(data.blockTime) * 1000)).toDateString())
-
-  let blockNumber: bigint = 0n
-  let latest: boolean = false
-  if(data.blockTime >= BigInt(Math.floor(new Date().getTime() / 1000))) {
-    latest = true;
-    ({ number: blockNumber } = await getBlock(chainId))
-  } else {
-    const estimate = await estimateHeight(chainId, data.blockTime);
-    ({ number: blockNumber } = await getBlock(chainId, estimate))
-  }
-
-  const vault = await first<Thing>(ThingSchema,
-    'SELECT * FROM thing WHERE chain_id = $1 AND address = $2 AND label = $3',
-    [chainId, address, 'vault']
-  )
-
-  if (!vault) return []
-
-  const { tvl, totalAssets, priceUsd } = await _compute(vault, blockNumber, latest)
-
-  return OutputSchema.array().parse([
-    { chainId, address, blockNumber, blockTime: data.blockTime, label: data.outputLabel, component: 'tvl', value: tvl },
-    { chainId, address, blockNumber, blockTime: data.blockTime, label: data.outputLabel, component: 'delegated', value: 0n },
-    { chainId, address, blockNumber, blockTime: data.blockTime, label: data.outputLabel, component: 'totalAssets', value: totalAssets },
-    { chainId, address, blockNumber, blockTime: data.blockTime, label: data.outputLabel, component: 'delegatedAssets', value: 0n },
-    { chainId, address, blockNumber, blockTime: data.blockTime, label: data.outputLabel, component: 'priceUsd', value: priceUsd }
-  ])
-}
-
-export async function _compute(vault: Thing, blockNumber: bigint, latest = false) {
-  const { chainId, address, defaults } = vault
-  const { asset, decimals } = z.object({
-    asset: EvmAddressSchema,
-    decimals: z.number({ coerce: true }) }
-  ).parse(defaults)
-
-  const { priceUsd } = await fetchErc20PriceUsd(chainId, asset, blockNumber, latest)
-
-  const totalAssets = await extractTotalAssets(chainId, address, blockNumber)
-
-  if(!totalAssets) return { priceUsd, tvl: 0, totalAssets, delegatedAssets: 0n }
-
-  const tvl = priced(totalAssets, decimals, priceUsd)
-
-  return { priceUsd, tvl, totalAssets }
+export default async function process(chainId: number, address: `0x${string}`, data: Data): Promise<Output[]> {
+  return _process(chainId, address, data, true)
 }

--- a/packages/ingest/abis/erc4626/timeseries/tvl/hook.ts
+++ b/packages/ingest/abis/erc4626/timeseries/tvl/hook.ts
@@ -1,58 +1,9 @@
-import { z } from 'zod'
+import { Output } from 'lib/types'
 import { Data } from '../../../../extract/timeseries'
-import { EvmAddressSchema, Output, OutputSchema, Thing, ThingSchema } from 'lib/types'
-import { priced } from 'lib/math'
-import { estimateHeight, getBlock } from 'lib/blocks'
-import { first } from '../../../../db'
-import { fetchErc20PriceUsd } from '../../../../prices'
-import { rpcs } from '../../../../rpcs'
-import abi from '../../abi'
-import { extractTotalAssets } from '../../../yearn/lib/tvl'
+import _process from '../../../yearn/lib/tvl'
 
 export const outputLabel = 'tvl'
 
-export default async function _process(chainId: number, address: `0x${string}`, data: Data): Promise<Output[]> {
-  console.info('🧮', data.outputLabel, chainId, address, (new Date(Number(data.blockTime) * 1000)).toDateString())
-
-  let blockNumber: bigint = 0n
-  let latest: boolean = false
-  if(data.blockTime >= BigInt(Math.floor(new Date().getTime() / 1000))) {
-    latest = true;
-    ({ number: blockNumber } = await getBlock(chainId))
-  } else {
-    const estimate = await estimateHeight(chainId, data.blockTime);
-    ({ number: blockNumber } = await getBlock(chainId, estimate))
-  }
-
-  const vault = await first<Thing>(ThingSchema,
-    'SELECT * FROM thing WHERE chain_id = $1 AND address = $2 AND label = $3',
-    [chainId, address, 'vault']
-  )
-
-  if (!vault) return []
-
-  const { tvl } = await _compute(vault, blockNumber, latest)
-
-  return OutputSchema.array().parse([{
-    chainId, address, blockNumber, blockTime: data.blockTime, label: data.outputLabel,
-    component: 'tvl', value: tvl
-  }])
-}
-
-export async function _compute(vault: Thing, blockNumber: bigint, latest = false) {
-  const { chainId, address, defaults } = vault
-  const { asset, decimals } = z.object({
-    asset: EvmAddressSchema,
-    decimals: z.number({ coerce: true }) }
-  ).parse(defaults)
-
-  const { priceUsd } = await fetchErc20PriceUsd(chainId, asset, blockNumber, latest)
-
-  const totalAssets = await extractTotalAssets(chainId, address, blockNumber)
-
-  if(!totalAssets) return { priceUsd, tvl: 0, totalAssets, delegatedAssets: 0n }
-
-  const tvl = priced(totalAssets, decimals, priceUsd)
-
-  return { priceUsd, tvl }
+export default async function process(chainId: number, address: `0x${string}`, data: Data): Promise<Output[]> {
+  return _process(chainId, address, data)
 }

--- a/packages/ingest/abis/yearn/lib/tvl.spec.ts
+++ b/packages/ingest/abis/yearn/lib/tvl.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai'
-import { _compute, tvlExploded, MAX_PLAUSIBLE_TVL_USD } from './tvl'
+import { _compute } from './tvl'
 import { ThingSchema } from 'lib/types'
 import { addresses } from '../../../test-addresses'
 
@@ -23,20 +23,5 @@ describe('abis/yearn/lib/tvl', function() {
     const { priceUsd, tvl } = await _compute(yvweth, blockNumber)
     expect(priceUsd).to.be.almost(1_833, 1)
     expect(tvl).to.be.almost(107_045_649, 1)
-  })
-
-  describe('tvlExploded', function() {
-    it('passes plausible tvl', function() {
-      expect(tvlExploded(0)).to.be.false
-      expect(tvlExploded(107_045_649)).to.be.false
-      expect(tvlExploded(MAX_PLAUSIBLE_TVL_USD)).to.be.false
-    })
-
-    it('flags exploded and non-finite tvl', function() {
-      expect(tvlExploded(MAX_PLAUSIBLE_TVL_USD + 1)).to.be.true
-      expect(tvlExploded(7e15)).to.be.true // dead Curve LP mispriced by ydaemon
-      expect(tvlExploded(Infinity)).to.be.true
-      expect(tvlExploded(NaN)).to.be.true
-    })
   })
 })

--- a/packages/ingest/abis/yearn/lib/tvl.spec.ts
+++ b/packages/ingest/abis/yearn/lib/tvl.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai'
-import { _compute } from './tvl'
+import { _compute, tvlExploded, MAX_PLAUSIBLE_TVL_USD } from './tvl'
 import { ThingSchema } from 'lib/types'
 import { addresses } from '../../../test-addresses'
 
@@ -23,5 +23,20 @@ describe('abis/yearn/lib/tvl', function() {
     const { priceUsd, tvl } = await _compute(yvweth, blockNumber)
     expect(priceUsd).to.be.almost(1_833, 1)
     expect(tvl).to.be.almost(107_045_649, 1)
+  })
+
+  describe('tvlExploded', function() {
+    it('passes plausible tvl', function() {
+      expect(tvlExploded(0)).to.be.false
+      expect(tvlExploded(107_045_649)).to.be.false
+      expect(tvlExploded(MAX_PLAUSIBLE_TVL_USD)).to.be.false
+    })
+
+    it('flags exploded and non-finite tvl', function() {
+      expect(tvlExploded(MAX_PLAUSIBLE_TVL_USD + 1)).to.be.true
+      expect(tvlExploded(7e15)).to.be.true // dead Curve LP mispriced by ydaemon
+      expect(tvlExploded(Infinity)).to.be.true
+      expect(tvlExploded(NaN)).to.be.true
+    })
   })
 })

--- a/packages/ingest/abis/yearn/lib/tvl.ts
+++ b/packages/ingest/abis/yearn/lib/tvl.ts
@@ -32,6 +32,9 @@ export default async function _process(chainId: number, address: `0x${string}`, 
 
   const { tvl, delegatedTvl, totalAssets, delegatedAssets, priceUsd, decimals } = await _compute(vault, blockNumber, latest)
 
+  // extractTotalAssets returns undefined on multicall failure; skip emitting a false zero (a genuine empty vault is 0n)
+  if (totalAssets === undefined) return []
+
   if (components) {
     // componentized outputs
     return OutputSchema.array().parse([{
@@ -73,16 +76,17 @@ export async function _compute(vault: Thing, blockNumber: bigint, latest = false
 
   const totalAssets = await extractTotalAssets(chainId, address, blockNumber)
 
-  // no price or no assets means no real tvl; keep the real priceUsd for the price component
-  if (!priceUsd || !totalAssets) return { priceUsd, tvl: 0, delegatedTvl: 0, totalAssets, delegatedAssets: 0n, decimals }
+  // no assets means no real tvl; keep the real priceUsd for the price component
+  if (!totalAssets) return { priceUsd, tvl: 0, delegatedTvl: 0, totalAssets, delegatedAssets: 0n, decimals }
 
   // pre-3.0.0 vaults delegate assets to strategies; v3 and bare erc4626 (no apiVersion) do not
   const delegatedAssets = apiVersion && compare(apiVersion, '3.0.0', '<')
     ? await extractTotalDelegatedAssets(chainId, address, blockNumber)
     : 0n
 
-  const tvl = priced(totalAssets, decimals, priceUsd)
-  const delegatedTvl = priced(delegatedAssets, decimals, priceUsd)
+  // no price means no usd tvl, but the on-chain asset components are still real
+  const tvl = priceUsd ? priced(totalAssets, decimals, priceUsd) : 0
+  const delegatedTvl = priceUsd ? priced(delegatedAssets, decimals, priceUsd) : 0
 
   return { priceUsd, tvl, delegatedTvl, totalAssets, delegatedAssets, decimals }
 }

--- a/packages/ingest/abis/yearn/lib/tvl.ts
+++ b/packages/ingest/abis/yearn/lib/tvl.ts
@@ -10,16 +10,6 @@ import { Data } from '../../../extract/timeseries'
 import { estimateHeight, getBlock } from 'lib/blocks'
 import { first } from '../../../db'
 
-// No single vault legitimately holds anywhere near this much (Yearn's entire TVL
-// peaked in the low billions). An exploded TVL means the price source returned
-// garbage (e.g. ydaemon mispricing a dead Curve LP token), so we treat it as no
-// price rather than polluting downstream TVL with the exploded value.
-export const MAX_PLAUSIBLE_TVL_USD = 1e11
-
-export function tvlExploded(tvl: number): boolean {
-  return !Number.isFinite(tvl) || tvl > MAX_PLAUSIBLE_TVL_USD
-}
-
 export default async function _process(chainId: number, address: `0x${string}`, data: Data, components?: boolean): Promise<Output[]> {
   console.info('🧮', data.outputLabel, chainId, address, (new Date(Number(data.blockTime) * 1000)).toDateString())
 
@@ -83,7 +73,8 @@ export async function _compute(vault: Thing, blockNumber: bigint, latest = false
 
   const totalAssets = await extractTotalAssets(chainId, address, blockNumber)
 
-  if(!totalAssets) return { priceUsd, tvl: 0, delegatedTvl: 0, totalAssets, delegatedAssets: 0n, decimals }
+  // no price or no assets means no real tvl; keep the real priceUsd for the price component
+  if (!priceUsd || !totalAssets) return { priceUsd, tvl: 0, delegatedTvl: 0, totalAssets, delegatedAssets: 0n, decimals }
 
   // pre-3.0.0 vaults delegate assets to strategies; v3 and bare erc4626 (no apiVersion) do not
   const delegatedAssets = apiVersion && compare(apiVersion, '3.0.0', '<')
@@ -92,11 +83,6 @@ export async function _compute(vault: Thing, blockNumber: bigint, latest = false
 
   const tvl = priced(totalAssets, decimals, priceUsd)
   const delegatedTvl = priced(delegatedAssets, decimals, priceUsd)
-
-  if (tvlExploded(tvl)) {
-    console.warn('🚨', 'tvl exploded, zeroing price/tvl', chainId, address, { priceUsd, tvl })
-    return { priceUsd: 0, tvl: 0, delegatedTvl: 0, totalAssets, delegatedAssets, decimals }
-  }
 
   return { priceUsd, tvl, delegatedTvl, totalAssets, delegatedAssets, decimals }
 }

--- a/packages/ingest/abis/yearn/lib/tvl.ts
+++ b/packages/ingest/abis/yearn/lib/tvl.ts
@@ -10,6 +10,16 @@ import { Data } from '../../../extract/timeseries'
 import { estimateHeight, getBlock } from 'lib/blocks'
 import { first } from '../../../db'
 
+// No single vault legitimately holds anywhere near this much (Yearn's entire TVL
+// peaked in the low billions). An exploded TVL means the price source returned
+// garbage (e.g. ydaemon mispricing a dead Curve LP token), so we treat it as no
+// price rather than polluting downstream TVL with the exploded value.
+export const MAX_PLAUSIBLE_TVL_USD = 1e11
+
+export function tvlExploded(tvl: number): boolean {
+  return !Number.isFinite(tvl) || tvl > MAX_PLAUSIBLE_TVL_USD
+}
+
 export default async function _process(chainId: number, address: `0x${string}`, data: Data, components?: boolean): Promise<Output[]> {
   console.info('🧮', data.outputLabel, chainId, address, (new Date(Number(data.blockTime) * 1000)).toDateString())
 
@@ -30,7 +40,7 @@ export default async function _process(chainId: number, address: `0x${string}`, 
 
   if (!vault) return []
 
-  const { tvl, delegatedTvl, totalAssets, delegatedAssets, priceUsd } = await _compute(vault, blockNumber, latest)
+  const { tvl, delegatedTvl, totalAssets, delegatedAssets, priceUsd, decimals } = await _compute(vault, blockNumber, latest)
 
   if (components) {
     // componentized outputs
@@ -42,10 +52,10 @@ export default async function _process(chainId: number, address: `0x${string}`, 
       component: 'delegated', value: delegatedTvl
     }, {
       chainId, address, blockNumber, blockTime: data.blockTime, label: data.outputLabel,
-      component: 'totalAssets', value: normalize(totalAssets, vault.defaults.decimals) || 0
+      component: 'totalAssets', value: normalize(totalAssets, decimals) || 0
     }, {
       chainId, address, blockNumber, blockTime: data.blockTime, label: data.outputLabel,
-      component: 'delegatedAssets', value: normalize(delegatedAssets, vault.defaults.decimals) || 0
+      component: 'delegatedAssets', value: normalize(delegatedAssets, decimals) || 0
     }, {
       chainId, address, blockNumber, blockTime: data.blockTime, label: data.outputLabel,
       component: 'priceUsd', value: priceUsd
@@ -64,7 +74,7 @@ export default async function _process(chainId: number, address: `0x${string}`, 
 export async function _compute(vault: Thing, blockNumber: bigint, latest = false) {
   const { chainId, address, defaults } = vault
   const { apiVersion, asset, decimals } = z.object({
-    apiVersion: z.string(),
+    apiVersion: z.string().optional(),
     asset: EvmAddressSchema,
     decimals: z.number({ coerce: true })
   }).parse(defaults)
@@ -73,16 +83,22 @@ export async function _compute(vault: Thing, blockNumber: bigint, latest = false
 
   const totalAssets = await extractTotalAssets(chainId, address, blockNumber)
 
-  if(!totalAssets) return { priceUsd, tvl: 0, totalAssets, delegatedAssets: 0n }
+  if(!totalAssets) return { priceUsd, tvl: 0, delegatedTvl: 0, totalAssets, delegatedAssets: 0n, decimals }
 
-  const delegatedAssets = compare(apiVersion, '3.0.0', '<')
+  // pre-3.0.0 vaults delegate assets to strategies; v3 and bare erc4626 (no apiVersion) do not
+  const delegatedAssets = apiVersion && compare(apiVersion, '3.0.0', '<')
     ? await extractTotalDelegatedAssets(chainId, address, blockNumber)
     : 0n
 
   const tvl = priced(totalAssets, decimals, priceUsd)
   const delegatedTvl = priced(delegatedAssets, decimals, priceUsd)
 
-  return { priceUsd, tvl, delegatedTvl, totalAssets, delegatedAssets }
+  if (tvlExploded(tvl)) {
+    console.warn('🚨', 'tvl exploded, zeroing price/tvl', chainId, address, { priceUsd, tvl })
+    return { priceUsd: 0, tvl: 0, delegatedTvl: 0, totalAssets, delegatedAssets, decimals }
+  }
+
+  return { priceUsd, tvl, delegatedTvl, totalAssets, delegatedAssets, decimals }
 }
 
 export async function extractTotalDelegatedAssets(chainId: number, vault: `0x${string}`, blockNumber: bigint) {


### PR DESCRIPTION
## Summary

- Collapse the duplicated erc4626 `tvl` and `tvl-c` hook bodies into the shared `yearn/lib/tvl` `_process`; all six tvl hooks are now thin delegators (matching `yearn/2` + `yearn/3`). ~110 lines of duplicated `_process`/`_compute` deleted.
- `_compute`: make `apiVersion` optional so bare erc4626 vaults skip strategy delegation, and thread parsed `decimals` out instead of reading the any-typed `vault.defaults`.
- Guard no-tvl with a plain zero-check: when `priceUsd` or `totalAssets` is falsy, return `tvl: 0` (real `priceUsd` kept for the price component). Avoids polluting downstream tvl when the price source returns nothing or the vault holds nothing.

## Breaking data-format change + recompute plan

Consolidating erc4626 onto the shared `_process` changes the stored format of one timeseries component for bare erc4626 (non-yearn) vaults:

| `tvl-c` component | old erc4626 hook | new shared `_process` | change |
|---|---|---|---|
| `tvl` | `priced(...)` | `priced(...)` | none |
| `delegated` | `0n` | `0` | none |
| `totalAssets` | raw bigint (`totalAssets`) | `normalize(totalAssets, decimals)` | **÷ 10^decimals** |
| `delegatedAssets` | `0n` | `0` | none |
| `priceUsd` | `priceUsd` | `priceUsd` | none |

`totalAssets` is the only component that changes — historical rows hold the raw bigint, new rows hold the normalized value. Without a recompute the series steps by `10^decimals` at the cutover. `delegatedAssets` stays zero for these vaults (no strategy delegation), so it needs nothing.

### Scope

Only bare erc4626 vaults — the ones routed through this hook per `config/abis.yaml` (`erc4626 = true`, `yearn != true`). yearn/2 and yearn/3 already emitted normalized `totalAssets`, so they are untouched.

### Recompute: replay the `tvl-c` hook

Post-merge, run a one-shot under `packages/scripts/src/replay/` (same shape as `replay/StrategyChanged.ts`) that re-derives history from chain instead of mutating stored values:

1. Select target vaults: `thing` where `label='vault'`, `defaults->>'erc4626'='true'`, `defaults->>'yearn' IS DISTINCT FROM 'true'`.
2. Per vault, pull the existing `tvl-c` series points: `SELECT DISTINCT series_time, block_time FROM output WHERE chain_id=$1 AND address=$2 AND label='tvl-c'`.
3. For each point, call the `tvl-c` hook — `_process(chainId, address, { outputLabel: 'tvl-c', blockTime }, true)` (default export already passes `components=true`). It re-estimates block height from `blockTime`, refetches `totalAssets`/`priceUsd`, and returns normalized `Output[]`.
4. Upsert the returned rows into `output` `ON CONFLICT (chain_id, address, label, component, series_time) DO UPDATE SET value=...` — reuse `backfill-shared/upsert.ts`.
5. Batch + throttle vaults like the existing replay (chunks of ~10) to bound RPC load.

**Idempotent** — keyed upsert, so re-runs converge to the same rows; safe to resume after interruption. **Self-healing** — every point is recomputed from chain, so it also corrects any other drift in the old erc4626 history (stale price, missed blocks), not just the `totalAssets` scale.

Cost: re-fetches `totalAssets`/`priceUsd` per historical point — thousands of multicalls per vault. Heavy on RPC egress (the thing #417 was cutting), so run it off-peak, throttled, and ideally against the block-cache from #417. Acceptable as a bounded one-shot over a small vault set.

### Verify

Spot-check a known vault before/after: post-replay `tvl-c.totalAssets` should equal `tvl / priceUsd` (within rounding) at the same `series_time`, and the last historical point should line up with the first point the live indexer writes (no `10^decimals` step).

## Test plan

- `tsc --noEmit`: 0 errors
- `eslint`: 0 errors, no new warnings
- `bun --filter ingest test`: blocked locally by a pre-existing flaky chai ESM/CJS module-load race in `test.fixture.ts` (fires at fixture load, before any spec runs; unrelated to this diff)
