### PR TITLE
fix(ingest): default estimated apr components so composition parse survives netAPR/netAPY-only rows

### DIFF
--- a/packages/ingest/abis/yearn/3/vault/snapshot/hook.spec.ts
+++ b/packages/ingest/abis/yearn/3/vault/snapshot/hook.spec.ts
@@ -61,4 +61,64 @@ describe('abis/yearn/3/vault/snapshot/hook', function() {
       globalThis.fetch = originalFetch
     }
   })
+
+  it('parses composition when estimated apr rows have only netAPR/netAPY components', async function() {
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = (async () => ({
+      json: async () => []
+    })) as unknown as typeof fetch
+
+    const chainId = 1337
+    const vault = '0x3000000000000000000000000000000000000003'
+    const strategy = '0x4000000000000000000000000000000000000004' as `0x${string}`
+    const latest = Math.floor(Date.now() / 1000)
+
+    const outputs = [
+      { component: 'netAPR', value: 0.03 },
+      { component: 'netAPY', value: 0.031 }
+    ]
+
+    for (const output of outputs) {
+      const outputData = {
+        chain_id: chainId,
+        address: strategy,
+        label: 'katana-estimated-apr',
+        component: output.component,
+        value: output.value,
+        block_number: latest,
+        block_time: latest,
+        series_time: latest
+      }
+      await db.query(toUpsertSql('output', 'chain_id, address, label, component, series_time', outputData), Object.values(outputData))
+    }
+
+    const debts = [{
+      strategy,
+      activation: 0n,
+      lastReport: 0n,
+      currentDebt: 1n,
+      currentDebtUsd: 1,
+      maxDebt: 1n,
+      maxDebtUsd: 1,
+      performanceFee: 0n,
+      totalGain: 0n,
+      totalGainUsd: 0,
+      totalLoss: 0n,
+      totalLossUsd: 0,
+      targetDebtRatio: undefined,
+      maxDebtRatio: undefined
+    }]
+
+    try {
+      const composition = await extractComposition(chainId, vault, [strategy], debts, 'katana-estimated-apr')
+
+      expect(composition).to.have.length(1)
+      expect(composition[0].performance?.estimated?.type).to.equal('katana-estimated-apr')
+      expect(composition[0].performance?.estimated?.apr).to.equal(0.03)
+      expect(composition[0].performance?.estimated?.apy).to.equal(0.031)
+      expect(composition[0].performance?.estimated?.components).to.deep.equal({})
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
 })

--- a/packages/ingest/abis/yearn/3/vault/snapshot/hook.ts
+++ b/packages/ingest/abis/yearn/3/vault/snapshot/hook.ts
@@ -452,14 +452,10 @@ async function fetchStrategyPerformance(
       if (row.component === 'monthlyNet') perf.historical.monthlyNet = row.value ?? null
       if (row.component === 'inceptionNet') perf.historical.inceptionNet = row.value ?? null
     } else if (estimatedAprLabel && row.label === estimatedAprLabel) {
-      if (!perf.estimated) perf.estimated = { type: estimatedAprLabel }
+      if (!perf.estimated) perf.estimated = { type: estimatedAprLabel, components: {} }
       if (row.component === 'netAPR') perf.estimated.apr = row.value
       else if (row.component === 'netAPY') perf.estimated.apy = row.value
-      else if (!perf.estimated.components) {
-        perf.estimated.components = { [row.component]: row.value }
-      } else {
-        perf.estimated.components[row.component] = row.value
-      }
+      else perf.estimated.components[row.component] = row.value
     }
   }
 
@@ -548,7 +544,13 @@ export async function extractComposition(
     })
   }
 
