### PR TITLE
Reduce Neon DB compute load

### DIFF
--- a/packages/db/migrations/20260625232000-evmlog-event-address-index.js
+++ b/packages/db/migrations/20260625232000-evmlog-event-address-index.js
@@ -1,0 +1,49 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20260625232000-evmlog-event-address-index-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20260625232000-evmlog-event-address-index-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/packages/db/migrations/sqls/20260625232000-evmlog-event-address-index-down.sql
+++ b/packages/db/migrations/sqls/20260625232000-evmlog-event-address-index-down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS evmlog_idx_chain_address_event_block;

--- a/packages/db/migrations/sqls/20260625232000-evmlog-event-address-index-up.sql
+++ b/packages/db/migrations/sqls/20260625232000-evmlog-event-address-index-up.sql
@@ -1,0 +1,2 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS evmlog_idx_chain_address_event_block
+  ON evmlog (chain_id, address, event_name, block_number, log_index);

--- a/packages/ingest/probe/index.ts
+++ b/packages/ingest/probe/index.ts
@@ -197,14 +197,8 @@ export default class Probe implements Processor {
     return counts
   }
 
-  private eventCountsCache: { rows: any[], ts: number } = { rows: [], ts: 0 }
-
   private async fetchEventCounts() {
-    const now = Date.now()
-    if (now - this.eventCountsCache.ts < 3_600_000) return this.eventCountsCache.rows
-    const query = 'SELECT event_name, count(*) FROM evmlog GROUP BY event_name ORDER BY count DESC;'
-    this.eventCountsCache = { rows: (await db.query(query)).rows, ts: now }
-    return this.eventCountsCache.rows
+    return []
   }
 
   private async probeIndexStats() {

--- a/packages/web/app/api/gql/resolvers/timeseries.ts
+++ b/packages/web/app/api/gql/resolvers/timeseries.ts
@@ -2,6 +2,33 @@ import db from '@/app/api/db'
 import { snakeToCamelCols } from '@/lib/strings'
 import { getAddress } from 'viem'
 
+const CACHE_TTL_MS = 60_000
+const cache = new Map<string, { expiresAt: number, rows: unknown[] }>()
+
+function pruneExpired(now: number) {
+  cache.forEach((value, key) => {
+    if (value.expiresAt <= now) cache.delete(key)
+  })
+}
+
+function cacheKey(scope: string, args: object) {
+  return `${scope}:${JSON.stringify(args, (_, value) =>
+    typeof value === 'bigint' ? value.toString() : value
+  )}`
+}
+
+async function cachedRows(scope: string, args: object, fetchRows: () => Promise<unknown[]>) {
+  const key = cacheKey(scope, args)
+  const now = Date.now()
+  const cached = cache.get(key)
+  if (cached && cached.expiresAt > now) return cached.rows
+
+  const rows = await fetchRows()
+  if (cache.size > 1_000) pruneExpired(now)
+  cache.set(key, { expiresAt: now + CACHE_TTL_MS, rows })
+  return rows
+}
+
 const timeseries = async (_: object, args: {
   chainId?: number,
   address?: `0x${string}`,
@@ -14,8 +41,11 @@ const timeseries = async (_: object, args: {
 }) => {
 
   try {
-    const result = await (args.yearn ? yearntimeseries : alltimeseries)(args)
-    return snakeToCamelCols(result.rows)
+    const rows = await cachedRows(args.yearn ? 'yearn' : 'all', args, async () => {
+      const result = await (args.yearn ? yearntimeseries : alltimeseries)(args)
+      return result.rows
+    })
+    return snakeToCamelCols(rows)
   } catch (error) {
     console.error(error)
     throw new Error('!outputs')
@@ -32,6 +62,12 @@ async function alltimeseries(args: {
   timestamp?: bigint
 }) {
   const { chainId, address, label, component, period, limit, timestamp } = args
+  const timeFloor = timestamp != null
+    ? `
+      AND block_time > to_timestamp($7)
+      AND series_time >= date_trunc('day', to_timestamp($7))`
+    : ''
+
   return await db.query(`
     SELECT
       chain_id AS "chainId",
@@ -46,7 +82,7 @@ async function alltimeseries(args: {
       AND (address = $2 OR $2 IS NULL)
       AND label = $3
       AND (component = $4 OR $4 IS NULL)
-      AND (block_time > to_timestamp($7) OR $7 IS NULL)
+      ${timeFloor}
     GROUP BY chain_id, address, component, time
     ORDER BY time ASC
     LIMIT $6`,
@@ -63,6 +99,12 @@ async function yearntimeseries(args: {
   timestamp?: bigint
 }) {
   const { chainId, address, label, component, period, limit, timestamp } = args
+  const timeFloor = timestamp != null
+    ? `
+      AND output.block_time > to_timestamp($7)
+      AND output.series_time >= date_trunc('day', to_timestamp($7))`
+    : ''
+
   return await db.query(`
     SELECT
       output.chain_id AS "chainId",
@@ -81,7 +123,7 @@ async function yearntimeseries(args: {
       AND (output.address = $2 OR $2 IS NULL)
       AND output.label = $3
       AND (output.component = $4 OR $4 IS NULL)
-      AND (output.block_time > to_timestamp($7) OR $7 IS NULL)
+      ${timeFloor}
     GROUP BY output.chain_id, output.address, output.component, time
     ORDER BY time ASC
     LIMIT $6`,

--- a/packages/web/app/api/gql/resolvers/tvls.ts
+++ b/packages/web/app/api/gql/resolvers/tvls.ts
@@ -2,6 +2,33 @@ import db from '@/app/api/db'
 import { snakeToCamelCols } from '@/lib/strings'
 import { getAddress } from 'viem'
 
+const CACHE_TTL_MS = 60_000
+const cache = new Map<string, { expiresAt: number, rows: unknown[] }>()
+
+function pruneExpired(now: number) {
+  cache.forEach((value, key) => {
+    if (value.expiresAt <= now) cache.delete(key)
+  })
+}
+
+function cacheKey(args: object) {
+  return JSON.stringify(args, (_, value) =>
+    typeof value === 'bigint' ? value.toString() : value
+  )
+}
+
+async function cachedRows(args: object, fetchRows: () => Promise<unknown[]>) {
+  const key = cacheKey(args)
+  const now = Date.now()
+  const cached = cache.get(key)
+  if (cached && cached.expiresAt > now) return cached.rows
+
+  const rows = await fetchRows()
+  if (cache.size > 1_000) pruneExpired(now)
+  cache.set(key, { expiresAt: now + CACHE_TTL_MS, rows })
+  return rows
+}
+
 const tvls = async (_: object, args: {
   chainId: number,
   address?: `0x${string}`,
@@ -10,9 +37,15 @@ const tvls = async (_: object, args: {
   timestamp?: bigint
 }) => {
   const { chainId, address, period, limit, timestamp } = args
+  const timeFloor = timestamp != null
+    ? `
+        AND o.block_time > to_timestamp($4)
+        AND o.series_time >= date_trunc('day', to_timestamp($4))`
+    : ''
 
   try {
-    const result = await db.query(`
+    const rows = await cachedRows(args, async () => {
+      const result = await db.query(`
     WITH asset_info AS (
       SELECT
         chain_id,
@@ -38,7 +71,7 @@ const tvls = async (_: object, args: {
         AND (o.address = $2 OR $2 IS NULL)
         AND o.label = 'tvl-c'
         AND o.component = 'tvl'
-        AND (o.block_time > to_timestamp($4) OR $4 IS NULL)
+        ${timeFloor}
       GROUP BY o.chain_id, o.address, time, a.asset_address
       ORDER BY time ASC
       LIMIT $5
@@ -57,9 +90,11 @@ const tvls = async (_: object, args: {
       ON t.chain_id = p.chain_id
       AND t.asset_address = p.address
       AND t.block_number = p.block_number`,
-    [chainId, address ? getAddress(address) : null, period ?? '1 day', timestamp, limit ?? 100])
+      [chainId, address ? getAddress(address) : null, period ?? '1 day', timestamp, limit ?? 100])
+      return result.rows
+    })
 
-    return snakeToCamelCols(result.rows)
+    return snakeToCamelCols(rows)
 
   } catch (error) {
     console.error(error)


### PR DESCRIPTION
### Summary
Reduce Neon DB compute pressure by caching the hot GraphQL timeseries/TVL resolvers for 60 seconds, adding `series_time` bounds for timestamped output queries so Timescale can prune chunks, removing an expensive full-table `evmlog` event-count probe, and adding a concurrent `evmlog` index for harvest/report lookups.

### How to review
Start with the GraphQL resolver changes in `packages/web/app/api/gql/resolvers/timeseries.ts` and `packages/web/app/api/gql/resolvers/tvls.ts`; both add small in-process caches and only inject the extra `series_time` predicate when the existing `timestamp` argument is present.

Then review `packages/ingest/probe/index.ts`, which stops running the expensive grouped `evmlog` count from the monitor path, and the migration under `packages/db/migrations/sqls/20260625232000-evmlog-event-address-index-up.sql`.

### Test plan
- [x] run web lint
  ```bash
  bun run --filter web lint
  ```
  Expected: command exits 0. Existing warnings about Next lint config and `components/LatestBlocks.tsx` may still appear.

- [x] run web typecheck
  ```bash
  cd packages/web && bunx tsc --noEmit
  ```
  Expected: command exits 0.

- [x] run ingest lint
  ```bash
  bun run --filter ingest lint
  ```
  Expected: command exits 0. Existing warning-only lint output may still appear.

- [x] check whitespace
  ```bash
  git diff --check
  ```
  Expected: no output.

- [ ] run migrations up in the intended DB environment
  ```bash
  bun --filter db migrate up
  ```
  Expected: `evmlog_idx_chain_address_event_block` is created concurrently without blocking normal writes.

- [ ] smoke test GraphQL timeseries with a timestamped query
  ```bash
  curl -sS -X POST http://localhost:3000/api/gql \
    -H 'content-type: application/json' \
    --data '{"query":"query { timeseries(chainId: 1, label: \"tvl-c\", component: \"tvl\", period: \"1 day\", limit: 10, timestamp: 1704067200) { chainId address label component value period time } }"}'
  ```
  Expected: response returns timeseries rows and no GraphQL errors.

- [ ] smoke test GraphQL TVLs with a timestamped query
  ```bash
  curl -sS -X POST http://localhost:3000/api/gql \
    -H 'content-type: application/json' \
    --data '{"query":"query { tvls(chainId: 1, period: \"1 day\", limit: 10, timestamp: 1704067200) { chainId address value period time priceUsd priceSource } }"}'
  ```
  Expected: response returns TVL rows and no GraphQL errors.

Note: I did not run migration up/down locally because this checkout's env points at the live Neon database; applying and rolling back the schema there from the PR workflow would be operationally unsafe.

### Risk / impact
The resolver cache is process-local and short-lived, so rollback is just reverting this PR. Timestamped output queries should return the same logical rows while giving Timescale a partition-column bound. The probe no longer reports `eventCounts`; any dashboard expecting that field will receive an empty list. The new index is created concurrently to reduce write-lock risk on the live `evmlog` table.