### PR TITLE
perf(ingest): cut DB CPU from thing upserts

### DIFF
--- a/packages/ingest/db.spec.ts
+++ b/packages/ingest/db.spec.ts
@@ -1,0 +1,90 @@
+import { expect } from 'chai'
+import { types } from 'lib'
+import db, { upsertThingDefaults } from './db'
+
+// upsertThingDefaults replaced a SELECT ... FOR UPDATE + read-modify-write
+// transaction with a single INSERT ... ON CONFLICT DO UPDATE that merges
+// `defaults` in-DB via jsonb `||`. This pins the old `{ ...current, ...new }`
+// shallow right-wins merge semantics so the perf rewrite can't silently change
+// upsert behavior. Cases below mirror real callers: registry/event/hook.ts sets
+// a vault's initial defaults (yearn, origin, registry, apiVersion, ...), and
+// StrategyChanged/hook.ts later upserts the same row with only a subset of keys
+// (v3, erc4626, apiVersion, asset, decimals, inceptBlock, inceptTime) — the
+// omitted keys (yearn, origin, registry) must survive the merge, since
+// idx_thing_chain_id_address_defaults filters on defaults->>'yearn'.
+describe('upsertThingDefaults', () => {
+  const thing = { chainId: 1, address: '0x1', label: 'vault' }
+
+  afterEach(async () => {
+    await db.query('DELETE FROM thing WHERE chain_id = $1 AND address = $2 AND label = $3',
+      [thing.chainId, thing.address, thing.label])
+  })
+
+  async function getDefaults() {
+    const result = await db.query('SELECT defaults FROM thing WHERE chain_id = $1 AND address = $2 AND label = $3',
+      [thing.chainId, thing.address, thing.label])
+    return result.rows[0]?.defaults
+  }
+
+  it('inserts defaults on a new row', async () => {
+    await upsertThingDefaults({ ...thing, defaults: { apiVersion: '1.0.0' } } as types.Thing)
+    expect(await getDefaults()).to.deep.equal({ apiVersion: '1.0.0' })
+  })
+
+  it('shallow merges new keys into existing defaults, new value wins on overlap', async () => {
+    await upsertThingDefaults({ ...thing, defaults: { apiVersion: '1.0.0', origin: 'yearn' } } as types.Thing)
+    await upsertThingDefaults({ ...thing, defaults: { apiVersion: '2.0.0', inceptBlock: 100 } } as types.Thing)
+
+    expect(await getDefaults()).to.deep.equal({ apiVersion: '2.0.0', origin: 'yearn', inceptBlock: 100 })
+  })
+
+  it('preserves keys a later upsert omits (registry hook, then StrategyChanged hook on the same vault)', async () => {
+    await upsertThingDefaults({
+      ...thing,
+      defaults: { erc4626: true, v3: true, yearn: true, origin: 'yearn', registry: '0xregistry', apiVersion: '3.0.0' },
+    } as types.Thing)
+
+    // StrategyChanged/hook.ts never sends yearn/origin/registry.
+    await upsertThingDefaults({
+      ...thing,
+      defaults: { v3: true, erc4626: true, apiVersion: '3.0.4', asset: '0xasset', decimals: 18, inceptBlock: 100, inceptTime: 1000 },
+    } as types.Thing)
+
+    expect(await getDefaults()).to.deep.equal({
+      erc4626: true, v3: true, yearn: true, origin: 'yearn', registry: '0xregistry',
+      apiVersion: '3.0.4', asset: '0xasset', decimals: 18, inceptBlock: 100, inceptTime: 1000,
+    })
+  })
+
+  it('does not drop defaults.yearn when a later upsert omits it', async () => {
+    await upsertThingDefaults({ ...thing, defaults: { yearn: true } } as types.Thing)
+    await upsertThingDefaults({ ...thing, defaults: { inceptBlock: 100 } } as types.Thing)
+
+    expect((await getDefaults()).yearn).to.equal(true)
+  })
+
+  it('upserting {} defaults is a no-op on existing keys', async () => {
+    await upsertThingDefaults({ ...thing, defaults: { apiVersion: '1.0.0', yearn: true } } as types.Thing)
+    await upsertThingDefaults({ ...thing, defaults: {} } as types.Thing)
+
+    expect(await getDefaults()).to.deep.equal({ apiVersion: '1.0.0', yearn: true })
+  })
+
+  it('replaces a nested object wholesale instead of deep-merging it (roleManager project)', async () => {
+    await upsertThingDefaults({
+      ...thing,
+      defaults: { roleManagerFactory: '0xfactory', project: { id: '0xproject-a' }, inceptBlock: 100 },
+    } as types.Thing)
+
+    await upsertThingDefaults({
+      ...thing,
+      defaults: { project: { id: '0xproject-b' } },
+    } as types.Thing)
+
+    const defaults = await getDefaults()
+    // project is fully replaced, not deep-merged: no leftover keys from the old nested object.
+    expect(defaults.project).to.deep.equal({ id: '0xproject-b' })
+    expect(defaults.roleManagerFactory).to.equal('0xfactory')
+    expect(defaults.inceptBlock).to.equal(100)
+  })
+})

