### PR TITLE
feat(ingest): report errors and exceptions to Sentry

### DIFF
--- a/packages/ingest/abis/yearn/3/strategy/event/hook.ts
+++ b/packages/ingest/abis/yearn/3/strategy/event/hook.ts
@@ -3,7 +3,7 @@ import { parseAbi, toEventSelector } from 'viem'
 import { priced } from 'lib/math'
 import { fetchOrExtractAssetAddress, fetchOrExtractDecimals } from '../../../lib'
 import { fetchErc20PriceUsd } from '../../../../../prices'
-import { math, multicall3 } from 'lib'
+import { math, multicall3, sentry } from 'lib'
 import { rpcs } from '../../../../../rpcs'
 import { first } from '../../../../../db'
 import { EvmLog, EvmLogSchema, zhexstring } from 'lib/types'
@@ -69,6 +69,7 @@ export async function totalAssets(harvest: Harvest) {
     }) as bigint
   } catch(error) {
     console.error('🤬', '!totalAssets')
+    sentry.captureException(error, { tags: { component: 'ingest', hook: 'strategy.event.totalAssets' } })
     return 0n
   }
 }

--- a/packages/ingest/abis/yearn/3/vault/event/StrategyReported/hook.ts
+++ b/packages/ingest/abis/yearn/3/vault/event/StrategyReported/hook.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 import { parseAbi, toEventSelector } from 'viem'
 import { priced } from 'lib/math'
+import { sentry } from 'lib'
 import { fetchOrExtractAssetAddress, fetchOrExtractDecimals } from '../../../../lib'
 import { fetchErc20PriceUsd } from '../../../../../../prices'
 import { EvmAddressSchema, EvmLog, EvmLogSchema } from 'lib/types'
@@ -83,6 +84,7 @@ async function performanceFee(harvest: Harvest) {
     }) as number
   } catch(error) {
     console.error('🤬', '!performanceFee')
+    sentry.captureException(error, { tags: { component: 'ingest', hook: 'StrategyReported.performanceFee' } })
     return 0
   }
 }

--- a/packages/ingest/abis/yearn/3/vault/snapshot/hook.ts
+++ b/packages/ingest/abis/yearn/3/vault/snapshot/hook.ts
@@ -1,4 +1,4 @@
-import { mq } from 'lib'
+import { mq, sentry } from 'lib'
 import { estimateCreationBlock } from 'lib/blocks'
 import { priced } from 'lib/math'
 import { snakeToCamelCols } from 'lib/strings'
@@ -650,6 +650,7 @@ export async function extractFeesBps(chainId: number, address: `0x${string}`, sn
 
   } catch(err) {
     console.error('🤬', '!extractFeesBps', err)
+    sentry.captureException(err, { tags: { component: 'ingest', hook: 'vault.snapshot.extractFeesBps' } })
     return {
       managementFee: 0,
       performanceFee: 0

--- a/packages/ingest/extract/webhook.ts
+++ b/packages/ingest/extract/webhook.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 import { createHmac } from 'crypto'
-import { mq } from 'lib'
+import { mq, sentry } from 'lib'
 import { OutputSchema, zhexstring } from 'lib/types'
 import { WebhookSubscription, WebhookSubscriptionSchema } from 'lib/subscriptions'
 
@@ -78,10 +78,20 @@ export class WebhookExtractor {
       const valid = [...grouped].flatMap(([key, group]) => {
         if (group.length > MAX_OUTPUTS_PER_VAULT) {
           console.error(`🤬 ${subscription.id} skipping ${key}: ${group.length} outputs > ${MAX_OUTPUTS_PER_VAULT}`)
+          sentry.captureMessage('WEBHOOK_OUTPUTS_OVER_LIMIT', {
+            level: 'warning',
+            tags: { component: 'ingest', job: 'extract.webhook' },
+            extra: { subscriptionId: subscription.id, key, outputs: group.length, max: MAX_OUTPUTS_PER_VAULT }
+          })
           return []
         }
         if (group.some(o => !subscription.labels.includes(o.label))) {
           console.error(`🤬 ${subscription.id} skipping ${key}: unexpected labels`)
+          sentry.captureMessage('WEBHOOK_UNEXPECTED_LABELS', {
+            level: 'warning',
+            tags: { component: 'ingest', job: 'extract.webhook' },
+            extra: { subscriptionId: subscription.id, key }
+          })
           return []
         }
         return group

--- a/packages/ingest/index.ts
+++ b/packages/ingest/index.ts
@@ -8,7 +8,7 @@ dotenv.config({ path: envPath })
 import fs from 'fs'
 import { rpcs } from './rpcs'
 import { Processor, ProcessorPool } from 'lib/processor'
-import { cache, chains, abisConfig, crons as cronsConfig, mq } from 'lib'
+import { cache, chains, abisConfig, crons as cronsConfig, mq, sentry } from 'lib'
 import db from './db'
 import { camelToSnake } from 'lib/strings'
 
@@ -63,6 +63,13 @@ const abis = abisConfig.cron.start
     console.log('⬆', 'abis up')
   }) : Promise<null>
 
+async function fatal(phase: string, error: unknown) {
+  console.error('🤬', phase, error)
+  sentry.captureException(error, { tags: { component: 'ingest', phase } })
+  await sentry.flush(2000)
+  process.exit(1)
+}
+
 function up() {
   Promise.all([
     rpcs.up(),
@@ -74,10 +81,7 @@ function up() {
 
     console.log('🐒 ingest up')
 
-  }).catch(error => {
-    console.error('🤬', error)
-    process.exit(1)
-  })
+  }).catch(error => fatal('up', error))
 }
 
 function down() {
@@ -91,12 +95,11 @@ function down() {
     console.log('🐒 ingest down')
     process.exit(0)
 
-  }).catch(error => {
-    console.error('🤬', error)
-    process.exit(1)
-  })
+  }).catch(error => fatal('down', error))
 }
 
 up()
 process.on('SIGINT', down)
 process.on('SIGTERM', down)
