### PR TITLE
fix(security): bound public GraphQL queries and harden webhook ingest

### DIFF
--- a/packages/ingest/extract/webhook.spec.ts
+++ b/packages/ingest/extract/webhook.spec.ts
@@ -1,0 +1,73 @@
+import { strict as assert } from 'node:assert'
+import { selectValidOutputs, MAX_OUTPUTS_PER_VAULT } from './webhook'
+import type { Data } from './webhook'
+import type { Output } from 'lib/types'
+import type { WebhookSubscription } from 'lib/subscriptions'
+
+const VAULT_A = '0x1111111111111111111111111111111111111111'
+const VAULT_B = '0x2222222222222222222222222222222222222222'
+const OUT_OF_SCOPE = '0x3333333333333333333333333333333333333333'
+
+const subscription: WebhookSubscription = {
+  id: 'S_TEST',
+  url: 'https://example.com/webhook',
+  abiPath: 'yearn/2/vault',
+  type: 'timeseries',
+  labels: ['apr']
+}
+
+function data(vaults: string[], chainId = 1): Data {
+  return {
+    abiPath: 'yearn/2/vault',
+    chainId,
+    blockNumber: 1n,
+    blockTime: 1n,
+    subscription,
+    vaults: vaults as `0x${string}`[]
+  }
+}
+
+function output(address: string, label = 'apr', chainId = 1): Output {
+  return {
+    chainId,
+    address: address as `0x${string}`,
+    label,
+    component: 'net',
+    value: 1,
+    blockNumber: 1n,
+    blockTime: 1n
+  }
+}
+
+describe('selectValidOutputs', () => {
+  it('keeps outputs for requested vaults with allowed labels', () => {
+    const valid = selectValidOutputs([output(VAULT_A), output(VAULT_B)], data([VAULT_A, VAULT_B]))
+    assert.equal(valid.length, 2)
+  })
+
+  it('drops outputs for vaults that were not requested', () => {
+    const valid = selectValidOutputs([output(OUT_OF_SCOPE)], data([VAULT_A]))
+    assert.equal(valid.length, 0)
+  })
+
+  it('drops outputs for a different chain than requested', () => {
+    const valid = selectValidOutputs([output(VAULT_A, 'apr', 10)], data([VAULT_A], 1))
+    assert.equal(valid.length, 0)
+  })
+
+  it('matches vault addresses case-insensitively', () => {
+    const valid = selectValidOutputs([output(VAULT_A.toUpperCase().replace('0X', '0x'))], data([VAULT_A.toLowerCase()]))
+    assert.equal(valid.length, 1)
+  })
+
+  it('drops a vault group with an unexpected label', () => {
+    const valid = selectValidOutputs([output(VAULT_A, 'not-allowed')], data([VAULT_A]))
+    assert.equal(valid.length, 0)
+  })
+
+  it('drops a vault group over the per-vault cap', () => {
+    const many = Array.from({ length: MAX_OUTPUTS_PER_VAULT + 1 }, () => output(VAULT_A))
+    const valid = selectValidOutputs(many, data([VAULT_A]))
+    assert.equal(valid.length, 0)
+  })
+})

--- a/packages/ingest/extract/webhook.spec.ts
+++ b/packages/ingest/extract/webhook.spec.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'node:assert'
-import { selectValidOutputs, MAX_OUTPUTS_PER_VAULT } from './webhook'
+import { selectValidOutputs, readJsonCapped, MAX_OUTPUTS_PER_VAULT } from './webhook'
 import type { Data } from './webhook'
 import type { Output } from 'lib/types'
 import type { WebhookSubscription } from 'lib/subscriptions'