--- a/packages/ingest/db.ts
+++ b/packages/ingest/db.ts
@@ -2,7 +2,7 @@
 
 import { z } from 'zod'
 import { strings } from 'lib'
-import { StrideSchema } from 'lib/types'
+import { StrideSchema, Thing } from 'lib/types'
 import { Pool, PoolClient, types as pgTypes } from 'pg'
 import { snakeToCamelCols } from 'lib/strings'
 
@@ -108,6 +108,21 @@ export async function getSparkline(chainId: number, address: string, label: stri
     blockTime: z.bigint({ coerce: true }),
     close: z.number()
   }).array().parse(result.rows)
+}
+
+export async function upsertThingDefaults(thing: Thing, client?: PoolClient) {
+  // Single-statement upsert with an in-DB jsonb merge, replacing a prior
+  // SELECT ... FOR UPDATE + read-modify-write that serialized concurrent ingest
+  // on hot `thing` rows (the lock wait dominated the cost). `||` is a shallow
+  // right-wins merge, matching the former { ...currentDefaults, ...thing.defaults },
+  // and runs atomically under the row lock taken by ON CONFLICT, so there is no
+  // lost-update race left to guard against.
+  await (client ?? db).query(`
+    INSERT INTO thing (chain_id, address, label, defaults)
+    VALUES ($1, $2, $3, $4)
+    ON CONFLICT (chain_id, address, label)
+    DO UPDATE SET defaults = COALESCE(thing.defaults, '{}'::jsonb) || EXCLUDED.defaults
+  `, [thing.chainId, thing.address, thing.label, thing.defaults])
 }
 
 export function toUpsertSql(table: string, pk: string, data: object, where?: string) {

--- a/packages/ingest/load/index.ts
+++ b/packages/ingest/load/index.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 import { mq, strider, types } from 'lib'
-import db, { firstRow, getTravelledStrides, toUpsertSql } from '../db'
+import db, { firstRow, getTravelledStrides, toUpsertSql, upsertThingDefaults } from '../db'
 import { Processor } from 'lib/processor'
 import { PoolClient } from 'pg'
 import { OutputSchema, SnapshotSchema, ThingSchema, zhexstring } from 'lib/types'
@@ -121,26 +121,7 @@ export async function upsertSnapshot(data: object) {
 
 export async function upsertThing(data: object) {
   const thing = ThingSchema.parse(data)
-  const client = await db.connect()
-
-  try {
-    await client.query('BEGIN')
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const currentDefaults: any = (await client.query(
-      'SELECT defaults FROM thing WHERE chain_id = $1 AND address = $2 AND label = $3 FOR UPDATE',
-      [thing.chainId, thing.address, thing.label]))
-      .rows[0]?.defaults
-    if (currentDefaults) thing.defaults = { ...currentDefaults, ...thing.defaults }
-    await upsert(thing, 'thing', 'chain_id, address, label', undefined, client)
-    await client.query('COMMIT')
-
-  } catch(error) {
-    await client.query('ROLLBACK')
-    throw error
-
-  } finally {
-    client.release()
-  }
+  await upsertThingDefaults(thing)
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Why

Neon compute was ~3,490 compute-hours/period (`cpu_used_sec`/3600). Investigation
showed two cost sources: idle computes that never scale to zero (the dominant lever,
~50%+, handled separately in the Neon console), and a handful of expensive ingest
queries. This PR fixes the one query offender still live in current code. Three
others (Q1 sparkline, Q2 strategy-perf, Q3 est-apr) were already fixed by the
chunk-pruning work in #428. Their large `pg_stat_statements` totals are frozen
history from the old query shapes; no change needed here.

A TTL bump on `probe.fetchEventCounts` (1h → 24h) was also explored, but reverted:
the query is already optimally planned (parallel index-only scan), so it isn't
included in this PR.

## What

**`upsertThing` lock contention** (`packages/ingest/load/index.ts`, `packages/ingest/db.ts`)

Replaced `BEGIN → SELECT defaults ... FOR UPDATE → JS merge → upsert → COMMIT` with a
single atomic statement, now in `db.ts` as `upsertThingDefaults`:
```sql
INSERT INTO thing (chain_id, address, label, defaults)
VALUES ($1, $2, $3, $4)
ON CONFLICT (chain_id, address, label)
DO UPDATE SET defaults = COALESCE(thing.defaults, '{}'::jsonb) || EXCLUDED.defaults
```
This removes the row-lock wait, the extra round-trip, and the explicit transaction.
`||` performs the same shallow right-wins merge as the former
`{...currentDefaults, ...thing.defaults}`, runs atomically under the ON CONFLICT row
lock, and closes a latent clobber race the old path had on concurrent first-inserts.

`upsertThingDefaults` now lives in `db.ts`, separate from `ThingSchema.parse`, so it's
directly testable. `db.spec.ts` is a new test that pins the merge semantics against a
real Postgres testcontainer.

## Metrics (before / after)

Source: `pg_stat_statements` on kong primary, 16.7-day window (2026-06-09 → 06-25).

### Already fixed by #428 (context, not changed in this PR)
| Query | Before (old shape) | After (current shape) |
|---|---|---|
| Q1 sparkline | 362 ms mean | 65 ms mean |
| Q2 strategy-perf | 40,734 ms mean | 89 ms mean (457×) |
| Q3 est-apr latest | 503 ms mean | 163 ms mean |

### upsertThing (changed here)
| | Before | After |
|---|---|---|
| Pattern | txn + SELECT FOR UPDATE + RMW | single atomic ON CONFLICT upsert |
| Calls (window) | 3,872,432 | — |
| Mean exec time | **138 ms** (dominated by lock wait) | sub-ms uncontended |
| Total exec time | 533,147 s | — |

Contention is concurrency-dependent and doesn't reproduce on a single connection, so
the real after-number has to come from `pg_stat_statements` ~24h post-deploy:
```sql
SELECT calls, round(mean_exec_time,1) mean_ms
FROM pg_stat_statements
WHERE query LIKE '%INSERT INTO thing%ON CONFLICT%defaults%';
```
Expected: mean drops from 138 ms toward low single-digit ms.

## Verification

- **Correctness:** `db.spec.ts` (new, real Postgres via testcontainers, not mocked)
  covers a fresh insert (defaults set as-is) and a merge on conflict (new keys added,
  overlapping keys right-wins), matching the prior `{...current,...new}` semantics.
  Also hand-verified in a session-local temp table on Neon:
  `'{"a":1,"yearn":true,"keep":"x"}' || '{"b":2,"yearn":false}'` =
  `{"a":1,"b":2,"keep":"x","yearn":false}`, byte-identical to `{...current,...new}`.
  Null-existing case (column is nullable, 0 such rows today): `COALESCE(NULL,'{}') ||
  '{"b":2}'` = `{"b":2}`. Without COALESCE that would be `NULL`, which is why it's there.
- **Review:** two independent finder/verifier passes over the diff. One finding, the
  NULL-defaults divergence, fixed with COALESCE. Param serialization, dropped-
  transaction safety, caller impact, and triggers/generated columns on `thing` all
  checked clean.
- **Lint:** clean, 0 errors, pre-existing warnings only.
- **Outstanding:** a full index run on a test fork, with before/after timing on
  `upsertThing` under real concurrency, was requested in review. Not done yet; will
  follow up with results.

## Notes

The bigger compute saving, enabling autosuspend on the 5 always-on kong computes, is
a Neon-console change and isn't part of this diff.
