### PR TITLE
katana-apy updates

### DIFF
--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -1076,6 +1076,8 @@ Returns [`[RiskScoreLegacy]`](#riskscorelegacy).
 |-------|------|-------------|
 | `apr` | `Float` | Estimated APR |
 | `apy` | `Float` | Estimated APY |
+| `netAPR` | `Float` | Fee-adjusted estimated APR |
+| `netAPY` | `Float` | Fee-adjusted estimated APY |
 | `type` | `String` | APR type |
 | `components` | [`EstimatedAprComponents`](#estimatedaprcomponents) | APR breakdown |
 

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -51,7 +51,7 @@ curl -s 'https://kong.yearn.fi/api/rest/list/vaults?origin=yearn' | jq
     "performance": {
       "oracle": { "apr": 0.045, "apy": 0.046 },
       "historical": { "net": 0.042, "weeklyNet": 0.041, "monthlyNet": 0.043, "inceptionNet": 0.05 },
-      "estimated": { "apr": 0.044, "apy": 0.045, "type": "base", "components": {} }
+      "estimated": { "apr": 0.044, "apy": 0.045, "netAPR": 0.039, "netAPY": 0.040, "type": "base", "components": {} }
     },
     "fees": { "managementFee": 0, "performanceFee": 1000 },
     "category": "Stablecoin",

--- a/packages/ingest/abis/erc4626/snapshot/hook.ts
+++ b/packages/ingest/abis/erc4626/snapshot/hook.ts
@@ -31,7 +31,8 @@ export default async function process(chainId: number, address: `0x${string}`, d
       estimated: undefined,
       oracle: (oracle[0] || oracle[1]) ? {
         apr: oracle[0],
-        apy: oracle[1]
+        apy: oracle[1],
+        source: oracle[2]
       } : undefined,
       historical: historical ? {
         net: historical.net,

--- a/packages/ingest/abis/erc4626/timeseries/apr-oracle/hook.spec.ts
+++ b/packages/ingest/abis/erc4626/timeseries/apr-oracle/hook.spec.ts
@@ -14,8 +14,9 @@ describe('abis/erc4626/timeseries/apr-oracle/hook', function() {
     // erc4626 path. The oracle still prices it via getStrategyApr.
     const oracle = getOracleConfig(mainnet.id)
     expect(oracle).to.not.equal(undefined)
-    const apr = await readApr(mainnet.id, morphoUsdt, 25211174n, oracle!.address)
-    expect(apr).to.be.closeTo(0.11878347712984644, 1e-6)
+    const read = await readApr(mainnet.id, morphoUsdt, 25211174n, oracle!.address)
+    expect(read?.apr).to.be.closeTo(0.11878347712984644, 1e-6)
+    expect(read?.source).to.equal('getStrategyApr')
   })
 
   it('returns nothing when the chain has no oracle configured', async function() {
@@ -32,12 +33,13 @@ describe('abis/erc4626/timeseries/apr-oracle/hook', function() {
       outputLabel, blockTime: BigInt(Math.floor(Date.now() / 1000)) + 60n
     }
     const outputs = await hook(mainnet.id, morphoUsdt, data)
-    expect(outputs.map(o => o.component).sort()).to.deep.equal(['apr', 'apy'])
+    expect(outputs.map(o => o.component).sort()).to.deep.equal(['apr', 'apy', 'source:getStrategyApr'])
     expect(outputs.every(o => o.label === outputLabel)).to.equal(true)
 
     const apr = outputs.find(o => o.component === 'apr')!.value as number
     const apy = outputs.find(o => o.component === 'apy')!.value as number
     expect(apr).to.be.greaterThan(0)
     expect(apy).to.be.closeTo(computeApy(apr), 1e-9)
+    expect(outputs.find(o => o.component === 'source:getStrategyApr')!.value).to.equal(1)
   })
 })

--- a/packages/ingest/abis/erc4626/timeseries/apr-oracle/hook.ts
+++ b/packages/ingest/abis/erc4626/timeseries/apr-oracle/hook.ts
@@ -23,5 +23,6 @@ export default async function (
   return OutputSchema.array().parse([
     output('apr', resolved.apr),
     output('apy', resolved.apy),
+    output(`source:${resolved.source}`, 1),
   ])
 }

--- a/packages/ingest/abis/yearn/3/vault/snapshot/hook.spec.ts
+++ b/packages/ingest/abis/yearn/3/vault/snapshot/hook.spec.ts
@@ -61,4 +61,69 @@ describe('abis/yearn/3/vault/snapshot/hook', function() {
       globalThis.fetch = originalFetch
     }
   })
+
+  it('preserves estimated gross and net fields separately', async function() {
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = (async () => ({
+      json: async () => []
+    })) as unknown as typeof fetch
+
+    const chainId = 1338
+    const vault = '0x1000000000000000000000000000000000000003'
+    const strategy = '0x2000000000000000000000000000000000000004' as `0x${string}`
+    const blockTime = BigInt(Math.floor(Date.now() / 1000))
+    const label = 'katana-estimated-apr'
+
+    for (const [component, value] of [
+      ['apr', 0.10],
+      ['apy', 0.11],
+      ['netAPR', 0.08],
+      ['netAPY', 0.085],
+      ['baseNetAPY', 0.07],
+    ] as const) {
+      const outputData = {
+        chain_id: chainId,
+        address: strategy,
+        label,
+        component,
+        value,
+        block_number: blockTime,
+        block_time: Number(blockTime),
+        series_time: Number(blockTime)
+      }
+      await db.query(toUpsertSql('output', 'chain_id, address, label, component, series_time', outputData), Object.values(outputData))
+    }
+
+    const debts = [{
+      strategy,
+      activation: 0n,
+      lastReport: 0n,
+      currentDebt: 1n,
+      currentDebtUsd: 1,
+      maxDebt: 1n,
+      maxDebtUsd: 1,
+      performanceFee: 0n,
+      totalGain: 0n,
+      totalGainUsd: 0,
+      totalLoss: 0n,
+      totalLossUsd: 0,
+      targetDebtRatio: undefined,
+      maxDebtRatio: undefined
+    }]
+
+    try {
+      const composition = await extractComposition(chainId, vault, [strategy], debts, label)
+      const estimated = composition[0].performance?.estimated
+
+      expect(estimated?.apr).to.equal(0.10)
+      expect(estimated?.apy).to.equal(0.11)
+      expect(estimated?.netAPR).to.equal(0.08)
+      expect(estimated?.netAPY).to.equal(0.085)
+      expect(estimated?.components?.baseNetAPY).to.equal(0.07)
+      expect(estimated?.components).to.not.have.property('netAPR')
+      expect(estimated?.components).to.not.have.property('netAPY')
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
 })

--- a/packages/ingest/abis/yearn/3/vault/snapshot/hook.ts
+++ b/packages/ingest/abis/yearn/3/vault/snapshot/hook.ts
@@ -458,12 +458,19 @@ async function fetchStrategyPerformance(
       if (row.component === 'monthlyNet') perf.historical.monthlyNet = row.value ?? null
       if (row.component === 'inceptionNet') perf.historical.inceptionNet = row.value ?? null
     } else if (estimatedAprLabel && row.label === estimatedAprLabel) {
-      if (!perf.estimated) perf.estimated = { type: estimatedAprLabel }
-      if (row.component === 'apr' || row.component === 'netAPR') perf.estimated.apr = row.value
-      else if (row.component === 'apy' || row.component === 'netAPY') perf.estimated.apy = row.value
-      else if (!perf.estimated.components) {
-        perf.estimated.components = { [row.component]: row.value }
-      } else {
+      if (!perf.estimated) perf.estimated = { type: estimatedAprLabel, components: {} }
+      if (!perf.estimated.components) perf.estimated.components = {}
+      if (row.component === 'apr' && row.value != null) perf.estimated.apr = row.value
+      else if (row.component === 'netAPR' && row.value != null) {
+        perf.estimated.netAPR = row.value
+        if (perf.estimated.apr == null) perf.estimated.apr = row.value
+      }
+      else if (row.component === 'apy' && row.value != null) perf.estimated.apy = row.value
+      else if (row.component === 'netAPY' && row.value != null) {
+        perf.estimated.netAPY = row.value
+        if (perf.estimated.apy == null) perf.estimated.apy = row.value
+      }
+      else if (row.component != null && row.value != null) {
         perf.estimated.components[row.component] = row.value
       }
     }

--- a/packages/ingest/abis/yearn/3/vault/snapshot/hook.ts
+++ b/packages/ingest/abis/yearn/3/vault/snapshot/hook.ts
@@ -28,7 +28,8 @@ export const CompositionSchema = z.object({
       netAPR: z.number().nullish(),
       netAPY: z.number().nullish(),
       apr: z.number().nullish(),
-      apy: z.number().nullish()
+      apy: z.number().nullish(),
+      source: z.string().nullish()
     }).nullish(),
     historical: z.object({
       net: z.number().nullish(),
@@ -136,7 +137,7 @@ export default async function process(chainId: number, address: `0x${string}`, d
   }
 
   const apy = await getLatestApy(chainId, address)
-  const [oracleApr, oracleApy] = await getLatestOracleApr(chainId, address)
+  const [oracleApr, oracleApy, oracleSource] = await getLatestOracleApr(chainId, address)
 
   // Query DB for staking pool associated with this vault
   const stakingPool = await db.query(`
@@ -166,6 +167,7 @@ export default async function process(chainId: number, address: `0x${string}`, d
         netAPR: oracleNetApr,
         apy: oracleApy,
         netAPY: oracleNetApr != null ? computeApy(oracleNetApr) : undefined,
+        source: oracleSource,
       },
       historical: apy ? {
         net: apy.net,
@@ -380,7 +382,8 @@ async function fetchStrategySnapshots(chainId: number, strategies: `0x${string}`
       estimated: EstimatedAprSchema.nullish(),
       oracle: z.object({
         apr: z.number().nullish(),
-        apy: z.number().nullish()
+        apy: z.number().nullish(),
+        source: z.string().nullish()
       }).nullish(),
       historical: z.object({
         net: z.number().nullish(),
@@ -446,6 +449,9 @@ async function fetchStrategyPerformance(
     if (row.label === 'apr-oracle') {
       if (row.component === 'apr') perf.oracle.apr = row.value ?? 0
       if (row.component === 'apy') perf.oracle.apy = row.value ?? 0
+      if (typeof row.component === 'string' && row.component.startsWith('source:')) {
+        perf.oracle.source = row.component.slice('source:'.length)
+      }
     } else if (row.label === 'apy-bwd-delta-pps') {
       if (row.component === 'net') perf.historical.net = row.value ?? null
       if (row.component === 'weeklyNet') perf.historical.weeklyNet = row.value ?? null
@@ -453,8 +459,8 @@ async function fetchStrategyPerformance(
       if (row.component === 'inceptionNet') perf.historical.inceptionNet = row.value ?? null
     } else if (estimatedAprLabel && row.label === estimatedAprLabel) {
       if (!perf.estimated) perf.estimated = { type: estimatedAprLabel }
-      if (row.component === 'netAPR') perf.estimated.apr = row.value
-      else if (row.component === 'netAPY') perf.estimated.apy = row.value
+      if (row.component === 'apr' || row.component === 'netAPR') perf.estimated.apr = row.value
+      else if (row.component === 'apy' || row.component === 'netAPY') perf.estimated.apy = row.value
       else if (!perf.estimated.components) {
         perf.estimated.components = { [row.component]: row.value }
       } else {

--- a/packages/ingest/abis/yearn/3/vault/timeseries/apr-oracle/hook.ts
+++ b/packages/ingest/abis/yearn/3/vault/timeseries/apr-oracle/hook.ts
@@ -12,6 +12,13 @@ export { computeNetApr } from '../../../../lib/apy'
 
 export const outputLabel = 'apr-oracle'
 
+export type OracleAprSource = 'getStrategyApr' | 'getCurrentApr'
+
+type OracleAprRead = {
+  apr: number
+  source: OracleAprSource
+}
+
 function parseApr(rawApr: bigint): number | undefined {
   const apr = Number(rawApr) / 1e18
   if (isNaN(apr) || !isFinite(apr)) return undefined
@@ -28,7 +35,7 @@ export async function readApr(
   address: `0x${string}`,
   blockNumber: bigint,
   oracleAddress: `0x${string}`,
-): Promise<number | undefined> {
+): Promise<OracleAprRead | undefined> {
   try {
     const rawApr = await rpcs.next(chainId).readContract({
       abi: V3_ORACLE_ABI,
@@ -38,7 +45,8 @@ export async function readApr(
       blockNumber,
     })
 
-    return parseApr(rawApr)
+    const apr = parseApr(rawApr)
+    return apr === undefined ? undefined : { apr, source: 'getStrategyApr' }
   } catch (error) {
     if (!isExpectedStrategyAprFallback(error)) throw error
   }
@@ -54,7 +62,8 @@ export async function readApr(
       blockNumber,
     })
     console.warn('🚨', 'apr-oracle getCurrentApr success', chainId, address, String(blockNumber), rawApr)
-    return parseApr(rawApr)
+    const apr = parseApr(rawApr)
+    return apr === undefined ? undefined : { apr, source: 'getCurrentApr' }
   } catch {
     console.warn('🚨', 'apr-oracle getCurrentApr failed', chainId, address, String(blockNumber))
     return undefined
@@ -68,7 +77,7 @@ export async function resolveOracleApr(
   chainId: number,
   address: `0x${string}`,
   data: Data,
-): Promise<{ apr: number, apy: number, blockNumber: bigint } | undefined> {
+): Promise<{ apr: number, apy: number, source: OracleAprSource, blockNumber: bigint } | undefined> {
   const oracleConfig = getOracleConfig(chainId)
   if (!oracleConfig) return undefined
 
@@ -78,10 +87,10 @@ export async function resolveOracleApr(
 
   if (blockNumber < oracleConfig.inceptBlock) return undefined
 
-  const apr = await readApr(chainId, address, blockNumber, oracleConfig.address)
-  if (apr === undefined) return undefined
+  const read = await readApr(chainId, address, blockNumber, oracleConfig.address)
+  if (!read) return undefined
 
-  return { apr, apy: computeApy(apr), blockNumber }
+  return { apr: read.apr, apy: computeApy(read.apr), source: read.source, blockNumber }
 }
 
 export default async function (
@@ -110,6 +119,7 @@ export default async function (
   return OutputSchema.array().parse([
     output('apr', apr),
     output('apy', apy),
+    output(`source:${resolved.source}`, 1),
     output('netApr', netApr),
     output('netApy', computeApy(netApr)),
   ])

--- a/packages/ingest/helpers/apy-apr.spec.ts
+++ b/packages/ingest/helpers/apy-apr.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai'
 import db from '../db'
-import { getLatestApy, getLatestEstimatedAprV3 } from './apy-apr'
+import { getLatestApy, getLatestEstimatedAprV3, getLatestOracleApr } from './apy-apr'
 
 const TEST_CHAIN = 99999
 const VAULT_ADDR = '0xtest_vault_apr_spec'
@@ -37,6 +37,25 @@ describe('getLatestEstimatedAprV3', function() {
       apr: 0.05,
       apy: 0.051,
       components: {}
+    })
+  })
+
+  it('promotes explicit apr and apy components before legacy net names', async function() {
+    const t = new Date()
+    await insertOutput(VAULT_ADDR, LABEL, 'apr', 0.1, t)
+    await insertOutput(VAULT_ADDR, LABEL, 'apy', 0.11, t)
+    await insertOutput(VAULT_ADDR, LABEL, 'netAPR', 0.09, t)
+    await insertOutput(VAULT_ADDR, LABEL, 'netAPY', 0.095, t)
+    await insertOutput(VAULT_ADDR, LABEL, 'baseNetAPY', 0.07, t)
+
+    const result = await getLatestEstimatedAprV3(TEST_CHAIN, VAULT_ADDR)
+    expect(result).to.deep.equal({
+      type: LABEL,
+      apr: 0.1,
+      apy: 0.11,
+      components: {
+        baseNetAPY: 0.07,
+      }
     })
   })
 
@@ -245,5 +264,20 @@ describe('getLatestApy', function() {
 
     const result = await getLatestApy(TEST_CHAIN, VAULT_ADDR)
     expect(result).to.be.undefined
+  })
+})
+
+describe('getLatestOracleApr', function() {
+  afterEach(cleanup)
+
+  it('returns the latest oracle apr, apy, and accepted oracle function source', async function() {
+    const t = new Date()
+    await insertOutput(VAULT_ADDR, 'apr-oracle', 'apr', 0.05, t)
+    await insertOutput(VAULT_ADDR, 'apr-oracle', 'apy', 0.051, t)
+    await insertOutput(VAULT_ADDR, 'apr-oracle', 'source:getStrategyApr', 1, t)
+
+    const result = await getLatestOracleApr(TEST_CHAIN, VAULT_ADDR)
+
+    expect(result).to.deep.equal([0.05, 0.051, 'getStrategyApr'])
   })
 })

--- a/packages/ingest/helpers/apy-apr.spec.ts
+++ b/packages/ingest/helpers/apy-apr.spec.ts
@@ -36,6 +36,8 @@ describe('getLatestEstimatedAprV3', function() {
       type: LABEL,
       apr: 0.05,
       apy: 0.051,
+      netAPR: 0.05,
+      netAPY: 0.051,
       components: {}
     })
   })
@@ -53,6 +55,8 @@ describe('getLatestEstimatedAprV3', function() {
       type: LABEL,
       apr: 0.1,
       apy: 0.11,
+      netAPR: 0.09,
+      netAPY: 0.095,
       components: {
         baseNetAPY: 0.07,
       }

--- a/packages/ingest/helpers/apy-apr.ts
+++ b/packages/ingest/helpers/apy-apr.ts
@@ -31,6 +31,8 @@ export async function getLatestEstimatedAprV3(chainId: number, address: string, 
     type: rows[0].label,
     ...(apr != null ? { apr } : netAPR != null ? { apr: netAPR } : {}),
     ...(apy != null ? { apy } : netAPY != null ? { apy: netAPY } : {}),
+    ...(netAPR != null ? { netAPR } : {}),
+    ...(netAPY != null ? { netAPY } : {}),
     components: rest
   }
 }

--- a/packages/ingest/helpers/apy-apr.ts
+++ b/packages/ingest/helpers/apy-apr.ts
@@ -19,12 +19,18 @@ export async function getLatestEstimatedAprV3(chainId: number, address: string, 
     if (row.value != null && row.component != null) components[row.component] = row.value
   }
 
-  const { netAPR, netAPY, ...rest } = components
+  const {
+    apr,
+    apy,
+    netAPR,
+    netAPY,
+    ...rest
+  } = components
 
   return {
     type: rows[0].label,
-    ...(netAPR != null ? { apr: netAPR } : {}),
-    ...(netAPY != null ? { apy: netAPY } : {}),
+    ...(apr != null ? { apr } : netAPR != null ? { apr: netAPR } : {}),
+    ...(apy != null ? { apy } : netAPY != null ? { apy: netAPY } : {}),
     components: rest
   }
 }
@@ -144,7 +150,7 @@ export async function getLatestApy(chainId: number, address: string) {
   }).parse(first)
 }
 
-export async function getLatestOracleApr(chainId: number, address: string): Promise<[number, number]> {
+export async function getLatestOracleApr(chainId: number, address: string): Promise<[number, number, string | undefined]> {
   const result = await firstRow(`
   SELECT
     chain_id as "chainId",
@@ -152,6 +158,7 @@ export async function getLatestOracleApr(chainId: number, address: string): Prom
     label,
     MAX(CASE WHEN component = 'apr' THEN value END) AS apr,
     MAX(CASE WHEN component = 'apy' THEN value END) AS apy,
+    MAX(CASE WHEN component LIKE 'source:%' THEN substring(component from 8) END) AS source,
     block_number as "blockNumber",
     block_time as "blockTime"
   FROM output
@@ -172,7 +179,7 @@ export async function getLatestOracleApr(chainId: number, address: string): Prom
   GROUP BY chain_id, address, label, block_number, block_time;
   `, [chainId, address, CURRENT_PERFORMANCE_LOOKBACK_DAYS])
 
-  if (!result) return [0, 0]
+  if (!result) return [0, 0, undefined]
 
-  return [result.apr || 0, result.apy || 0]
+  return [result.apr || 0, result.apy || 0, result.source || undefined]
 }

--- a/packages/lib/types.ts
+++ b/packages/lib/types.ts
@@ -444,6 +444,8 @@ export type Incept = z.infer<typeof InceptSchema>
 export const EstimatedAprSchema = z.object({
   apr: z.number().optional(),
   apy: z.number().optional(),
+  netAPR: z.number().optional(),
+  netAPY: z.number().optional(),
   type: z.string(),
   components: z.record(z.string(), z.number().nullish())
 })

--- a/packages/scripts/src/backfill-apr-oracle-getCurrentApr/compute.ts
+++ b/packages/scripts/src/backfill-apr-oracle-getCurrentApr/compute.ts
@@ -99,7 +99,8 @@ async function computeVaultOracle(row: AffectedRow): Promise<TempRow[]> {
   if (!oracleConfig) return []
   const blockNumber = BigInt(row.block_number)
 
-  const apr = await readApr(row.chain_id, row.address, blockNumber, oracleConfig.address)
+  const read = await readApr(row.chain_id, row.address, blockNumber, oracleConfig.address)
+  const apr = read?.apr
   // Intentionally falsy check: skip rows where the oracle still returns 0.
   if (!apr) return []
 

--- a/packages/web/app/api/gql/typeDefs/vault.ts
+++ b/packages/web/app/api/gql/typeDefs/vault.ts
@@ -136,6 +136,8 @@ type EstimatedAprComponents {
 type EstimatedApr {
   apr: Float
   apy: Float
+  netAPR: Float
+  netAPY: Float
   type: String!
   components: EstimatedAprComponents!
 }

--- a/packages/web/app/api/gql/typeDefs/vault.ts
+++ b/packages/web/app/api/gql/typeDefs/vault.ts
@@ -106,6 +106,7 @@ type Oracle {
   apr: Float
   netAPR: Float
   apy: Float
+  source: String
 }
 
 type EstimatedAprComponents {
@@ -121,6 +122,13 @@ type EstimatedAprComponents {
   grossAPR: Float
   baseNetAPR: Float
   baseNetAPY: Float
+  morphoBaseAPY: Float
+  morphoRewardsAPR: Float
+  morphoRewardsAPY: Float
+  morphoKatRewardsAPR: Float
+  steerAPY: Float
+  oracleAPY: Float
+  estimatedDebtCoverage: Float
   lockerBonusAPR: Float
   lockerBonusAPY: Float
 }

--- a/packages/web/app/api/rest/list/db.ts
+++ b/packages/web/app/api/rest/list/db.ts
@@ -43,6 +43,8 @@ export const VaultListItemSchema = z.object({
     estimated: z.object({
       apr: z.number().optional(),
       apy: z.number().optional(),
+      netAPR: z.number().optional(),
+      netAPY: z.number().optional(),
       type: z.string(),
       components: z.record(z.string(), z.union([z.number(), z.string()]).nullable()).optional(),
     }).nullish(),

--- a/packages/web/app/api/rest/snapshot/db.ts
+++ b/packages/web/app/api/rest/snapshot/db.ts
@@ -72,5 +72,197 @@ export async function getVaultSnapshot(
     ...row.hook
   }
 
-  return snapshot
+  return await hydrateStrategyEstimatedApr(chainId, row.address, snapshot)
+}
+
+type EstimatedMetric = 'apr' | 'apy'
+
+type StrategyEstimated = {
+  apr?: number
+  apy?: number
+}
+
+type OutputMetricRow = {
+  address: string
+  component: string | null
+  value: number | null
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function normalizeAddress(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  try {
+    return getAddress(value as `0x${string}`).toLowerCase()
+  } catch {
+    return undefined
+  }
+}
+
+function parseMetric(component: string): EstimatedMetric | undefined {
+  const normalized = component.toLowerCase()
+  if (normalized === 'apy' || normalized === 'netapy') return 'apy'
+  if (normalized === 'apr' || normalized === 'netapr') return 'apr'
+  return undefined
+}
+
+function setStrategyMetric(
+  map: Map<string, StrategyEstimated>,
+  strategyAddress: string,
+  metric: EstimatedMetric,
+  value: number
+) {
+  const current = map.get(strategyAddress) ?? {}
+  current[metric] = value
+  map.set(strategyAddress, current)
+}
+
+function parseComponentStrategyMetric(
+  component: string,
+  strategyAddresses: Set<string>
+): { strategyAddress: string, metric: EstimatedMetric } | undefined {
+  const addressMatch = component.match(/0x[a-fA-F0-9]{40}/)
+  if (!addressMatch) return undefined
+
+  const strategyAddress = normalizeAddress(addressMatch[0])
+  if (!strategyAddress || !strategyAddresses.has(strategyAddress)) return undefined
+
+  const metric = parseMetric(component)
+  if (!metric) return undefined
+
+  return { strategyAddress, metric }
+}
+
+async function resolveEstimatedAprLabel(
+  chainId: number,
+  vaultAddress: string,
+  snapshot: VaultSnapshot
+): Promise<string | undefined> {
+  const performance = isRecord(snapshot.performance) ? snapshot.performance : undefined
+  const estimated = performance && isRecord(performance.estimated) ? performance.estimated : undefined
+  const estimatedType = estimated?.type
+
+  if (typeof estimatedType === 'string' && estimatedType.endsWith('-estimated-apr')) {
+    return estimatedType
+  }
+
+  const latest = await db.query(`
+    SELECT label
+    FROM output
+    WHERE chain_id = $1
+      AND address = $2
+      AND label LIKE '%-estimated-apr'
+    ORDER BY block_time DESC
+    LIMIT 1
+  `, [chainId, vaultAddress])
+
+  const label = latest.rows[0]?.label
+  return typeof label === 'string' ? label : undefined
+}
+
+async function fetchLatestEstimatedAprRows(
+  chainId: number,
+  vaultAddress: string,
+  strategyAddresses: string[],
+  label: string
+): Promise<OutputMetricRow[]> {
+  const rows = await db.query(`
+    WITH latest AS (
+      SELECT block_time
+      FROM output
+      WHERE chain_id = $1
+        AND address = $2
+        AND label = $3
+      ORDER BY block_time DESC
+      LIMIT 1
+    )
+    SELECT
+      address,
+      component,
+      value
+    FROM output
+    WHERE chain_id = $1
+      AND label = $3
+      AND block_time = (SELECT block_time FROM latest)
+      AND (address = $2 OR address = ANY($4))
+  `, [chainId, vaultAddress, label, strategyAddresses])
+
+  return rows.rows as OutputMetricRow[]
+}
+
+async function hydrateStrategyEstimatedApr(
+  chainId: number,
+  vaultAddress: string,
+  snapshot: VaultSnapshot
+): Promise<VaultSnapshot> {
+  if (!Array.isArray(snapshot.composition) || snapshot.composition.length === 0) {
+    return snapshot
+  }
+
+  const strategies = snapshot.composition
+    .filter(isRecord)
+    .map(item => normalizeAddress(item.address))
+    .filter((address): address is string => !!address)
+
+  if (strategies.length === 0) return snapshot
+
+  const label = await resolveEstimatedAprLabel(chainId, vaultAddress, snapshot)
+  if (!label) return snapshot
+
+  const rows = await fetchLatestEstimatedAprRows(chainId, vaultAddress, strategies, label)
+  if (!rows.length) return snapshot
+
+  const strategySet = new Set(strategies)
+  const mapped = new Map<string, StrategyEstimated>()
+
+  for (const row of rows) {
+    if (typeof row.value !== 'number' || !isFinite(row.value)) continue
+    if (typeof row.component !== 'string') continue
+
+    const rowAddress = normalizeAddress(row.address)
+    const metric = parseMetric(row.component)
+
+    if (rowAddress && strategySet.has(rowAddress) && metric) {
+      setStrategyMetric(mapped, rowAddress, metric, row.value)
+      continue
+    }
+
+    const parsed = parseComponentStrategyMetric(row.component, strategySet)
+    if (!parsed) continue
+    setStrategyMetric(mapped, parsed.strategyAddress, parsed.metric, row.value)
+  }
+
+  if (!mapped.size) return snapshot
+
+  const composition = snapshot.composition.map(item => {
+    if (!isRecord(item)) return item
+    const address = normalizeAddress(item.address)
+    if (!address) return item
+
+    const estimated = mapped.get(address)
+    if (!estimated || (estimated.apr == null && estimated.apy == null)) return item
+
+    const currentPerformance = isRecord(item.performance) ? item.performance : {}
+    const nextEstimated: Record<string, unknown> = {
+      ...(isRecord(currentPerformance.estimated) ? currentPerformance.estimated : {}),
+      ...(estimated.apr != null ? { apr: estimated.apr } : {}),
+      ...(estimated.apy != null ? { apy: estimated.apy } : {}),
+      type: label,
+    }
+
+    return {
+      ...item,
+      performance: {
+        ...currentPerformance,
+        estimated: nextEstimated,
+      },
+    }
+  })
+
+  return {
+    ...snapshot,
+    composition,
+  }
 }


### PR DESCRIPTION
### Summary
Updates Kong to ingest Katana’s new `katana-estimated-apr` shape, where webhook rows named `apr` and `apy` are promoted into `performance.estimated.apr/apy` and the remaining rows stay in `performance.estimated.components`.

Also surfaces APR oracle source metadata so Katana consumers can tell whether `getStrategyApr` or `getCurrentApr` was accepted, and expands the exposed estimated component schema for Morpho/Steer forward APY fields.

Related to katana-apr-service PR 

### How to review
Start with:
- `packages/ingest/helpers/apy-apr.ts`
- `packages/ingest/abis/yearn/3/vault/snapshot/hook.ts`
- `packages/web/app/api/rest/snapshot/db.ts`
- `packages/web/app/api/gql/typeDefs/vault.ts`
- `packages/ingest/abis/yearn/3/vault/timeseries/apr-oracle/hook.ts`

Review focus:
- `apr` / `apy` components should win over legacy `netAPR` / `netAPY`.
- `katRewardsAPR` and other reward-only rows should remain components, not become the strategy estimate.
- `performance.oracle.source` should be populated from `source:getStrategyApr` or `source:getCurrentApr`.
- No DB migration should be needed; this uses existing `output.component` rows.

Smoke test:
- Load a Katana vault snapshot with `katana-estimated-apr` rows.
- Confirm vault-level `performance.estimated.apy` is populated.
- Confirm strategy composition rows have `performance.estimated.apy` where strategy rows exist.
- Confirm `performance.estimated.components.morphoKatRewardsAPR` is present but not added into `apy`.

### Test plan
- [ ] Manual: Query a Katana vault via REST snapshot and GraphQL; verify `performance.estimated.apr/apy`, Morpho components, and `performance.oracle.source`.
- [ ] Manual: Check a strategy with KAT rewards only; verify KAT remains under estimated components.
- [ ] Automated: `bun run lint`
- [ ] Automated: `bun run --filter ingest test`
- [ ] Automated: `bun run --filter web test`

### Risk / impact
No funds, auth, or migration impact. Risk is limited to APR/APY presentation in Kong snapshots and API responses.

Main compatibility risk is consumers expecting only legacy `netAPR` / `netAPY` component promotion. This keeps legacy support while preferring explicit `apr` / `apy`, so rollback is a normal revert of this PR.