@@ -69,5 +69,22 @@ describe('selectValidOutputs', () => {
     const many = Array.from({ length: MAX_OUTPUTS_PER_VAULT + 1 }, () => output(VAULT_A))
     const valid = selectValidOutputs(many, data([VAULT_A]))
     assert.equal(valid.length, 0)
+  })
+})
+
+describe('readJsonCapped', () => {
+  it('parses a body under the cap', async () => {
+    const response = new Response(JSON.stringify({ a: 1 }))
+    assert.deepEqual(await readJsonCapped(response, 1024), { a: 1 })
+  })
+
+  it('rejects when the declared content-length exceeds the cap', async () => {
+    const fake = { headers: { get: () => '999999' } } as unknown as Response
+    await assert.rejects(() => readJsonCapped(fake, 10))
+  })
+
+  it('rejects when the streamed body exceeds the cap', async () => {
+    const big = JSON.stringify(Array.from({ length: 1000 }, (_, i) => i))
+    await assert.rejects(() => readJsonCapped(new Response(big), 10))
   })
 })

--- a/packages/ingest/extract/webhook.ts
+++ b/packages/ingest/extract/webhook.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 import { createHmac } from 'crypto'
 import { mq, sentry } from 'lib'
-import { OutputSchema, zhexstring } from 'lib/types'
+import { Output, OutputSchema, zhexstring } from 'lib/types'
 import { WebhookSubscription, WebhookSubscriptionSchema } from 'lib/subscriptions'
 
 export const DataSchema = z.object({
@@ -52,6 +52,49 @@ async function fetchResponse(subscription: WebhookSubscription, data: Data): Pro
   }
 }
 
