### PR TITLE
feat(ingest): index oracle currentApr in apr-oracle timeseries

### DIFF
--- a/docs/rest.md
+++ b/docs/rest.md
@@ -165,6 +165,17 @@ Historical timeseries data for a vault.
 |-----------|------|-------------|
 | `components` | `string[]` | Override default component(s) |
 
+**`apr-oracle` components**
+
+| Component | Description |
+|-----------|-------------|
+| `apr` | Resolved oracle APR (strategy APR, or current APR when no strategy oracle) — the default |
+| `apy` | Resolved oracle APR compounded to APY |
+| `netApr` / `netApy` | Resolved APR/APY net of vault fees (v3 vaults only) |
+| `currentApr` | Oracle `getCurrentApr(vault)`, the vault-level current APR indexed for comparison against the resolved/strategy APR |
+| `currentApy` | `currentApr` compounded to APY |
+| `currentNetApr` / `currentNetApy` | `currentApr`/`currentApy` net of vault fees (v3 vaults only) |
+
 ```bash
 # historical APY
 curl -s https://kong.yearn.fi/api/rest/timeseries/apy-historical/1/0x6faf8b7ffee3306efcfc2ba9fec912b4d49834c1 | jq
@@ -174,6 +185,12 @@ curl -s https://kong.yearn.fi/api/rest/timeseries/tvl/1/0x6faf8b7ffee3306efcfc2b
 
 # price per share
 curl -s https://kong.yearn.fi/api/rest/timeseries/pps/1/0x6faf8b7ffee3306efcfc2ba9fec912b4d49834c1 | jq
+
+# oracle current APR (v3 vaults)
+curl -s "https://kong.yearn.fi/api/rest/timeseries/apr-oracle/1/0x6faf8b7ffee3306efcfc2ba9fec912b4d49834c1?components=currentApr" | jq
+
+# compare resolved oracle APR against current APR (repeated components)
+curl -s "https://kong.yearn.fi/api/rest/timeseries/apr-oracle/1/0x6faf8b7ffee3306efcfc2ba9fec912b4d49834c1?components=apr&components=currentApr" | jq
 ```
 
 **Response**