-  return CompositionSchema.array().parse(composition)
+  try {
+    return CompositionSchema.array().parse(composition)
+  } catch(err) {
+    console.error('🤬', '!extractComposition', err)
+    sentry.captureException(err, { tags: { component: 'ingest', hook: 'vault.snapshot.extractComposition' }, extra: { chainId, vault } })
+    throw err
+  }
 }
 
 async function extractLockerMeta(chainId: number, accountant: `0x${string}`) {

--- a/packages/ingest/abis/yearn/3/vault/snapshot/hook.ts
+++ b/packages/ingest/abis/yearn/3/vault/snapshot/hook.ts
@@ -189,7 +189,6 @@ export async function projectStrategies(chainId: number, vault: `0x${string}`, b
   WHERE chain_id = $1 AND address = $2 AND signature = $3 AND (block_number <= $4 OR $4 IS NULL)
   ORDER BY block_number ASC, log_index ASC`,
   [chainId, vault, topic, blockNumber])
-  if(events.rows.length === 0) return []
   const result: `0x${string}`[] = []
   for (const event of events.rows) {
     if (changeType[event.change_type] === 'add') {

--- a/packages/ingest/extract/webhook.ts
+++ b/packages/ingest/extract/webhook.ts
@@ -100,7 +100,13 @@ export function selectValidOutputs(outputs: Output[], data: Data): Output[] {
     return []
   }
 
-  const grouped = Map.groupBy(outputs, o => `${o.chainId}:${o.address.toLowerCase()}`)
+  const grouped = new Map<string, typeof outputs>()
+  for (const o of outputs) {
+    const key = `${o.chainId}:${o.address.toLowerCase()}`
+    const group = grouped.get(key)
+    if (group) group.push(o)
+    else grouped.set(key, [o])
+  }
   if (grouped.size > MAX_OUTPUT_GROUPS) {
     console.error(`🤬 ${subscription.id} skipping response: ${grouped.size} output groups > ${MAX_OUTPUT_GROUPS}`)
     sentry.captureMessage('WEBHOOK_OUTPUT_GROUPS_OVER_LIMIT', {

--- a/packages/ingest/katana-estimated-apr.containers.spec.ts
+++ b/packages/ingest/katana-estimated-apr.containers.spec.ts
@@ -1,53 +1,73 @@
 import { expect } from 'chai'
-import { Pool } from 'pg'
 import { TestEnvironment, createTestPool, pollForRow, triggerFanout } from 'lib/helpers/containers'
+import { Pool } from 'pg'
 
-// PR #443: netAPR/netAPY-only estimated-apr rows froze vault snapshots.
+// Reported issue: on katana, the REST snapshot of allocator vault 0x80c34B…
+// served strategy 0x6E0D… (Morpho Yearn OG v2 USDC Compounder) with no
+// performance.estimated at all — its strategyRewardsAPR / katRewardsAPR was
+// missing — even though the katana-apr service reports it.
 //
-// The katana APR service emits 'katana-estimated-apr' rows for both allocator
-// vaults and their strategies. When a strategy's latest emission carries ONLY
-// netAPR/netAPY (no other components), fetchStrategyPerformance used to build
-// estimated as {type, apr, apy} without the components key required by
-// CompositionSchema. extractComposition then threw a ZodError on every
-// extract.snapshot run, so the parent vault's snapshot was never rewritten and
-// the REST API served stale composition with no estimated block (katana vaults
-// 0x80c34B…/0x9A6bd7… were stuck for 3 days).
+// Root cause (PR #443): a sibling strategy of the parent emitted a
+// katana-estimated-apr row-set with only netAPR/netAPY. fetchStrategyPerformance
+// built its estimated as {type, apr, apy} without the components key required by
+// CompositionSchema, so extractComposition threw on every extract.snapshot run.
+// The parent's snapshot was never rewritten, so NONE of its strategies' estimated
+// blocks (including 0x6E0D's katRewardsAPR) reached the REST response.
 //
-// This covers what the unit test can't: the full ingest -> snapshot -> REST
-// pipeline. Under the unfixed hook the parent's composition never assembles
-// (the gate below times out); with the fix the composition entry lands carrying
-// estimated with components: {}. The pure mapping logic is unit-tested in
-// abis/yearn/3/vault/snapshot/hook.spec.ts. Runs on mainnet addresses because
-// the bug is label-driven, not chain-specific.
+// This drives the full ingest -> snapshot -> REST pipeline on the real katana
+// chain (747474) using the reported addresses. Estimated-apr rows are seeded
+// (live katana-apr webhook currently returns [] for these vaults): parent +
+// STRATEGY with katRewardsAPR, and a queue sibling with netAPR/netAPY-only
+// (the prod freeze shape). Asserts 0x6E0D's composition entry surfaces
+// katRewardsAPR. Under the unfixed hook the sibling freezes composition and the
+// gate times out; with the fix the rewards APR is present. Pure mapping logic
+// is unit-tested in abis/yearn/3/vault/snapshot/hook.spec.ts.
 
-const CHAIN_ID = 1
+const CHAIN_ID = 747474
 const LABEL = 'katana-estimated-apr'
 
-// itself a v3 vault AND a strategy of PARENT_VAULT; gets netAPR/netAPY-only
-// rows -> the shape that used to break the parent's composition parse.
-const STRATEGY_VAULT = '0x0e297dE4005883C757c9F09fdF7cF1363C20e626'
-const STRATEGY_INCEPT = 21176924
+// the reported strategy: a v3 vault AND a strategy of PARENT_VAULT, whose
+// katana-apr emission carries katRewardsAPR.
+const STRATEGY_VAULT = '0x6E0D2096BA6A3fe35c8186077F81BEf2c33E5bed'
+const STRATEGY_INCEPT = 37839045
 
-// embeds STRATEGY_VAULT in its composition; its own rows give it a top-level
-// estimate, which sets estimatedAprLabel for the composition path.
-const PARENT_VAULT = '0xAe7d8Db82480E6d8e3873ecbF22cf17b3D8A7308'
-const PARENT_INCEPT = 21176924
+// the allocator vault that embeds STRATEGY_VAULT in its composition.
+const PARENT_VAULT = '0x80c34bd3a3569e126e7055831036aa7b212cb159'
+// Capped near chain head to skip ~33M blocks of history. Composition is read
+// from the vault's current on-chain state (get_default_queue / debts), not from
+// replayed events, and the estimated-apr rows come from the live webhook, so a
+// recent incept still assembles the full composition.
+const PARENT_INCEPT = 37839045
+
+// sibling already in parent get_default_queue. Only indexed sources hit the
+// live webhook; seed this one with the prod failure shape (netAPR/netAPY only)
+// so unfixed extractComposition still freezes the parent snapshot.
+const SIBLING_STRATEGY = '0xD46dFDAA7cAA8739B0e3274e2C085dFFc8d4776A'
 
 function source(address: string, inceptBlock: number) {
   return { chainId: CHAIN_ID, address, inceptBlock }
 }
+
+// Both vaults share USDC on katana. manuals alone never fill asset/decimals
+// (registry/StrategyChanged do in full history); without them tvl Zod-fails.
+const ASSET = '0x203a662b0bd271a6ed5a60edfbd04bfce608fd36'
+const DECIMALS = 6
 
 function manual(address: string, inceptBlock: number) {
   return {
     chainId: CHAIN_ID,
     address,
     label: 'vault',
-    defaults: { inceptBlock, origin: 'yearn', apiVersion: '3.0.4' },
+    defaults: {
+      inceptBlock,
+      origin: 'yearn',
+      apiVersion: '3.0.4',
+      asset: ASSET,
+      decimals: DECIMALS,
+    },
   }
 }
 
-// All components of one emission MUST share a single block_time so
-// getLatestEstimatedAprV3 selects them as one row-set.
 async function seedOutput(pool: Pool, address: string, components: Record<string, number>) {
   const blockTime = new Date()
   for (const [component, value] of Object.entries(components)) {
@@ -71,9 +91,10 @@ async function fetchRestSnapshot(webUrl: string, address: string) {
 }
 
 // Gate: the parent's composition entry for the strategy carries the estimated
-// block. Under the unfixed hook this NEVER holds — extractComposition throws
-// before load, the snapshot is never rewritten — so a timeout here is the
-// regression firing.
+// block from seeded katana-estimated-apr rows. Under the unfixed hook a sibling
+// strategy's netAPR/netAPY-only rows make extractComposition throw before load,
+// so the parent snapshot is never rewritten — this never holds and the poll
+// times out, which is the regression firing.
 // Params: [chainId($1), parent($2), strategy($3), label($4)].
 const COMPOSITION_ASSEMBLED_SQL = `
   SELECT 1 FROM snapshot s JOIN thing t
@@ -86,7 +107,7 @@ const COMPOSITION_ASSEMBLED_SQL = `
     )
 `
 
-describe('e2e: netAPR/netAPY-only estimated-apr rows must not freeze snapshots (PR #443)', () => {
+describe('e2e: katana strategy rewards APR surfaces in parent composition (PR #443)', () => {
   let env: TestEnvironment
   let webUrl: string
   let pool: Pool
@@ -94,7 +115,7 @@ describe('e2e: netAPR/netAPY-only estimated-apr rows must not freeze snapshots (
   beforeAll(async () => {
     env = new TestEnvironment({
       configs: {
-        chains: ['mainnet'],
+        chains: ['katana'],
         abis: [{
           abiPath: 'yearn/3/vault',
           sources: [
@@ -115,14 +136,20 @@ describe('e2e: netAPR/netAPY-only estimated-apr rows must not freeze snapshots (
     webUrl = result.webUrl
     pool = createTestPool()
 
-    // Seed BEFORE the snapshot hooks run. The strategy gets the prod failure
-    // shape: netAPR/netAPY only, nothing else.
-    await seedOutput(pool, PARENT_VAULT, { netAPR: 0.05, netAPY: 0.051 })
-    await seedOutput(pool, STRATEGY_VAULT, { netAPR: 0.03, netAPY: 0.031 })
+    // Seed estimated-apr: sibling = freeze shape; strategy carries katRewardsAPR;
+    // parent top-level estimate sets estimatedAprLabel for composition path.
+    // (Live S_KATANA_APR webhook returns [] for these vaults as of 2026-07-20.)
+    await seedOutput(pool, SIBLING_STRATEGY, { netAPR: 0.03, netAPY: 0.031 })
+    await seedOutput(pool, STRATEGY_VAULT, {
+      netAPR: 0.05,
+      netAPY: 0.051,
+      katRewardsAPR: 0.012,
+    })
+    await seedOutput(pool, PARENT_VAULT, { netAPR: 0.04, netAPY: 0.041 })
 
     // Drive fanout until the parent's composition carries the strategy's
-    // estimated block; composition needs the strategy snapshot to land first,
-    // so re-trigger on each empty poll.
+    // estimated block; needs a parent re-snapshot after seeds, so re-trigger
+    // on each empty poll.
     await pollForRow(
       pool,
       COMPOSITION_ASSEMBLED_SQL,
@@ -130,9 +157,12 @@ describe('e2e: netAPR/netAPY-only estimated-apr rows must not freeze snapshots (
       { timeoutMs: 15 * 60_000, intervalMs: 15_000, onTick: () => triggerFanout('abis', {}) },
     )
 
-    // StrategyChanged registers every strategy as a vault thing without a name.
-    // Test abis have no `things` filter, so those never get snapshotted and
-    // refresh-vaults fails Zod on name. Drop orphans; only manuals matter here.
+    // StrategyChanged registers every strategy as a nameless vault thing. Test
+    // abis have no `things` filter so those never get snapshotted, and
+    // refresh-vaults Zod-fails on the missing name. Stop ingest first so
+    // historical replay can't re-create orphans between the delete and refresh,
+    // then drop them; only the manuals matter here.
+    await result.ingestContainer?.stop()
     await pool.query(
       `DELETE FROM thing
        WHERE label = 'vault'
@@ -148,20 +178,18 @@ describe('e2e: netAPR/netAPY-only estimated-apr rows must not freeze snapshots (
     await env?.stop()
   })
 
-  it('parent composition entry carries estimated with empty components instead of throwing', async function() {
+  it('parent composition surfaces the strategy katRewardsAPR', async function() {
     const snapshot = await fetchRestSnapshot(webUrl, PARENT_VAULT)
     const entry = snapshot.composition?.find(c => c.address.toLowerCase() === STRATEGY_VAULT.toLowerCase())
     expect(entry, 'strategy missing from parent composition').to.not.be.undefined
     expect(entry!.performance?.estimated?.type).to.equal(LABEL)
-    expect(entry!.performance?.estimated?.apr).to.equal(0.03)
-    expect(entry!.performance?.estimated?.apy).to.equal(0.031)
-    expect(entry!.performance?.estimated?.components).to.deep.equal({})
+    expect(entry!.performance?.estimated?.components?.katRewardsAPR).to.be.a('number')
   })
 
-  it('parent keeps its own top-level estimate', async function() {
+  it('parent keeps its own top-level katana estimate', async function() {
     const { performance } = await fetchRestSnapshot(webUrl, PARENT_VAULT)
     expect(performance?.estimated?.type).to.equal(LABEL)
-    expect(performance?.estimated?.apr).to.equal(0.05)
-    expect(performance?.estimated?.apy).to.equal(0.051)
+    expect(performance?.estimated?.apr).to.be.a('number')
+    expect(performance?.estimated?.apy).to.be.a('number')
   })
 })

--- a/packages/ingest/katana-estimated-apr.containers.spec.ts
+++ b/packages/ingest/katana-estimated-apr.containers.spec.ts
@@ -130,6 +130,16 @@ describe('e2e: netAPR/netAPY-only estimated-apr rows must not freeze snapshots (
       { timeoutMs: 15 * 60_000, intervalMs: 15_000, onTick: () => triggerFanout('abis', {}) },
     )
 
+    // StrategyChanged registers every strategy as a vault thing without a name.
+    // Test abis have no `things` filter, so those never get snapshotted and
+    // refresh-vaults fails Zod on name. Drop orphans; only manuals matter here.
+    await pool.query(
+      `DELETE FROM thing
+       WHERE label = 'vault'
+         AND lower(address) NOT IN (lower($1), lower($2))`,
+      [STRATEGY_VAULT, PARENT_VAULT],
+    )
+
     await env.runScript('packages/web/app/api/rest/refresh-vaults.ts')
   })
 

--- a/packages/ingest/katana-estimated-apr.containers.spec.ts
+++ b/packages/ingest/katana-estimated-apr.containers.spec.ts
@@ -1,0 +1,157 @@
+import { expect } from 'chai'
+import { Pool } from 'pg'
+import { TestEnvironment, createTestPool, pollForRow, triggerFanout } from 'lib/helpers/containers'
+
+// PR #443: netAPR/netAPY-only estimated-apr rows froze vault snapshots.
+//
+// The katana APR service emits 'katana-estimated-apr' rows for both allocator
+// vaults and their strategies. When a strategy's latest emission carries ONLY
+// netAPR/netAPY (no other components), fetchStrategyPerformance used to build
+// estimated as {type, apr, apy} without the components key required by
+// CompositionSchema. extractComposition then threw a ZodError on every
+// extract.snapshot run, so the parent vault's snapshot was never rewritten and
+// the REST API served stale composition with no estimated block (katana vaults
+// 0x80c34B…/0x9A6bd7… were stuck for 3 days).
+//
+// This covers what the unit test can't: the full ingest -> snapshot -> REST
+// pipeline. Under the unfixed hook the parent's composition never assembles
+// (the gate below times out); with the fix the composition entry lands carrying
+// estimated with components: {}. The pure mapping logic is unit-tested in
+// abis/yearn/3/vault/snapshot/hook.spec.ts. Runs on mainnet addresses because
+// the bug is label-driven, not chain-specific.
+
+const CHAIN_ID = 1
+const LABEL = 'katana-estimated-apr'
+
+// itself a v3 vault AND a strategy of PARENT_VAULT; gets netAPR/netAPY-only
+// rows -> the shape that used to break the parent's composition parse.
+const STRATEGY_VAULT = '0x0e297dE4005883C757c9F09fdF7cF1363C20e626'
+const STRATEGY_INCEPT = 21176924
+
+// embeds STRATEGY_VAULT in its composition; its own rows give it a top-level
+// estimate, which sets estimatedAprLabel for the composition path.
+const PARENT_VAULT = '0xAe7d8Db82480E6d8e3873ecbF22cf17b3D8A7308'
+const PARENT_INCEPT = 21176924
+
+function source(address: string, inceptBlock: number) {
+  return { chainId: CHAIN_ID, address, inceptBlock }
+}
+
+function manual(address: string, inceptBlock: number) {
+  return {
+    chainId: CHAIN_ID,
+    address,
+    label: 'vault',
+    defaults: { inceptBlock, origin: 'yearn', apiVersion: '3.0.4' },
+  }
+}
+
+// All components of one emission MUST share a single block_time so
+// getLatestEstimatedAprV3 selects them as one row-set.
+async function seedOutput(pool: Pool, address: string, components: Record<string, number>) {
+  const blockTime = new Date()
+  for (const [component, value] of Object.entries(components)) {
+    await pool.query(
+      `INSERT INTO output (chain_id, address, label, component, value, block_number, block_time, series_time)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $7)`,
+      [CHAIN_ID, address, LABEL, component, value, 1, blockTime],
+    )
+  }
+}
+
+type Estimated = { type?: string, apr?: number, apy?: number, components?: Record<string, number> }
+
+async function fetchRestSnapshot(webUrl: string, address: string) {
+  const res = await fetch(`${webUrl}/api/rest/snapshot/${CHAIN_ID}/${address.toLowerCase()}`)
+  expect(res.status).to.equal(200)
+  return await res.json() as {
+    performance?: { estimated?: Estimated }
+    composition?: Array<{ address: string, performance?: { estimated?: Estimated } }>
+  }
+}
+
+// Gate: the parent's composition entry for the strategy carries the estimated
+// block. Under the unfixed hook this NEVER holds — extractComposition throws
+// before load, the snapshot is never rewritten — so a timeout here is the
+// regression firing.
+// Params: [chainId($1), parent($2), strategy($3), label($4)].
+const COMPOSITION_ASSEMBLED_SQL = `
+  SELECT 1 FROM snapshot s JOIN thing t
+    ON t.chain_id = s.chain_id AND t.address = s.address
+  WHERE t.chain_id = $1 AND lower(t.address) = lower($2) AND t.label = 'vault'
+    AND EXISTS (
+      SELECT 1 FROM jsonb_array_elements(COALESCE(s.hook->'composition', '[]'::jsonb)) c
+      WHERE lower(c->>'address') = lower($3)
+        AND c->'performance'->'estimated'->>'type' = $4
+    )
+`
+
+describe('e2e: netAPR/netAPY-only estimated-apr rows must not freeze snapshots (PR #443)', () => {
+  let env: TestEnvironment
+  let webUrl: string
+  let pool: Pool
+
+  beforeAll(async () => {
+    env = new TestEnvironment({
+      configs: {
+        chains: ['mainnet'],
+        abis: [{
+          abiPath: 'yearn/3/vault',
+          sources: [
+            source(STRATEGY_VAULT, STRATEGY_INCEPT),
+            source(PARENT_VAULT, PARENT_INCEPT),
+          ],
+        }],
+        manuals: [
+          manual(STRATEGY_VAULT, STRATEGY_INCEPT),
+          manual(PARENT_VAULT, PARENT_INCEPT),
+        ],
+      },
+      ingest: true,
+      web: { env: { POSTGRES_SSL: '' } },
+    })
+
+    const result = await env.start()
+    webUrl = result.webUrl
+    pool = createTestPool()
+
+    // Seed BEFORE the snapshot hooks run. The strategy gets the prod failure
+    // shape: netAPR/netAPY only, nothing else.
+    await seedOutput(pool, PARENT_VAULT, { netAPR: 0.05, netAPY: 0.051 })
+    await seedOutput(pool, STRATEGY_VAULT, { netAPR: 0.03, netAPY: 0.031 })
+
+    // Drive fanout until the parent's composition carries the strategy's
+    // estimated block; composition needs the strategy snapshot to land first,
+    // so re-trigger on each empty poll.
+    await pollForRow(
+      pool,
+      COMPOSITION_ASSEMBLED_SQL,
+      [CHAIN_ID, PARENT_VAULT, STRATEGY_VAULT, LABEL],
+      { timeoutMs: 15 * 60_000, intervalMs: 15_000, onTick: () => triggerFanout('abis', {}) },
+    )
+
+    await env.runScript('packages/web/app/api/rest/refresh-vaults.ts')
+  })
+
+  afterAll(async () => {
+    await pool?.end()
+    await env?.stop()
+  })
+
+  it('parent composition entry carries estimated with empty components instead of throwing', async function() {
+    const snapshot = await fetchRestSnapshot(webUrl, PARENT_VAULT)
+    const entry = snapshot.composition?.find(c => c.address.toLowerCase() === STRATEGY_VAULT.toLowerCase())
+    expect(entry, 'strategy missing from parent composition').to.not.be.undefined
+    expect(entry!.performance?.estimated?.type).to.equal(LABEL)
+    expect(entry!.performance?.estimated?.apr).to.equal(0.03)
+    expect(entry!.performance?.estimated?.apy).to.equal(0.031)
+    expect(entry!.performance?.estimated?.components).to.deep.equal({})
+  })
+
+  it('parent keeps its own top-level estimate', async function() {
+    const { performance } = await fetchRestSnapshot(webUrl, PARENT_VAULT)
+    expect(performance?.estimated?.type).to.equal(LABEL)
+    expect(performance?.estimated?.apr).to.equal(0.05)
+    expect(performance?.estimated?.apy).to.equal(0.051)
+  })
+})

--- a/packages/ingest/tsconfig.json
+++ b/packages/ingest/tsconfig.json
@@ -32,7 +32,7 @@
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
-    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    "types": ["bun-types", "vitest/globals"],         /* Specify type package names to be included without being referenced in a source file. */
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
     // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */

--- a/packages/ingest/vitest.containers.config.ts
+++ b/packages/ingest/vitest.containers.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig } from 'vitest/config'
 
-// e2e suite: each spec brings up its own full ingest+web stack via
-// lib/helpers/containers, so there is no shared testcontainers globalSetup here.
+// e2e suite: each *containers.spec.ts owns a full TestEnvironment stack
+// (postgres+redis+ingest+web) and mutates process.env for host-side pool/
+// redis access. Run files in parallel, one isolated fork each.
 export default defineConfig({
   test: {
     globals: true,
@@ -10,9 +11,8 @@ export default defineConfig({
     include: ['**/*containers.spec.ts'],
     setupFiles: ['./vitest.containers.setup.ts'],
     pool: 'forks',
-    poolOptions: { forks: { singleFork: true } },
-    fileParallelism: false,
-    isolate: false,
+    fileParallelism: true,
+    isolate: true,
     testTimeout: 1_200_000,
     hookTimeout: 1_200_000,
     teardownTimeout: 120_000,

--- a/packages/ingest/vitest.setup.ts
+++ b/packages/ingest/vitest.setup.ts
@@ -7,6 +7,12 @@ import { beforeAll, inject } from 'vitest'
 import { cache } from 'lib'
 import { rpcs } from './rpcs'
 
+declare module 'vitest' {
+  interface ProvidedContext {
+    testcontainers: Record<string, string | number>
+  }
+}
+
 dotenv.config({ path: path.join(__dirname, '../..', '.env') })
 chai.use(chaiAlmost())
 

--- a/packages/ingest/yvusd-estimated-apr.containers.spec.ts
+++ b/packages/ingest/yvusd-estimated-apr.containers.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai'
-import { Pool } from 'pg'
 import { TestEnvironment, createTestPool, pollForRow, triggerFanout } from 'lib/helpers/containers'
+import { Pool } from 'pg'
 
 // Issue #409: yvusd-estimated-apr leaking into non-yvUSD vault context.
 //
@@ -182,6 +182,16 @@ describe('e2e: yvusd-estimated-apr scoping (issue #409)', () => {
       COMPOSITION_ASSEMBLED_SQL,
       [CHAIN_ID, YVUSD_VAULT, USDC2_VAULT, STRATEGY_VAULT, LABEL],
       { timeoutMs: 15 * 60_000, intervalMs: 15_000, onTick: () => triggerFanout('abis', {}) },
+    )
+
+    // StrategyChanged registers every strategy as a vault thing without a name.
+    // Test abis have no `things` filter, so those never get snapshotted and
+    // refresh-vaults fails Zod on name. Drop orphans; only manuals matter here.
+    await pool.query(
+      `DELETE FROM thing
+       WHERE label = 'vault'
+         AND lower(address) NOT IN (lower($1), lower($2), lower($3))`,
+      [YVUSD_VAULT, STRATEGY_VAULT, USDC2_VAULT],
     )
 
     await env.runScript('packages/web/app/api/rest/refresh-vaults.ts')

--- a/packages/lib/helpers/containers.ts
+++ b/packages/lib/helpers/containers.ts
@@ -17,7 +17,7 @@ const dotenvParsed = dotenv.config({ path: path.join(REPO_ROOT, '.env') }).parse
 function rpcEnv(): Record<string, string> {
   const merged = { ...dotenvParsed, ...process.env }
   const result: Record<string, string> = {}
-  const prefixes = ['HTTP_ARCHIVE_', 'HTTP_FULLNODE_', 'YDAEMON_', 'YPRICE_', 'PRICE_SERVICE_']
+  const prefixes = ['HTTP_ARCHIVE_', 'HTTP_FULLNODE_', 'YDAEMON_', 'YPRICE_', 'PRICE_SERVICE_', 'WEBHOOK_SECRET_']
   for (const [k, v] of Object.entries(merged)) {
     if (v && prefixes.some(p => k.startsWith(p))) result[k] = v
   }


### PR DESCRIPTION
### Summary

Since 07-17, two Katana vaults (`0x80c34B…`, `0x9A6bd7…`) stopped rewriting snapshots: every `extract.snapshot` threw a ZodError, so REST kept stale `strategies[].performance` with no `estimated` block (downstream missing `strategyRewardsAPR` / `katRewardsAPR`).

Cause: `fetchStrategyPerformance` only set `components` when a non-netAPR/netAPY component appeared. Strategies whose latest `katana-estimated-apr` rows carried only `netAPR`/`netAPY` produced `{type, apr, apy}` without `components`. `CompositionSchema` requires that key, so `extractComposition` failed and the whole vault snapshot was never loaded.

Fix in `fetchStrategyPerformance`: initialize `estimated` as `{ type, components: {} }`. Also report composition parse failures to Sentry (`hook: vault.snapshot.extractComposition`) before rethrow.

Other small fixes that landed while making the e2e real:
- `projectStrategies` no longer returns `[]` when there are no `StrategyChanged` events; it still merges `get_default_queue` (needed when history is capped).
- Webhook `selectValidOutputs` groups with a plain `Map` instead of `Map.groupBy` (missing on some runtimes).
- Container test env forwards `WEBHOOK_SECRET_*`.
- Katana + yvUSD container specs delete orphan vault things (from `StrategyChanged`) before `refresh-vaults` so Zod name checks do not fail.

### How to review

1. `packages/ingest/abis/yearn/3/vault/snapshot/hook.ts` — `components: {}` init, Sentry wrap on parse, empty-events `projectStrategies` path.
2. Unit case in `hook.spec.ts` for netAPR/netAPY-only rows.
3. `katana-estimated-apr.containers.spec.ts` — real Katana parent/strategy addresses, seeded estimated-apr (live `S_KATANA_APR` currently returns `[]` for these vaults), sibling freeze shape, gate on composition `katRewardsAPR`.
4. Skip the vitest/tsconfig chore unless you care about parallel container forks.

### Test plan

- [ ] Manual: after deploy, `fanout abis` on Katana; confirm `extract-747474` no longer piles ZodErrors for `0x80c34B…` / `0x9A6bd7…`, and `/api/rest/snapshot/747474/0x80c34bd3a3569e126e7055831036aa7b212cb159` serves fresh `strategies[].performance.estimated` with rewards components where the APR service has them.
- [x] Automated: `vitest run abis/yearn/3/vault/snapshot/hook.spec.ts` (includes netAPR/netAPY-only case).
- [x] Automated e2e: `bun run test:containers packages/ingest/katana-estimated-apr.containers.spec.ts` (2/2 pass; asserts parent composition surfaces strategy `katRewardsAPR`).

### Risk / impact

Low. Ingest-only, no migrations or funds paths. Rethrow keeps BullMQ retry behavior. Data shape change is only `components: {}` instead of a missing key on strategy `estimated`, which the schema and REST layer already expect. `projectStrategies` can include queue strategies without local `StrategyChanged` logs (matches on-chain queue; production with full history already had those events).