+export const MAX_OUTPUTS_PER_VAULT = 100
+
+// Drop any receiver output that isn't for the chain/vaults we asked it to compute,
+// exceeds the per-vault cap, or carries an unexpected label, before it reaches the
+// load queue. Scope filtering also bounds total groups to the requested vault set
+// (FINDINGS.md findings 4-5, CWE-20 / CWE-400).
+export function selectValidOutputs(outputs: Output[], data: Data): Output[] {
+  const { subscription } = data
+  const requestedVaults = new Set(data.vaults.map(v => v.toLowerCase()))
+  const grouped = Map.groupBy(outputs, o => `${o.chainId}:${o.address}`)
+  return [...grouped].flatMap(([key, group]) => {
+    const [first] = group
+    if (first.chainId !== data.chainId || !requestedVaults.has(first.address.toLowerCase())) {
+      console.error(`🤬 ${subscription.id} skipping ${key}: out of requested scope`)
+      sentry.captureMessage('WEBHOOK_OUT_OF_SCOPE', {
+        level: 'warning',
+        tags: { component: 'ingest', job: 'extract.webhook' },
+        extra: { subscriptionId: subscription.id, key, requestedChainId: data.chainId }
+      })
+      return []
+    }
+    if (group.length > MAX_OUTPUTS_PER_VAULT) {
+      console.error(`🤬 ${subscription.id} skipping ${key}: ${group.length} outputs > ${MAX_OUTPUTS_PER_VAULT}`)
+      sentry.captureMessage('WEBHOOK_OUTPUTS_OVER_LIMIT', {
+        level: 'warning',
+        tags: { component: 'ingest', job: 'extract.webhook' },
+        extra: { subscriptionId: subscription.id, key, outputs: group.length, max: MAX_OUTPUTS_PER_VAULT }
+      })
+      return []
+    }
+    if (group.some(o => !subscription.labels.includes(o.label))) {
+      console.error(`🤬 ${subscription.id} skipping ${key}: unexpected labels`)
+      sentry.captureMessage('WEBHOOK_UNEXPECTED_LABELS', {
+        level: 'warning',
+        tags: { component: 'ingest', job: 'extract.webhook' },
+        extra: { subscriptionId: subscription.id, key }
+      })
+      return []
+    }
+    return group
+  })
+}
+
 export class WebhookExtractor {
   async extract(data: Data) {
     data = DataSchema.parse(data)
@@ -72,30 +115,7 @@ export class WebhookExtractor {
 
       const body = await response.json()
       const outputs = OutputSchema.array().parse(body)
-
-      const MAX_OUTPUTS_PER_VAULT = 100
-      const grouped = Map.groupBy(outputs, o => `${o.chainId}:${o.address}`)
-      const valid = [...grouped].flatMap(([key, group]) => {
-        if (group.length > MAX_OUTPUTS_PER_VAULT) {
-          console.error(`🤬 ${subscription.id} skipping ${key}: ${group.length} outputs > ${MAX_OUTPUTS_PER_VAULT}`)
-          sentry.captureMessage('WEBHOOK_OUTPUTS_OVER_LIMIT', {
-            level: 'warning',
-            tags: { component: 'ingest', job: 'extract.webhook' },
-            extra: { subscriptionId: subscription.id, key, outputs: group.length, max: MAX_OUTPUTS_PER_VAULT }
-          })
-          return []
-        }
-        if (group.some(o => !subscription.labels.includes(o.label))) {
-          console.error(`🤬 ${subscription.id} skipping ${key}: unexpected labels`)
-          sentry.captureMessage('WEBHOOK_UNEXPECTED_LABELS', {
-            level: 'warning',
-            tags: { component: 'ingest', job: 'extract.webhook' },
-            extra: { subscriptionId: subscription.id, key }
-          })
-          return []
-        }
-        return group
-      })
+      const valid = selectValidOutputs(outputs, data)
 
       await mq.add(mq.job.load.output, { batch: valid })
     } finally {

--- a/packages/ingest/extract/webhook.ts
+++ b/packages/ingest/extract/webhook.ts
@@ -31,6 +31,9 @@ function getWebhookSecret(subscriptionId: string): string {
   return secret
 }
 
+const WEBHOOK_TIMEOUT_MS = 30_000
+const MAX_RESPONSE_BYTES = 10 * 1024 * 1024 // 10 MiB
+
 async function fetchResponse(subscription: WebhookSubscription, data: Data): Promise<Response> {
   try {
     const timestamp = Math.floor(Date.now() / 1000)
@@ -44,12 +47,38 @@ async function fetchResponse(subscription: WebhookSubscription, data: Data): Pro
         'Content-Type': 'application/json',
         'Kong-Signature': signature
       },
-      body
+      body,
+      redirect: 'manual', // a receiver must not redirect worker egress elsewhere (SSRF)
+      signal: AbortSignal.timeout(WEBHOOK_TIMEOUT_MS)
     })
   } catch (error) {
     console.error('🤬', 'webhook failed', subscription)
     throw error
   }
+}
+
+// Read and JSON-parse a response while enforcing a hard byte ceiling, so a receiver
+// can't exhaust worker memory with an oversized (or content-length-lying) body.
+export async function readJsonCapped(response: Response, maxBytes = MAX_RESPONSE_BYTES): Promise<unknown> {
+  const declared = Number(response.headers.get('content-length'))
+  if (Number.isFinite(declared) && declared > maxBytes) {
+    throw new Error(`Webhook response too large: ${declared} > ${maxBytes} bytes`)
+  }
+  const reader = response.body?.getReader()
+  if (!reader) return response.json()
+  const chunks: Uint8Array[] = []
+  let total = 0
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) break
+    total += value.length
+    if (total > maxBytes) {
+      await reader.cancel()
+      throw new Error(`Webhook response exceeded ${maxBytes} bytes`)
+    }
+    chunks.push(value)
+  }
+  return JSON.parse(Buffer.concat(chunks).toString('utf8'))
 }
 
 export const MAX_OUTPUTS_PER_VAULT = 100
@@ -113,7 +142,7 @@ export class WebhookExtractor {
         throw new Error(`Webhook returned ${response.status}: ${response.statusText}`)
       }
 
-      const body = await response.json()
+      const body = await readJsonCapped(response)
       const outputs = OutputSchema.array().parse(body)
       const valid = selectValidOutputs(outputs, data)
 