+process.on('unhandledRejection', reason => fatal('unhandledRejection', reason))
+process.on('uncaughtException', error => fatal('uncaughtException', error))

--- a/packages/lib/mq.ts
+++ b/packages/lib/mq.ts
@@ -1,6 +1,6 @@
 import { Queue, Worker } from 'bullmq'
 import chains from './chains'
-import { countMetric, flush as flushSentry } from './sentry'
+import { captureException, countMetric, flush as flushSentry } from './sentry'
 import { Job } from './types'
 
 const MQ_INVENTORY = process.env.MQ_INVENTORY === 'true'
@@ -103,6 +103,7 @@ export function worker(queueName: string, handler: (job: any) => Promise<any>, c
       await handler(job)
     } catch(error) {
       console.error('🤬', error)
+      captureException(error, { tags: { component: 'mq.worker', queue: queueName } })
       throw error
     }
   }, {

--- a/packages/lib/sentry.ts
+++ b/packages/lib/sentry.ts
@@ -27,6 +27,16 @@ export function captureMessage(
   })
 }
 
+export function captureException(
+  exception: unknown,
+  options?: Parameters<(typeof import('@sentry/node'))['captureException']>[1]
+) {
+  void getSentry().then(Sentry => {
+    if (!Sentry) return
+    Sentry.captureException(exception, options)
+  })
+}
+
 export function countMetric(
   name: string,
   value: number,


### PR DESCRIPTION
### Summary
Ingest logged errors to stderr only, so failures never reached Sentry. A new `sentry.captureException` helper routes ingest error and exception paths to Sentry.

### How to review
Start with `packages/lib/sentry.ts` (new `captureException`) and the worker catch in `packages/lib/mq.ts`. The worker boundary captures every job exception, so re-throwing catches (like `extract/webhook.ts`) report there once with no duplicate. Three hook catches swallow their errors and never reach the boundary, so they capture directly: `extractFeesBps` (vault snapshot), `performanceFee` (StrategyReported), `totalAssets` (strategy event). `packages/ingest/index.ts` adds a `fatal()` helper plus process-level `unhandledRejection`/`uncaughtException` handlers that flush Sentry before exit.

### Test plan
- [ ] Manual: with `SENTRY_DSN` set, force an ingest job to throw and confirm a single event reaches Sentry (no duplicate); push a webhook over the output limit and confirm a `WEBHOOK_OUTPUTS_OVER_LIMIT` warning. With `SENTRY_DSN` unset, confirm capture is a no-op and the process still exits.
- [ ] Automated: `tsc --noEmit` and `eslint` pass for `lib` and `ingest` (observed). Unit tests not run (require redis/postgres).

### Risk / impact
Low. The new `unhandledRejection`/`uncaughtException` handlers keep ingest's crash-on-fatal behavior (still `exit(1)`) and add reporting. Capture is a no-op when `SENTRY_DSN` is unset. The worker-boundary capture lives in `lib/mq.ts`, shared by all queue consumers. Rollback: revert the commit.