--- a/packages/ingest/abis/erc4626/timeseries/apr-oracle/hook.spec.ts
+++ b/packages/ingest/abis/erc4626/timeseries/apr-oracle/hook.spec.ts
@@ -14,8 +14,10 @@ describe('abis/erc4626/timeseries/apr-oracle/hook', function() {
     // erc4626 path. The oracle still prices it via getStrategyApr.
     const oracle = getOracleConfig(mainnet.id)
     expect(oracle).to.not.equal(undefined)
-    const apr = await readApr(mainnet.id, morphoUsdt, 25211174n, oracle!.address)
+    const { apr, currentApr } = await readApr(mainnet.id, morphoUsdt, 25211174n, oracle!.address)
     expect(apr).to.be.closeTo(0.11878347712984644, 1e-6)
+    // getStrategyApr succeeds, so the fallback never runs and currentApr stays undefined.
+    expect(currentApr).to.equal(undefined)
   })
 
   it('returns nothing when the chain has no oracle configured', async function() {
@@ -26,18 +28,27 @@ describe('abis/erc4626/timeseries/apr-oracle/hook', function() {
     expect(await hook(999999, morphoUsdt, data)).to.deep.equal([])
   })
 
-  it('emits apr and apy outputs', async function() {
+  it('emits apr/apy, plus currentApr/currentApy when the oracle returns a current apr', async function() {
     const data: Data = {
       abiPath: 'erc4626', chainId: mainnet.id, address: morphoUsdt,
       outputLabel, blockTime: BigInt(Math.floor(Date.now() / 1000)) + 60n
     }
     const outputs = await hook(mainnet.id, morphoUsdt, data)
-    expect(outputs.map(o => o.component).sort()).to.deep.equal(['apr', 'apy'])
+    const components = outputs.map(o => o.component)
+    // net* stays v3-only; erc4626 emits apr/apy and optionally currentApr/currentApy.
+    expect(components).to.include.members(['apr', 'apy'])
+    expect(components.every(c => ['apr', 'apy', 'currentApr', 'currentApy'].includes(c))).to.equal(true)
     expect(outputs.every(o => o.label === outputLabel)).to.equal(true)
 
-    const apr = outputs.find(o => o.component === 'apr')!.value as number
-    const apy = outputs.find(o => o.component === 'apy')!.value as number
-    expect(apr).to.be.greaterThan(0)
-    expect(apy).to.be.closeTo(computeApy(apr), 1e-9)
+    const value = (component: string) => outputs.find(o => o.component === component)?.value as number | undefined
+    expect(value('apr')!).to.be.greaterThan(0)
+    expect(value('apy')!).to.be.closeTo(computeApy(value('apr')!), 1e-9)
+
+    // currentApr/currentApy travel as a pair with the same apy relationship.
+    const currentApr = value('currentApr')
+    expect(components.includes('currentApy')).to.equal(currentApr !== undefined)
+    if (currentApr !== undefined) {
+      expect(value('currentApy')!).to.be.closeTo(computeApy(currentApr), 1e-9)
+    }
   })
 })

--- a/packages/ingest/abis/erc4626/timeseries/apr-oracle/hook.ts
+++ b/packages/ingest/abis/erc4626/timeseries/apr-oracle/hook.ts
@@ -1,13 +1,14 @@
 import { Output, OutputSchema } from 'lib/types'
 import { Data } from '../../../../extract/timeseries'
-import { resolveOracleApr } from '../../../yearn/3/vault/timeseries/apr-oracle/hook'
+import { computeApy } from '../../../yearn/lib/apy'
+import { readCurrentApr, resolveOracleApr } from '../../../yearn/3/vault/timeseries/apr-oracle/hook'
 
 export const outputLabel = 'apr-oracle'
 
 // Plain erc4626 vaults (e.g. Yearn-branded Morpho vaults) aren't classified as
 // yearn/3/vault, so they never ran the apr oracle. The oracle prices them by
-// address all the same. Net apr/apy aren't surfaced for erc4626 vaults, so only
-// emit apr/apy.
+// address all the same. netApr/netApy stay v3-only (they need the v3 fee path),
+// but currentApr/currentApy only need the oracle read, so surface them here too.
 export default async function (
   chainId: number,
   address: `0x${string}`,
@@ -16,12 +17,18 @@ export default async function (
   const resolved = await resolveOracleApr(chainId, address, data)
   if (!resolved) return []
 
+  const currentApr = resolved.currentApr !== undefined
+    ? resolved.currentApr
+    : await readCurrentApr(chainId, address, resolved.blockNumber, resolved.oracleAddress)
+
   const output = (component: string, value: number): Output => ({
     label: outputLabel, component, value, chainId, address, blockNumber: resolved.blockNumber, blockTime: data.blockTime,
   })
 
-  return OutputSchema.array().parse([
-    output('apr', resolved.apr),
-    output('apy', resolved.apy),
-  ])
+  const outputs = [output('apr', resolved.apr), output('apy', resolved.apy)]
+  if (currentApr !== undefined) {
+    outputs.push(output('currentApr', currentApr), output('currentApy', computeApy(currentApr)))
+  }
+
+  return OutputSchema.array().parse(outputs)
 }

--- a/packages/ingest/abis/yearn/3/vault/timeseries/apr-oracle/hook.spec.ts
+++ b/packages/ingest/abis/yearn/3/vault/timeseries/apr-oracle/hook.spec.ts
@@ -1,9 +1,99 @@
 import { expect } from 'chai'
-import { computeNetApr } from '../../../../lib/apy'
+import { vi } from 'vitest'
+import { rpcs } from 'lib/rpcs'
+import { ContractFunctionRevertedError } from 'viem'
+import { computeApy, computeNetApr } from '../../../../lib/apy'
+import { buildOracleComponents, readApr, readCurrentApr } from './hook'
+import { V3_ORACLE_ABI } from './abi'
 
 describe('abis/yearn/3/vault/timeseries/apr-oracle/hook', function() {
+  const vault = '0x6faf8b7ffee3306efcfc2ba9fec912b4d49834c1' as const
+  const oracle = '0x1981AD9F44F2EA9aDd2dC4AD7D075c102C70aF92' as const
+  const fees = { management: 0.02, performance: 0.1 }
+
+  afterEach(function() {
+    vi.restoreAllMocks()
+  })
+
   it('re-exports computeNetApr from lib/apy', async function() {
     const { computeNetApr: reExported } = await import('./hook')
     expect(reExported).to.equal(computeNetApr)
+  })
+
+  describe('buildOracleComponents', function() {
+    it('emits resolved apr/apy/netApr/netApy plus current* when current apr is present', function() {
+      const apr = 0.1
+      const currentApr = 0.2
+      const components = buildOracleComponents(apr, fees, currentApr)
+
+      expect(components.map(c => c.component).sort()).to.deep.equal(
+        ['apr', 'apy', 'currentApr', 'currentApy', 'currentNetApr', 'currentNetApy', 'netApr', 'netApy']
+      )
+
+      const value = (component: string) => components.find(c => c.component === component)!.value
+      expect(value('apr')).to.equal(apr)
+      expect(value('apy')).to.equal(computeApy(apr))
+      expect(value('netApr')).to.equal(computeNetApr(apr, fees))
+      expect(value('netApy')).to.equal(computeApy(computeNetApr(apr, fees)))
+
+      expect(value('currentApr')).to.equal(currentApr)
+      expect(value('currentApy')).to.equal(computeApy(currentApr))
+      expect(value('currentNetApr')).to.equal(computeNetApr(currentApr, fees))
+      expect(value('currentNetApy')).to.equal(computeApy(computeNetApr(currentApr, fees)))
+    })
+
+    it('keeps the resolved output when current apr is missing (getCurrentApr failure)', function() {
+      const apr = 0.1
+      const components = buildOracleComponents(apr, fees, undefined)
+
+      expect(components.map(c => c.component).sort()).to.deep.equal(['apr', 'apy', 'netApr', 'netApy'])
+      expect(components.find(c => c.component === 'apr')!.value).to.equal(apr)
+      expect(components.some(c => c.component.startsWith('current'))).to.equal(false)
+    })
+  })
+
+  describe('readCurrentApr', function() {
+    it('parses the oracle getCurrentApr value', async function() {
+      vi.spyOn(rpcs, 'next').mockReturnValue(
+        { readContract: async () => 5n * 10n ** 16n } as never
+      )
+      const apr = await readCurrentApr(1, vault, 100n, oracle)
+      expect(apr).to.equal(0.05)
+    })
+
+    it('returns undefined when getCurrentApr reverts', async function() {
+      vi.spyOn(rpcs, 'next').mockReturnValue(
+        { readContract: async () => { throw new Error('reverted') } } as never
+      )
+      expect(await readCurrentApr(1, vault, 100n, oracle)).to.equal(undefined)
+    })
+  })
+
+  describe('readApr', function() {
+    it('returns the strategy apr and no currentApr when getStrategyApr succeeds', async function() {
+      vi.spyOn(rpcs, 'next').mockReturnValue(
+        { readContract: async (params: { functionName: string }) => {
+          expect(params.functionName).to.equal('getStrategyApr')
+          return 8n * 10n ** 16n
+        } } as never
+      )
+      // strategy path: currentApr left undefined (the export reads it separately)
+      expect(await readApr(1, vault, 100n, oracle)).to.deep.equal({ apr: 0.08, currentApr: undefined })
+    })
+
+    it('falls back to getCurrentApr when getStrategyApr reverts, and reports it as currentApr', async function() {
+      const revert = new ContractFunctionRevertedError({
+        abi: V3_ORACLE_ABI, functionName: 'getStrategyApr', message: 'reverted'
+      })
+      vi.spyOn(rpcs, 'next').mockReturnValue(
+        { readContract: async (params: { functionName: string }) => {
+          if (params.functionName === 'getStrategyApr') throw revert
+          if (params.functionName === 'getCurrentApr') return 3n * 10n ** 16n
+          throw new Error(`unexpected call: ${params.functionName}`)
+        } } as never
+      )
+      // fallback path: resolved apr IS getCurrentApr, surfaced as currentApr to reuse
+      expect(await readApr(1, vault, 100n, oracle)).to.deep.equal({ apr: 0.03, currentApr: 0.03 })
+    })
   })
 })

--- a/packages/ingest/abis/yearn/3/vault/timeseries/apr-oracle/hook.ts
+++ b/packages/ingest/abis/yearn/3/vault/timeseries/apr-oracle/hook.ts
@@ -23,12 +23,14 @@ function isExpectedStrategyAprFallback(error: unknown): boolean {
   return !!error.walk(cause => cause instanceof ContractFunctionRevertedError)
 }
 
+// On the getStrategyApr-revert fallback the resolved apr IS getCurrentApr, so
+// `currentApr` is surfaced there for callers to reuse instead of re-reading it.
 export async function readApr(
   chainId: number,
   address: `0x${string}`,
   blockNumber: bigint,
   oracleAddress: `0x${string}`,
-): Promise<number | undefined> {
+): Promise<{ apr: number | undefined, currentApr: number | undefined }> {
   try {
     const rawApr = await rpcs.next(chainId).readContract({
       abi: V3_ORACLE_ABI,
@@ -38,14 +40,25 @@ export async function readApr(
       blockNumber,
     })
 
-    return parseApr(rawApr)
+    return { apr: parseApr(rawApr), currentApr: undefined }
   } catch (error) {
     if (!isExpectedStrategyAprFallback(error)) throw error
   }
 
+  // Fallback: regular vaults without a registered strategy oracle revert on
+  // getStrategyApr. getCurrentApr returns APR based on the vault's profit-unlocking rate.
+  const currentApr = await readCurrentApr(chainId, address, blockNumber, oracleAddress)
+  return { apr: currentApr, currentApr }
+}
+
+// Direct getCurrentApr read; tolerates reverts by returning undefined.
+export async function readCurrentApr(
+  chainId: number,
+  address: `0x${string}`,
+  blockNumber: bigint,
+  oracleAddress: `0x${string}`,
+): Promise<number | undefined> {
   try {
-    // Fallback: regular vaults without a registered strategy oracle revert on
-    // getStrategyApr. getCurrentApr returns APR based on the vault's profit-unlocking rate.
     const rawApr = await rpcs.next(chainId).readContract({
       abi: V3_ORACLE_ABI,
       address: oracleAddress,
@@ -53,7 +66,6 @@ export async function readApr(
       args: [address],
       blockNumber,
     })
-    console.warn('🚨', 'apr-oracle getCurrentApr success', chainId, address, String(blockNumber), rawApr)
     return parseApr(rawApr)
   } catch {
     console.warn('🚨', 'apr-oracle getCurrentApr failed', chainId, address, String(blockNumber))
@@ -68,7 +80,13 @@ export async function resolveOracleApr(
   chainId: number,
   address: `0x${string}`,
   data: Data,
-): Promise<{ apr: number, apy: number, blockNumber: bigint } | undefined> {
+): Promise<{
+  apr: number,
+  apy: number,
+  blockNumber: bigint,
+  currentApr: number | undefined,
+  oracleAddress: `0x${string}`,
+} | undefined> {
   const oracleConfig = getOracleConfig(chainId)
   if (!oracleConfig) return undefined
 
@@ -78,10 +96,38 @@ export async function resolveOracleApr(
 
   if (blockNumber < oracleConfig.inceptBlock) return undefined
 
-  const apr = await readApr(chainId, address, blockNumber, oracleConfig.address)
+  const { apr, currentApr } = await readApr(chainId, address, blockNumber, oracleConfig.address)
   if (apr === undefined) return undefined
 
-  return { apr, apy: computeApy(apr), blockNumber }
+  return { apr, apy: computeApy(apr), blockNumber, currentApr, oracleAddress: oracleConfig.address }
+}
+
+// Pure so the component names and APY/net math are unit-testable. current*
+// components are appended only when a getCurrentApr value is present.
+export function buildOracleComponents(
+  apr: number,
+  fees: { management: number, performance: number },
+  currentApr?: number,
+): { component: string, value: number }[] {
+  const netApr = computeNetApr(apr, fees)
+  const components = [
+    { component: 'apr', value: apr },
+    { component: 'apy', value: computeApy(apr) },
+    { component: 'netApr', value: netApr },
+    { component: 'netApy', value: computeApy(netApr) },
+  ]
+
+  if (currentApr !== undefined) {
+    const currentNetApr = computeNetApr(currentApr, fees)
+    components.push(
+      { component: 'currentApr', value: currentApr },
+      { component: 'currentApy', value: computeApy(currentApr) },
+      { component: 'currentNetApr', value: currentNetApr },
+      { component: 'currentNetApy', value: computeApy(currentNetApr) },
+    )
+  }
+
+  return components
 }
 
 export default async function (
@@ -91,7 +137,7 @@ export default async function (
 ): Promise<Output[]> {
   const resolved = await resolveOracleApr(chainId, address, data)
   if (!resolved) return []
-  const { apr, apy, blockNumber } = resolved
+  const { apr, blockNumber, oracleAddress } = resolved
 
   let fees = { management: 0, performance: 0 }
   try {
@@ -101,16 +147,17 @@ export default async function (
     console.warn('🚨', 'apr-oracle fee fetch failed', chainId, address, String(blockNumber), error)
   }
 
-  const netApr = computeNetApr(apr, fees)
+  // Reuse the fallback's getCurrentApr when present; otherwise read it (the
+  // strategy path succeeded, so current APR is a distinct value).
+  const currentApr = resolved.currentApr !== undefined
+    ? resolved.currentApr
+    : await readCurrentApr(chainId, address, blockNumber, oracleAddress)
 
   const output = (component: string, value: number): Output => ({
     label: outputLabel, component, value, chainId, address, blockNumber, blockTime: data.blockTime,
   })
 
-  return OutputSchema.array().parse([
-    output('apr', apr),
-    output('apy', apy),
-    output('netApr', netApr),
-    output('netApy', computeApy(netApr)),
-  ])
+  return OutputSchema.array().parse(
+    buildOracleComponents(apr, fees, currentApr).map(c => output(c.component, c.value)),
+  )
 }

--- a/packages/ingest/apr-oracle-current.containers.spec.ts
+++ b/packages/ingest/apr-oracle-current.containers.spec.ts
@@ -1,0 +1,128 @@
+import { expect } from 'chai'
+import { Pool } from 'pg'
+import { getAddress } from 'viem'
+import { TestEnvironment, createTestPool } from 'lib/helpers/containers'
+import { buildOracleComponents } from './abis/yearn/3/vault/timeseries/apr-oracle/hook'
+
+// Issue #437: prove the new apr-oracle currentApr components flow through the
+// untouched read pipeline (output -> refresh job -> Redis -> REST route, and
+// GraphQL DB-direct) with no schema/cache change. Seed rows come from the
+// production buildOracleComponents so the assertions track what the hook emits.
+
+const CHAIN_ID = 1
+const LABEL = 'apr-oracle'
+const VAULT = getAddress('0x6faf8b7ffee3306efcfc2ba9fec912b4d49834c1')
+
+const APR = 0.1
+const CURRENT_APR = 0.2
+const FEES = { management: 0.02, performance: 0.1 }
+const COMPONENTS = buildOracleComponents(APR, FEES, CURRENT_APR)
+
+function componentValue(component: string): number {
+  const found = COMPONENTS.find(c => c.component === component)
+  if (!found) throw new Error(`missing seed component ${component}`)
+  return found.value
+}
+
+type Point = { time: number; component: string; value: number | string }
+
+async function seedTimeseries(pool: Pool) {
+  await pool.query(
+    `INSERT INTO thing (chain_id, address, label, defaults)
+     VALUES ($1, $2, 'vault', $3)`,
+    [CHAIN_ID, VAULT, JSON.stringify({ origin: 'yearn', apiVersion: '3.0.4', inceptBlock: 1 })],
+  )
+
+  const blockTime = new Date()
+  for (const { component, value } of COMPONENTS) {
+    await pool.query(
+      `INSERT INTO output (chain_id, address, label, component, value, block_number, block_time, series_time)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $7)`,
+      [CHAIN_ID, VAULT, LABEL, component, value, 1, blockTime],
+    )
+  }
+}
+
+async function fetchRest(webUrl: string, query: string): Promise<Point[]> {
+  const res = await fetch(
+    `${webUrl}/api/rest/timeseries/apr-oracle/${CHAIN_ID}/${VAULT.toLowerCase()}${query}`,
+  )
+  expect(res.status).to.equal(200)
+  return await res.json() as Point[]
+}
+
+async function fetchGql(webUrl: string, component: string): Promise<Point[]> {
+  const res = await fetch(`${webUrl}/api/gql`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      query: `query($chainId: Int!, $address: String!, $label: String!, $component: String) {
+        timeseries(chainId: $chainId, address: $address, label: $label, component: $component) {
+          component
+          value
+          time
+        }
+      }`,
+      variables: { chainId: CHAIN_ID, address: VAULT, label: LABEL, component },
+    }),
+  })
+  expect(res.status).to.equal(200)
+  const body = await res.json() as { data?: { timeseries?: Point[] }, errors?: unknown }
+  expect(body.errors, JSON.stringify(body.errors)).to.equal(undefined)
+  return body.data?.timeseries ?? []
+}
+
+describe('e2e: apr-oracle currentApr exposure (issue #437)', () => {
+  let env: TestEnvironment
+  let webUrl: string
+  let pool: Pool
+
+  beforeAll(async () => {
+    env = new TestEnvironment({
+      // Web only — seed the output rows directly, no ingest/RPC. POSTGRES_SSL=''
+      // makes the web db pool skip SSL against the test Postgres.
+      web: { env: { POSTGRES_SSL: '' } },
+    })
+
+    const result = await env.start()
+    webUrl = result.webUrl
+    pool = createTestPool()
+
+    await seedTimeseries(pool)
+
+    await env.runScript('packages/web/app/api/rest/timeseries/refresh-historical.ts')
+    await env.runScript('packages/web/app/api/rest/timeseries/refresh.ts')
+  })
+
+  afterAll(async () => {
+    await pool?.end()
+    await env?.stop()
+  })
+
+  it('REST defaults apr-oracle to the apr component (backward compatible)', async () => {
+    const points = await fetchRest(webUrl, '')
+    expect(points.map(p => p.component)).to.deep.equal(['apr'])
+    expect(Number(points[0].value)).to.be.closeTo(componentValue('apr'), 1e-9)
+  })
+
+  it('REST exposes currentApr via ?components=currentApr', async () => {
+    const points = await fetchRest(webUrl, '?components=currentApr')
+    expect(points.map(p => p.component)).to.deep.equal(['currentApr'])
+    expect(Number(points[0].value)).to.be.closeTo(componentValue('currentApr'), 1e-9)
+  })
+
+  it('REST returns both series for repeated components (apr + currentApr)', async () => {
+    const points = await fetchRest(webUrl, '?components=apr&components=currentApr')
+    const byComponent = new Map(points.map(p => [p.component, Number(p.value)]))
+    expect([...byComponent.keys()].sort()).to.deep.equal(['apr', 'currentApr'])
+    expect(byComponent.get('apr')).to.be.closeTo(componentValue('apr'), 1e-9)
+    expect(byComponent.get('currentApr')).to.be.closeTo(componentValue('currentApr'), 1e-9)
+  })
+
+  it('GraphQL timeseries(label: "apr-oracle", component: "currentApr") works without a migration', async () => {
+    const points = await fetchGql(webUrl, 'currentApr')
+    expect(points.length).to.be.greaterThan(0)
+    expect(points.every(p => p.component === 'currentApr')).to.equal(true)
+    expect(Number(points[0].value)).to.be.closeTo(componentValue('currentApr'), 1e-9)
+  })
+})

--- a/packages/scripts/src/backfill-apr-oracle-current/README.md
+++ b/packages/scripts/src/backfill-apr-oracle-current/README.md
@@ -1,0 +1,45 @@
+# backfill-apr-oracle-current
+
+Backfill the apr-oracle `currentApr` components (issue #437) into historical output rows.
+
+## Background
+
+The apr-oracle timeseries hook now reads the oracle's `getCurrentApr(vault)` as its own components alongside the resolved strategy APR:
+
+- v3 vaults: `currentApr`, `currentApy`, `currentNetApr`, `currentNetApy`
+- erc4626 vaults: `currentApr`, `currentApy` (net needs the v3 fee path)
+
+Rows written before this change only have `apr`/`apy`/`netApr`/`netApy`. This backfill adds the `current*` components to those historical points.
+
+## Scripts
+
+### 1. compute.ts
+
+Finds every apr-oracle point (anchored on the `apr` component) that has no `currentApr` row at the same `series_time`, then **replays the real apr-oracle hook** at each point so staged values match production exactly. It picks the v3 or erc4626 hook per vault (from the `thing` classification), and stages only the `current*` components — `apr`/`apy`/`netApr`/`netApy` are left untouched. Points where `getCurrentApr` reverts stage nothing.
+
+- Writes to `output_temp_apr_oracle_current_backfill`
+- Idempotent: points already carrying `currentApr` are skipped, so re-runs resume
+
+```
+bun packages/scripts/src/backfill-apr-oracle-current/compute.ts
+```
+
+### 2. upsert.ts
+
+Promotes the staged rows from the temp table into the production `output` table, then drops the temp table.
+
+```
+bun packages/scripts/src/backfill-apr-oracle-current/upsert.ts
+```
+
+## Workflow
+
+```
+compute.ts  -->  upsert.ts
+```
+
+1. Run `compute.ts` to stage the new `current*` rows.
+2. Run `upsert.ts` to promote them into `output`.
+3. Run the REST timeseries refresh jobs so Redis holds the new `currentApr` history:
+   - `packages/web/app/api/rest/timeseries/refresh-historical.ts`
+   - `packages/web/app/api/rest/timeseries/refresh.ts`

--- a/packages/scripts/src/backfill-apr-oracle-current/compute.ts
+++ b/packages/scripts/src/backfill-apr-oracle-current/compute.ts
@@ -1,0 +1,238 @@
+import 'lib/global'
+
+import aprOracleHookErc4626 from 'ingest/abis/erc4626/timeseries/apr-oracle/hook'
+import aprOracleHookV3 from 'ingest/abis/yearn/3/vault/timeseries/apr-oracle/hook'
+import db from 'ingest/db'
+import { rpcs } from 'ingest/rpcs'
+import type { Output } from 'lib/types'
+import { insertTempBatch, resetTempTable, type TempRow } from '../backfill-shared/tempTable'
+
+/**
+ * Backfill the apr-oracle currentApr components (issue #437) into historical
+ * rows. The hook now reads the oracle's getCurrentApr(vault) as its own
+ * timeseries components; existing rows predate that read and need to be filled.
+ *
+ * - Finds every apr-oracle data point (anchored on the `apr` component) that
+ *   does not yet have a `currentApr` row at the same series_time.
+ * - Replays the real apr-oracle hook at each point so the staged values match
+ *   production exactly. v3 vaults replay yearn/3/vault (currentApr/currentApy +
+ *   currentNetApr/currentNetApy); erc4626 vaults replay erc4626 (currentApr/
+ *   currentApy only — net needs the v3 fee path). getCurrentApr reverts stage
+ *   nothing for that point.
+ * - Stages only the current* components (apr/apy/netApr/netApy are untouched).
+ *
+ * Run upsert.ts to promote results to the output table.
+ */
+
+const TEMP_TABLE = 'output_temp_apr_oracle_current_backfill'
+const CONCURRENCY = 150
+
+const STAGED_V3 = new Set(['currentApr', 'currentApy', 'currentNetApr', 'currentNetApy'])
+const STAGED_ERC4626 = new Set(['currentApr', 'currentApy'])
+
+type Kind = 'v3' | 'erc4626'
+
+type Affected = {
+  chain_id: number
+  address: `0x${string}`
+  kind: Kind
+  series_times: bigint[]
+}
+
+// v3 vs erc4626 mirror the config/abis.yaml `things` filters: v3 vaults are
+// yearn/3/vault (apiVersion >= 3, non-ydaemon origin), erc4626 vaults carry
+// erc4626=true and are not yearn. The kind picks which hook to replay, which in
+// turn decides whether currentNet* components exist.
+function classifyVault(defaults: Record<string, unknown> | null): Kind | undefined {
+  if (!defaults) return undefined
+  const truthy = (v: unknown) => v === true || v === 'true'
+  if (truthy(defaults.erc4626) && !truthy(defaults.yearn)) return 'erc4626'
+  const apiVersion = typeof defaults.apiVersion === 'string' ? defaults.apiVersion : undefined
+  const major = apiVersion ? parseInt(apiVersion.split('.')[0], 10) : NaN
+  if (Number.isFinite(major) && major >= 3 && defaults.origin !== 'ydaemon') return 'v3'
+  return undefined
+}
+
+async function loadVaultKinds(): Promise<Map<string, Kind>> {
+  const { rows } = await db.query(`
+    SELECT chain_id, address, defaults FROM thing WHERE label = 'vault'
+  `)
+  const kinds = new Map<string, Kind>()
+  for (const r of rows) {
+    const kind = classifyVault(r.defaults)
+    if (kind) kinds.set(`${r.chain_id}:${r.address.toLowerCase()}`, kind)
+  }
+  return kinds
+}
+
+async function findAffected(kinds: Map<string, Kind>): Promise<{ affected: Affected[], skippedUnknown: number }> {
+  console.log('querying apr-oracle points missing currentApr...')
+  const queryStart = Date.now()
+  // Anchor on the `apr` component: every apr-oracle point has exactly one apr
+  // row, so this yields one row per (vault, series_time) point. NOT EXISTS keeps
+  // the backfill idempotent — points already carrying currentApr are skipped.
+  const { rows } = await db.query(`
+    SELECT o.chain_id, o.address, EXTRACT(EPOCH FROM o.series_time)::bigint AS series_time_epoch
+    FROM public.output o
+    WHERE o.label = 'apr-oracle' AND o.component = 'apr'
+      AND NOT EXISTS (
+        SELECT 1 FROM public.output c
+        WHERE c.chain_id = o.chain_id AND c.address = o.address
+          AND c.label = 'apr-oracle' AND c.component = 'currentApr'
+          AND c.series_time = o.series_time
+      )
+    ORDER BY o.chain_id, o.address, o.series_time
+  `)
+  console.log(`query returned ${rows.length} points in ${((Date.now() - queryStart) / 1000).toFixed(2)}s`)
+
+  const grouped = new Map<string, Affected>()
+  let skippedUnknown = 0
+
+  for (const r of rows) {
+    const vaultKey = `${r.chain_id}:${r.address.toLowerCase()}`
+    const kind = kinds.get(vaultKey)
+    if (!kind) {
+      skippedUnknown++
+      continue
+    }
+    const seriesTime = BigInt(r.series_time_epoch)
+    const existing = grouped.get(vaultKey)
+    if (existing) {
+      existing.series_times.push(seriesTime)
+    } else {
+      grouped.set(vaultKey, { chain_id: r.chain_id, address: r.address, kind, series_times: [seriesTime] })
+    }
+  }
+
+  return { affected: [...grouped.values()], skippedUnknown }
+}
+
+function outputToTempRow(output: Output): TempRow | null {
+  if (output.component == null || output.value == null) return null
+  // The hook echoes the blockTime we pass in, so series_time/block_time both
+  // become the series-bucket timestamp — matching the temp-table primary key
+  // (chain_id, address, label, component, series_time) used on upsert.
+  const seriesDate = new Date(Number(output.blockTime) * 1000)
+  return {
+    chain_id: output.chainId,
+    address: output.address,
+    label: output.label,
+    component: output.component,
+    value: output.value,
+    block_number: output.blockNumber,
+    block_time: seriesDate,
+    series_time: seriesDate,
+  }
+}
+
+async function replayVault(vault: Affected) {
+  const hook = vault.kind === 'v3' ? aprOracleHookV3 : aprOracleHookErc4626
+  const abiPath = vault.kind === 'v3' ? 'yearn/3/vault' : 'erc4626'
+  const staged = vault.kind === 'v3' ? STAGED_V3 : STAGED_ERC4626
+
+  const rows: TempRow[] = []
+  let errors = 0
+  const total = vault.series_times.length
+  const tag = `${vault.chain_id}:${vault.address} (${vault.kind})`
+  const logEvery = Math.max(1, Math.floor(total / 10))
+
+  console.log(`  ${tag} start series=${total}`)
+
+  for (let i = 0; i < total; i++) {
+    const seriesTime = vault.series_times[i]
+    try {
+      const outputs = await hook(vault.chain_id, vault.address, {
+        abiPath,
+        chainId: vault.chain_id,
+        address: vault.address,
+        outputLabel: 'apr-oracle',
+        blockTime: seriesTime,
+      })
+      for (const output of outputs) {
+        if (!output.component || !staged.has(output.component)) continue
+        const row = outputToTempRow(output)
+        if (row) rows.push(row)
+      }
+    } catch (error) {
+      errors++
+      console.error(`  ${tag} error @ ${seriesTime}:`, error instanceof Error ? error.message : error)
+    }
+
+    if ((i + 1) % logEvery === 0 || i + 1 === total) {
+      console.log(`  ${tag} progress ${i + 1}/${total} staged=${rows.length} errors=${errors}`)
+    }
+  }
+
+  if (rows.length > 0) {
+    const BATCH = 500
+    for (let i = 0; i < rows.length; i += BATCH) {
+      await insertTempBatch(TEMP_TABLE, rows.slice(i, i + BATCH))
+    }
+  }
+
+  console.log(`  ${tag} done series=${total} staged=${rows.length} errors=${errors}`)
+  return { staged: rows.length, errors }
+}
+
+async function main() {
+  const startTime = Date.now()
+
+  try {
+    await rpcs.up()
+    await resetTempTable(TEMP_TABLE)
+    console.log(`reset temp table ${TEMP_TABLE}`)
+
+    const kinds = await loadVaultKinds()
+    console.log(`classified ${kinds.size} vault things`)
+
+    const { affected, skippedUnknown } = await findAffected(kinds)
+    const uniquePoints = affected.reduce((acc, v) => acc + v.series_times.length, 0)
+    const v3Count = affected.filter(v => v.kind === 'v3').length
+    const erc4626Count = affected.filter(v => v.kind === 'erc4626').length
+    console.log(`To replay: ${uniquePoints} points across ${affected.length} vaults (v3=${v3Count} erc4626=${erc4626Count})`)
+    console.log(`Skipped (unclassified vault): ${skippedUnknown} points\n`)
+
+    if (affected.length === 0) {
+      console.log('nothing to backfill.')
+      return
+    }
+
+    let totalStaged = 0
+    let totalErrors = 0
+    let completedVaults = 0
+
+    for (let i = 0; i < affected.length; i += CONCURRENCY) {
+      const batch = affected.slice(i, i + CONCURRENCY)
+      const batchStart = Date.now()
+      console.log(`\nbatch ${i / CONCURRENCY + 1}/${Math.ceil(affected.length / CONCURRENCY)}: vaults ${i + 1}-${Math.min(i + CONCURRENCY, affected.length)}/${affected.length}`)
+      const results = await Promise.all(batch.map(replayVault))
+      for (const r of results) {
+        totalStaged += r.staged
+        totalErrors += r.errors
+      }
+      completedVaults += batch.length
+      const elapsed = (Date.now() - startTime) / 1000
+      const rate = completedVaults / elapsed
+      const remaining = affected.length - completedVaults
+      const eta = rate > 0 ? (remaining / rate).toFixed(0) : '?'
+      console.log(`batch done in ${((Date.now() - batchStart) / 1000).toFixed(2)}s | progress ${completedVaults}/${affected.length} vaults | staged=${totalStaged} errors=${totalErrors} | eta=${eta}s`)
+    }
+
+    const duration = ((Date.now() - startTime) / 1000).toFixed(2)
+    console.log('\n=== Summary ===')
+    console.log(`Points to backfill:  ${uniquePoints}`)
+    console.log(`Vaults replayed:     ${affected.length} (v3=${v3Count} erc4626=${erc4626Count})`)
+    console.log(`Output rows staged:  ${totalStaged}`)
+    console.log(`Skipped points:      ${skippedUnknown} (unclassified vault)`)
+    console.log(`Errors:              ${totalErrors}`)
+    console.log(`Duration:            ${duration}s`)
+  } finally {
+    await rpcs.down()
+    await db.end()
+  }
+}
+
+main().catch(error => {
+  console.error('Fatal error:', error)
+  process.exit(1)
+})

--- a/packages/scripts/src/backfill-apr-oracle-current/upsert.ts
+++ b/packages/scripts/src/backfill-apr-oracle-current/upsert.ts
@@ -1,0 +1,24 @@
+import 'lib/global'
+
+import db from 'ingest/db'
+import { promoteTempTable } from '../backfill-shared/upsert'
+
+/**
+ * Phase 2: Promote the staged apr-oracle current* components from the temp
+ * table into the production output table. Run compute.ts first.
+ */
+
+const TEMP_TABLE = 'output_temp_apr_oracle_current_backfill'
+
+async function main() {
+  try {
+    await promoteTempTable(TEMP_TABLE)
+  } finally {
+    await db.end()
+  }
+}
+
+main().catch(error => {
+  console.error('Fatal error:', error)
+  process.exit(1)
+})

--- a/packages/scripts/src/backfill-apr-oracle-getCurrentApr/compute.ts
+++ b/packages/scripts/src/backfill-apr-oracle-getCurrentApr/compute.ts
@@ -99,7 +99,7 @@ async function computeVaultOracle(row: AffectedRow): Promise<TempRow[]> {
   if (!oracleConfig) return []
   const blockNumber = BigInt(row.block_number)
 
-  const apr = await readApr(row.chain_id, row.address, blockNumber, oracleConfig.address)
+  const { apr } = await readApr(row.chain_id, row.address, blockNumber, oracleConfig.address)
   // Intentionally falsy check: skip rows where the oracle still returns 0.
   if (!apr) return []
 


### PR DESCRIPTION
Closes #437.

## What

Index the APR oracle's `getCurrentApr(vault)` as its own `apr-oracle` timeseries components, so the vault-level current APR can be compared against the resolved/strategy APR Kong already stores — without changing the existing `apr`/`apy` semantics or requiring a DB migration.

For v3 vaults the hook now emits, under the existing `apr-oracle` label:
- `currentApr`, `currentApy`
- `currentNetApr`, `currentNetApy` (net of vault fees, via the same fee path as the resolved APR)

These are read independently of `getStrategyApr`, so the current APR is captured even when a strategy oracle is present. A `getCurrentApr` revert omits only the `current*` components — the resolved `apr`/`apy`/`netApr`/`netApy` output is never dropped.

## Details

- `packages/ingest/abis/yearn/3/vault/timeseries/apr-oracle/hook.ts`
  - `readCurrentApr()` reads `getCurrentApr` directly, tolerating reverts.
  - `readApr()` now reports the `currentApr` it already fetched on its `getStrategyApr`-revert fallback path, so regular (strategy-oracle-less) vaults don't read the oracle twice.
  - A pure `buildOracleComponents()` builds the component set (testable without RPC).
- `packages/ingest/abis/erc4626/timeseries/apr-oracle/hook.ts` — stays `apr`/`apy` only; documented why (`current*` is a v3 strategy-vs-current comparison aid).
- `docs/rest.md` — documents the new `apr-oracle` components and comparison request shapes.

## Consumer-contract decision

The new components are **timeseries-only**. Snapshot/API `performance.oracle` (`helpers/apy-apr.ts`, v3 `snapshot/hook.ts`) is unchanged — it keeps serving the resolved `apr`/`apy`/`netAPR`/`netAPY`. The `current*` series are queried directly from timeseries for comparison.

No DB migration and no web code change: the `output` key already includes `component`; both REST refresh jobs cache every component row unfiltered, and the timeseries route passes requested `components` through with no allowlist.

## Tests

- Unit (ingest): `buildOracleComponents` component names + APY/net math, current-failure preserving the resolved output, `readCurrentApr` success/revert, `readApr` revert→fallback.
- Unit (web): the REST timeseries route returns `currentApr` via `?components=currentApr`, both series via repeated components, and stays `apr` by default.
- Integration (testcontainers): seeds `output` (via the production `buildOracleComponents`) + `thing`, runs the real refresh jobs, and asserts `currentApr` is exposed through both the REST cache path and the GraphQL DB-direct path.

After deploy, the timeseries refresh jobs need to run once so Redis holds the new `currentApr` history.