--- a/packages/lib/subscriptions.spec.ts
+++ b/packages/lib/subscriptions.spec.ts
@@ -1,0 +1,32 @@
+import { strict as assert } from 'node:assert'
+import { isPublicHttpsUrl } from './subscriptions'
+
+describe('isPublicHttpsUrl', () => {
+  it('accepts public https urls', () => {
+    assert.equal(isPublicHttpsUrl('https://v2-estimated-apr-hook.vercel.app/webhook'), true)
+    assert.equal(isPublicHttpsUrl('https://katana-apr.yearn.fi/api/webhook'), true)
+  })
+
+  it('rejects non-https schemes', () => {
+    assert.equal(isPublicHttpsUrl('http://example.com/webhook'), false)
+    assert.equal(isPublicHttpsUrl('file:///etc/passwd'), false)
+  })
+
+  it('rejects localhost and loopback hosts', () => {
+    assert.equal(isPublicHttpsUrl('https://localhost/x'), false)
+    assert.equal(isPublicHttpsUrl('https://127.0.0.1/x'), false)
+    assert.equal(isPublicHttpsUrl('https://[::1]/x'), false)
+  })
+
+  it('rejects private ranges and the cloud metadata ip', () => {
+    assert.equal(isPublicHttpsUrl('https://10.0.0.5/x'), false)
+    assert.equal(isPublicHttpsUrl('https://192.168.1.1/x'), false)
+    assert.equal(isPublicHttpsUrl('https://172.16.0.1/x'), false)
+    assert.equal(isPublicHttpsUrl('https://169.254.169.254/latest/meta-data'), false)
+  })
+
+  it('rejects internal tlds and malformed urls', () => {
+    assert.equal(isPublicHttpsUrl('https://db.internal/x'), false)
+    assert.equal(isPublicHttpsUrl('not a url'), false)
+  })
+})

