### PR TITLE
perf(ingest): cut DB egress with column projection and hypertable chunk pruning

### DIFF
--- a/packages/ingest/abis/yearn/2/tradeHandler/snapshot/hook.ts
+++ b/packages/ingest/abis/yearn/2/tradeHandler/snapshot/hook.ts
@@ -16,7 +16,7 @@ async function project(chainId: number, tradeHandler: `0x${string}`) {
   ]
 
   const events = await db.query(`
-  SELECT signature, args
+  SELECT signature, args->>'seller' AS seller, args->>'tokenIn' AS "tokenIn"
   FROM evmlog
   WHERE chain_id = $1 AND address = $2 AND signature = ANY($3)
   ORDER BY block_number ASC, log_index ASC`,
@@ -26,13 +26,13 @@ async function project(chainId: number, tradeHandler: `0x${string}`) {
   const result: Partial<Tradeable>[] = []
 
   for (const event of events.rows) {
-    const index = result.findIndex(r => r.strategy === zhexstring.parse(event.args.seller) && r.token === zhexstring.parse(event.args.tokenIn))
+    const index = result.findIndex(r => r.strategy === zhexstring.parse(event.seller) && r.token === zhexstring.parse(event.tokenIn))
     switch (event.signature) {
     case topics[0]:
       if (index > -1) break
       result.push({
-        strategy: zhexstring.parse(event.args.seller),
-        token: zhexstring.parse(event.args.tokenIn)
+        strategy: zhexstring.parse(event.seller),
+        token: zhexstring.parse(event.tokenIn)
       })
       break
     case topics[1]:

--- a/packages/ingest/abis/yearn/2/vault/snapshot/hook.ts
+++ b/packages/ingest/abis/yearn/2/vault/snapshot/hook.ts
@@ -136,7 +136,7 @@ export async function projectStrategies(chainId: number, vault: `0x${string}`, b
   ]
 
   const events = await db.query(`
-  SELECT signature, args
+  SELECT signature, args->>'strategy' AS strategy, args->>'newVersion' AS "newVersion"
   FROM evmlog
   WHERE chain_id = $1 AND address = $2 AND signature = ANY($3) AND (block_number <= $4 OR $4 IS NULL)
   ORDER BY block_number ASC, log_index ASC`,
@@ -148,13 +148,13 @@ export async function projectStrategies(chainId: number, vault: `0x${string}`, b
   for (const event of events.rows) {
     switch (event.signature) {
     case topics[0]:
-      result.push(zhexstring.parse(event.args.strategy))
+      result.push(zhexstring.parse(event.strategy))
       break
     case topics[1]:
-      result.push(zhexstring.parse(event.args.newVersion))
+      result.push(zhexstring.parse(event.newVersion))
       break
     case topics[2]:
-      result.splice(result.indexOf(zhexstring.parse(event.args.strategy)), 1)
+      result.splice(result.indexOf(zhexstring.parse(event.strategy)), 1)
       break
     }
   }

--- a/packages/ingest/db.ts
+++ b/packages/ingest/db.ts
@@ -77,7 +77,10 @@ export async function getTravelledStrides(chainId: number, address: `0x${string}
 }
 
 export async function getSparkline(chainId: number, address: string, label: string, component?: string) {
-  const result = await db.query(`
+  // series_time floor prunes hypertable chunks. If the 90d window holds all 3
+  // buckets they're the 3 most recent overall; fall back to a full scan when
+  // fewer, so sparse/stale vaults keep their full series.
+  const sql = (floor: string) => `
     SELECT
       CAST($1 AS int4) AS "chainId",
       CAST($2 AS text) AS address,
@@ -87,10 +90,15 @@ export async function getSparkline(chainId: number, address: string, label: stri
       COALESCE(LAST(NULLIF(value, 0), block_number), 0) AS close
     FROM output
     WHERE chain_id = $1 AND address = $2 AND label = $3 AND (component = $4 OR $4 IS NULL)
+      ${floor}
     GROUP BY "blockTime"
     ORDER BY "blockTime" DESC
     LIMIT 3;
-  `, [chainId, address, label, component])
+  `
+
+  const params = [chainId, address, label, component]
+  let result = await db.query(sql('AND series_time >= now() - make_interval(days => 90)'), params)
+  if (result.rows.length < 3) result = await db.query(sql(''), params)
 
   return z.object({
     chainId: z.number(),

--- a/packages/ingest/probe/index.ts
+++ b/packages/ingest/probe/index.ts
@@ -1,7 +1,7 @@
-import os from 'os'
-import { chains, mq } from 'lib'
 import { Queue, Worker } from 'bullmq'
+import { chains, mq } from 'lib'
 import { Processor } from 'lib/processor'
+import os from 'os'
 import { parse as parseRedisRaw } from 'redis-info'
 import db from '../db'
 
@@ -201,7 +201,7 @@ export default class Probe implements Processor {
 
   private async fetchEventCounts() {
     const now = Date.now()
-    if (now - this.eventCountsCache.ts < 300_000) return this.eventCountsCache.rows
+    if (now - this.eventCountsCache.ts < 3_600_000) return this.eventCountsCache.rows
     const query = 'SELECT event_name, count(*) FROM evmlog GROUP BY event_name ORDER BY count DESC;'
     this.eventCountsCache = { rows: (await db.query(query)).rows, ts: now }
     return this.eventCountsCache.rows

--- a/packages/lib/estimated-apr.ts
+++ b/packages/lib/estimated-apr.ts
@@ -32,7 +32,14 @@ export async function getLatestEstimatedAprRows(
   return result.rows
 }
 
-function latestEstimatedAprRowsSql(latestWhere: string, includeAddressesParam: string) {
+// series_time is the `output` hypertable partition column; a floor on it prunes
+// chunks. series_time >= block_time always holds, so a floor at the same
+// maxAgeDays bound never drops a row the block_time bound keeps.
+function latestEstimatedAprRowsSql(
+  latestWhere: string,
+  includeAddressesParam: string,
+  maxAgeParam: string
+) {
   return `
     WITH latest AS (
       SELECT o.block_time, o.label
@@ -49,6 +56,7 @@ function latestEstimatedAprRowsSql(latestWhere: string, includeAddressesParam: s
     FROM output
     WHERE chain_id = $1
       AND (block_time, label) = (SELECT block_time, label FROM latest)
+      AND (${maxAgeParam}::int IS NULL OR series_time > NOW() - (${maxAgeParam}::int * INTERVAL '1 day'))
       AND (address = $2 OR address = ANY(${includeAddressesParam}::text[]))
   `
 }
@@ -58,13 +66,15 @@ const LATEST_ROWS_BY_LABEL_SQL = latestEstimatedAprRowsSql(`
         AND o.address = $2
         AND o.label = $3
         AND ($4::int IS NULL OR o.block_time > NOW() - ($4::int * INTERVAL '1 day'))
-`, '$5')
+        AND ($4::int IS NULL OR o.series_time > NOW() - ($4::int * INTERVAL '1 day'))
+`, '$5', '$4')
 
 const LATEST_ROWS_BY_ESTIMATED_APR_SQL = latestEstimatedAprRowsSql(`
         o.chain_id = $1
         AND o.address = $2
         AND o.label LIKE '%-estimated-apr'
         AND ($3::int IS NULL OR o.block_time > NOW() - ($3::int * INTERVAL '1 day'))
+        AND ($3::int IS NULL OR o.series_time > NOW() - ($3::int * INTERVAL '1 day'))
         AND NOT EXISTS (
           SELECT 1 FROM output o2
           WHERE o2.chain_id = o.chain_id
@@ -72,5 +82,6 @@ const LATEST_ROWS_BY_ESTIMATED_APR_SQL = latestEstimatedAprRowsSql(`
             AND o2.label = o.label
             AND o2.block_time = o.block_time
             AND o2.component = 'debtRatio'
+            AND ($3::int IS NULL OR o2.series_time > NOW() - ($3::int * INTERVAL '1 day'))
         )
-`, '$4')
+`, '$4', '$3')


### PR DESCRIPTION
### Summary
Indexer hooks pulled more data off the database than they used: full `args` JSONB blobs on `evmlog` and unbounded hypertable scans on `output`. This trims each query to the columns and time window it needs, lowering egress and letting TimescaleDB prune chunks. Split into one commit per optimization for independent review.

### Changes
- **`getSparkline()` (`packages/ingest/db.ts`)** — 90-day `series_time` floor to prune chunks, with a full-scan fallback when the window holds fewer than 3 buckets so sparse/stale vaults keep their series.
- **evmlog projection (`tradeHandler/snapshot/hook.ts`, `yearn/2/vault/snapshot/hook.ts`)** — `SELECT signature, args` becomes `SELECT signature, args->>'<key>' AS ...` for the one or two keys each projection reads. Renamed fields (`event.seller`, `event.tokenIn`, `event.strategy`, `event.newVersion`) match the old `event.args.*` access.
- **estimated-apr (`packages/lib/estimated-apr.ts`)** — adds a `series_time` floor alongside the existing `block_time` bound. `series_time >= block_time` always holds, so the same `maxAgeDays` floor never drops a row the block_time bound keeps.
- **probe (`probe/index.ts`)** — `eventCountsCache` TTL raised from 5 minutes to 1 hour; the `count(*)` over `evmlog` is a full-table scan.

`getThing()` was dropped from this PR. It saved only tens of bytes (it still pulls the large `defaults` blob) and regressed null-`defaults` rows from a loud parse failure to a silent `undefined`.

### Impact
Measured with `EXPLAIN (ANALYZE, BUFFERS)` on the dev DB (TimescaleDB 2.13; `output` 35.3M rows / 130 chunks, `evmlog` 5.27M rows / ~7 GB).

| change | runs | measured result |
|---|---|---|
| probe TTL 5m → 1h | probe interval | full `evmlog` scan ~1.5 s / ~573k buffers (~4.5 GB IO) per run; **288 → 24 runs/day** (~264 fewer full scans/day) |
| estimated-apr `series_time` floor | per-vault APR lookup (`maxAgeDays=7`) | **chunks excluded 0 → 128/130**; buffers 6,474 → 156 (~40×); disk reads 4,740 → 37 |
| sparkline 90d floor | per vault per snapshot, ×2–3 | **chunks excluded 116/130**; buffers 2,188 → 221 (~10×); disk reads 1,608 → 0 |
| evmlog `args` projection | per v2 vault / tradeHandler snapshot | payload only (same index scan): `args` ~204 B/row → ~92 B projected = ~112 B/row off the wire (~55%) |

Relative impact: probe TTL (DB load) > estimated-apr > sparkline > evmlog projection.

### Test plan
- [ ] Manual: fanout/replay a vault; confirm timeseries (apy, pps, tvl) and snapshot hooks still produce output, and sparkline renders for active and stale vaults.
- [ ] Manual: verify estimated-apr rows return for vaults inside and outside the `maxAgeDays` window.
- [ ] Automated: `bun --filter ingest test`, `bun --filter lib test`

### Risk / impact
The 90-day sparkline floor and the estimated-apr `series_time` floor narrow query windows. The sparkline fallback covers sparse history and `series_time >= block_time` keeps the apr floor safe; both are the areas to sanity-check. No migrations, auth, or funds touched. Rollback is reverting the branch.