--- a/packages/lib/subscriptions.spec.ts
+++ b/packages/lib/subscriptions.spec.ts
@@ -14,6 +14,7 @@ describe('isPublicHttpsUrl', () => {
 
   it('rejects localhost and loopback hosts', () => {
     assert.equal(isPublicHttpsUrl('https://localhost/x'), false)
+    assert.equal(isPublicHttpsUrl('https://api.localhost/x'), false)
     assert.equal(isPublicHttpsUrl('https://127.0.0.1/x'), false)
     assert.equal(isPublicHttpsUrl('https://[::1]/x'), false)
   })

--- a/packages/lib/subscriptions.ts
+++ b/packages/lib/subscriptions.ts
@@ -13,7 +13,7 @@ const WebhookFilterSchema = z.object({
 
 // Block non-https schemes and private/loopback/link-local hosts so a webhook URL
 // can't point worker egress at internal or metadata endpoints (FINDINGS.md 6, SSRF).
-const PRIVATE_HOST = /^(localhost|0\.0\.0\.0|::1?|127\.|10\.|169\.254\.|192\.168\.|172\.(1[6-9]|2\d|3[01])\.)|(\.local|\.internal)$/i
+const PRIVATE_HOST = /^(localhost|0\.0\.0\.0|::1?|127\.|10\.|169\.254\.|192\.168\.|172\.(1[6-9]|2\d|3[01])\.)|(\.local|\.localhost|\.internal)$/i
 
 export function isPublicHttpsUrl(raw: string): boolean {
   let url: URL

--- a/packages/lib/subscriptions.ts
+++ b/packages/lib/subscriptions.ts
@@ -11,9 +11,19 @@ const WebhookFilterSchema = z.object({
   })).optional()
 }).optional()
 
+// Block non-https schemes and private/loopback/link-local hosts so a webhook URL
+// can't point worker egress at internal or metadata endpoints (FINDINGS.md 6, SSRF).
+const PRIVATE_HOST = /^(localhost|0\.0\.0\.0|::1?|127\.|10\.|169\.254\.|192\.168\.|172\.(1[6-9]|2\d|3[01])\.)|(\.local|\.internal)$/i
+
+export function isPublicHttpsUrl(raw: string): boolean {
+  let url: URL
+  try { url = new URL(raw) } catch { return false }
+  return url.protocol === 'https:' && !PRIVATE_HOST.test(url.hostname.replace(/^\[|\]$/g, ''))
+}
+
 export const WebhookSubscriptionSchema = z.object({
   id: z.string(),
-  url: z.string().url(),
+  url: z.string().url().refine(isPublicHttpsUrl, 'webhook url must be public https'),
   abiPath: z.string(),
   type: z.enum(['timeseries']),
   labels: z.array(z.string()),

--- a/packages/web/app/api/gql/resolvers/guards.spec.ts
+++ b/packages/web/app/api/gql/resolvers/guards.spec.ts
@@ -1,0 +1,41 @@
+import { strict as assert } from 'node:assert'
+import { clampLimit, resolvePeriod, MAX_GQL_LIMIT } from './guards'
+
+describe('clampLimit', () => {
+  it('defaults to 100 when omitted', () => {
+    assert.equal(clampLimit(), 100)
+    assert.equal(clampLimit(null), 100)
+  })
+
+  it('passes through values within range', () => {
+    assert.equal(clampLimit(30), 30)
+  })
+
+  it('caps values above the max', () => {
+    assert.equal(clampLimit(1_000_000), MAX_GQL_LIMIT)
+  })
+
+  it('rejects non-positive or non-integer limits', () => {
+    assert.throws(() => clampLimit(0))
+    assert.throws(() => clampLimit(-5))
+    assert.throws(() => clampLimit(1.5))
+  })
+})
+
+describe('resolvePeriod', () => {
+  it('defaults to 1 day when omitted', () => {
+    assert.equal(resolvePeriod(), '1 day')
+    assert.equal(resolvePeriod(null), '1 day')
+  })
+
+  it('passes through allowlisted periods', () => {
+    assert.equal(resolvePeriod('1 hour'), '1 hour')
+    assert.equal(resolvePeriod('1 week'), '1 week')
+  })
+
+  it('rejects sub-day and arbitrary interval strings', () => {
+    assert.throws(() => resolvePeriod('1 second'))
+    assert.throws(() => resolvePeriod('30 minutes'))
+    assert.throws(() => resolvePeriod('1 day; DROP TABLE output;--'))
+  })
+})

--- a/packages/web/app/api/gql/resolvers/guards.ts
+++ b/packages/web/app/api/gql/resolvers/guards.ts
@@ -1,0 +1,22 @@
+// Guards that bound the database work an anonymous public-GraphQL caller can request.
+// See FINDINGS.md findings 1-3 (CWE-400, unbounded query/aggregation).
+
+export const MAX_GQL_LIMIT = 1000
+const DEFAULT_GQL_LIMIT = 100
+
+// Coarse buckets only. `output` is sampled at >= 1 day, so finer periods just
+// multiply time_bucket work; an allowlist also blocks arbitrary interval strings.
+const ALLOWED_PERIODS = new Set(['1 hour', '1 day', '1 week', '1 month', '1 year'])
+const DEFAULT_PERIOD = '1 day'
+
+export function clampLimit(limit?: number | null): number {
+  if (limit == null) return DEFAULT_GQL_LIMIT
+  if (!Number.isInteger(limit) || limit < 1) throw new Error(`invalid limit: ${limit}`)
+  return Math.min(limit, MAX_GQL_LIMIT)
+}
+
+export function resolvePeriod(period?: string | null): string {
+  if (period == null) return DEFAULT_PERIOD
+  if (!ALLOWED_PERIODS.has(period)) throw new Error(`invalid period: ${period}`)
+  return period
+}

--- a/packages/web/app/api/gql/resolvers/prices.ts
+++ b/packages/web/app/api/gql/resolvers/prices.ts
@@ -1,8 +1,20 @@
 import db from '@/app/api/db'
 import { getAddress } from 'viem'
 
+// Backstop cap so a single-token history can never return the whole table.
+// ponytail: a fixed ceiling, not cursor pagination — selective filters keep real
+// queries far under it; raise + add a cursor if a token legitimately exceeds it.
+const MAX_PRICE_ROWS = 50000
+
 const prices = async (_: object, args: { chainId?: number, address?: `0x${string}`, timestamp?: bigint }) => {
   const { chainId, address, timestamp } = args
+
+  // Require a selective partition so an anonymous caller cannot scan the 124M-row
+  // price table with no filters (FINDINGS.md finding 1, CWE-400).
+  if (!address && timestamp == null) {
+    throw new Error('prices requires address or timestamp')
+  }
+
   try {
 
     const result = await db.query(`
@@ -17,7 +29,8 @@ const prices = async (_: object, args: { chainId?: number, address?: `0x${string
     WHERE (chain_id = $1 OR $1 IS NULL)
       AND (address = $2 OR $2 IS NULL)
       AND (block_time > to_timestamp($3) OR $3 IS NULL)
-    ORDER BY block_time ASC`,
+    ORDER BY block_time ASC
+    LIMIT ${MAX_PRICE_ROWS}`,
     [chainId, address ? getAddress(address) : null, timestamp])
 
     return result.rows

--- a/packages/web/app/api/gql/resolvers/prices.ts
+++ b/packages/web/app/api/gql/resolvers/prices.ts
@@ -9,10 +9,11 @@ const MAX_PRICE_ROWS = 50000
 const prices = async (_: object, args: { chainId?: number, address?: `0x${string}`, timestamp?: bigint }) => {
   const { chainId, address, timestamp } = args
 
-  // Require a selective partition so an anonymous caller cannot scan the 124M-row
-  // price table with no filters (FINDINGS.md finding 1, CWE-400).
-  if (!address && timestamp == null) {
-    throw new Error('prices requires address or timestamp')
+  // Require the selective address partition so an anonymous caller cannot scan the
+  // 124M-row price table. timestamp alone (e.g. to_timestamp(0)) is a near-full
+  // table scan, so it does not qualify (FINDINGS.md finding 1, CWE-400).
+  if (!address) {
+    throw new Error('prices requires an address')
   }
 
   try {

--- a/packages/web/app/api/gql/resolvers/timeseries.ts
+++ b/packages/web/app/api/gql/resolvers/timeseries.ts
@@ -1,6 +1,7 @@
 import db from '@/app/api/db'
 import { snakeToCamelCols } from '@/lib/strings'
 import { getAddress } from 'viem'
+import { clampLimit, resolvePeriod } from './guards'
 
 const timeseries = async (_: object, args: {
   chainId?: number,
@@ -13,8 +14,13 @@ const timeseries = async (_: object, args: {
   yearn?: boolean
 }) => {
 
+  // Bound caller-controlled aggregation cost before issuing the query (throws on
+  // invalid input ahead of the generic catch so the message reaches the client).
+  const period = resolvePeriod(args.period)
+  const limit = clampLimit(args.limit)
+
   try {
-    const result = await (args.yearn ? yearntimeseries : alltimeseries)(args)
+    const result = await (args.yearn ? yearntimeseries : alltimeseries)({ ...args, period, limit })
     return snakeToCamelCols(result.rows)
   } catch (error) {
     console.error(error)

--- a/packages/web/app/api/gql/resolvers/timeseries.ts
+++ b/packages/web/app/api/gql/resolvers/timeseries.ts
@@ -56,7 +56,7 @@ async function alltimeseries(args: {
     GROUP BY chain_id, address, component, time
     ORDER BY time ASC
     LIMIT $6`,
-  [chainId, address ? getAddress(address) : null, label, component, period ?? '1 day', limit ?? 100, timestamp])
+  [chainId, address ? getAddress(address) : null, label, component, period, limit, timestamp])
 }
 
 async function yearntimeseries(args: {
@@ -91,7 +91,7 @@ async function yearntimeseries(args: {
     GROUP BY output.chain_id, output.address, output.component, time
     ORDER BY time ASC
     LIMIT $6`,
-  [chainId, address, label, component, period ?? '1 day', limit ?? 100, timestamp])
+  [chainId, address, label, component, period, limit, timestamp])
 }
 
 export default timeseries

--- a/packages/web/app/api/gql/resolvers/tvls.ts
+++ b/packages/web/app/api/gql/resolvers/tvls.ts
@@ -1,6 +1,7 @@
 import db from '@/app/api/db'
 import { snakeToCamelCols } from '@/lib/strings'
 import { getAddress } from 'viem'
+import { clampLimit, resolvePeriod } from './guards'
 
 const tvls = async (_: object, args: {
   chainId: number,
@@ -9,7 +10,11 @@ const tvls = async (_: object, args: {
   limit?: number,
   timestamp?: bigint
 }) => {
-  const { chainId, address, period, limit, timestamp } = args
+  const { chainId, address, timestamp } = args
+
+  // Bound caller-controlled aggregation cost before issuing the chain-wide query.
+  const period = resolvePeriod(args.period)
+  const limit = clampLimit(args.limit)
 
   try {
     const result = await db.query(`
@@ -57,7 +62,7 @@ const tvls = async (_: object, args: {
       ON t.chain_id = p.chain_id
       AND t.asset_address = p.address
       AND t.block_number = p.block_number`,
-    [chainId, address ? getAddress(address) : null, period ?? '1 day', timestamp, limit ?? 100])
+    [chainId, address ? getAddress(address) : null, period, timestamp, limit])
 
     return snakeToCamelCols(result.rows)
 


### PR DESCRIPTION
### Summary

A security scan flagged six issues across the public API and webhook ingest. Anonymous callers could force full-table scans and uncapped Timescale aggregations through the `prices`, `timeseries`, and `tvls` GraphQL resolvers, and the webhook extractor accepted out-of-scope receiver output, read unbounded response bodies, and followed receiver-controlled redirects. This branch bounds each path.

- **Public GraphQL (findings 1-3):** `prices` now requires an `address` (timestamp alone is a near-full table scan); `timeseries` and `tvls` clamp `limit` to 1000 and reject any `period` outside a coarse allowlist. A 50k-row backstop caps `prices` responses.
- **Webhook output scope (findings 4-5):** receiver outputs whose `chainId`/`address` fall outside the fanout request are dropped before the load queue, which also bounds total groups to the requested vault set.
- **Webhook fetch (findings 4, 6):** a 30s timeout and a 10 MiB capped reader stop a receiver from stalling workers or exhausting memory; `redirect: 'manual'` plus a public-https-only subscription URL check block SSRF pivots.

### How to review

Start with `packages/web/app/api/gql/resolvers/guards.ts` (the shared `clampLimit`/`resolvePeriod`) and how `prices.ts`/`timeseries.ts`/`tvls.ts` apply it. Then `packages/ingest/extract/webhook.ts`: `selectValidOutputs` (scope filter, extracted as a pure function) and `readJsonCapped` plus the hardened `fetchResponse`. Finish with `isPublicHttpsUrl` in `packages/lib/subscriptions.ts`. The `.spec.ts` files alongside each show the intended boundaries.

### Test plan

- [ ] Automated: `bun --filter web test` (guards spec, no containers) and `bun --filter ingest test` / `bun --filter lib test` (webhook + subscriptions specs; these spin up postgres/redis testcontainers, so Docker must be running).
- [ ] Manual: smoke the public GraphQL endpoint. `prices` with no `address` should error, `timeseries`/`tvls` with `period: "1 second"` or `limit: 999999` should reject/clamp, and a normal `prices(chainId, address)` / `tvls(chainId, address)` query should still return data.

### Risk / impact

Behavioral changes a client could hit:
- `prices` rejects calls without an `address` (e.g. bare `{ prices }` or `prices(chainId: 1)`). Documented usage always passes `address`.
- `timeseries`/`tvls` reject sub-day or arbitrary `period` values and clamp `limit` above 1000.
- Webhook receivers that return a 3xx, take over 30s, or send over 10 MiB now fail that job.
- Subscription URLs must be public https. A private or http URL in `config/subscriptions.yaml` fails config load at startup, and all committed URLs already pass.

No DB migrations, no auth changes, no funds-handling code. Rollback is a branch revert.