### PR TITLE
fix(web): serve contract state over stale hook keys

### DIFF
--- a/packages/ingest/abis/erc4626/timeseries/pps/hook.spec.ts
+++ b/packages/ingest/abis/erc4626/timeseries/pps/hook.spec.ts
@@ -2,11 +2,12 @@ import { expect } from 'chai'
 import { base, mainnet } from 'viem/chains'
 import { _compute } from './hook'
 import { ThingSchema } from 'lib/types'
+import { chains } from 'lib'
 
-describe('abis/erc4626/timeseries/pps/hook', function() {
-  it('extracts sdai pps', async function() {
-    this.timeout(30_000)
+const hasBase = chains.some(chain => chain.id === base.id)
 
+describe('abis/erc4626/timeseries/pps/hook', () => {
+  it('extracts sdai pps', { timeout: 30_000 }, async () => {
     const sdai = '0x83F20F44975D03b1b09e64809B757c47f942BEeA'
     const vault = ThingSchema.parse({
       chainId: mainnet.id,
@@ -18,9 +19,7 @@ describe('abis/erc4626/timeseries/pps/hook', function() {
     expect(pps.humanized).to.be.closeTo(1.1040043785400659, 1e-5)
   })
 
-  it('extracts avantis usdc pps', async function() {
-    this.timeout(30_000)
-
+  it.skipIf(!hasBase)('extracts avantis usdc pps', { timeout: 30_000 }, async () => {
     const usdc = '0x944766f715b51967E56aFdE5f0Aa76cEaCc9E7f9'
     const vault = ThingSchema.parse({
       chainId: base.id,
@@ -33,9 +32,7 @@ describe('abis/erc4626/timeseries/pps/hook', function() {
     expect(pps.humanized).to.be.closeTo(1.2807073904123205, 1e-5)
   })
 
-  it('uses share decimals when they differ from asset decimals', async function() {
-    this.timeout(30_000)
-
+  it('uses share decimals when they differ from asset decimals', { timeout: 30_000 }, async () => {
     // Yearn USDT (Morpho): 18-decimal shares, 6-decimal USDT asset.
     // defaults.decimals holds the asset decimals (6); convertToAssets needs the
     // share decimals (18) or it rounds to 0. Pre-fix this returned 0.

--- a/packages/ingest/abis/yearn/3/strategy/event/hook.spec.ts
+++ b/packages/ingest/abis/yearn/3/strategy/event/hook.spec.ts
@@ -1,6 +1,10 @@
 import { expect } from 'chai'
+import { polygon } from 'viem/chains'
+import { chains } from 'lib'
 import { HarvestSchema, computeApr, totalAssets } from './hook'
 import { addresses } from '../../../../../test-addresses'
+
+const hasPolygon = chains.some(chain => chain.id === polygon.id)
 
 function mock() {
   return HarvestSchema.parse({
@@ -18,7 +22,7 @@ function mock() {
 }
 
 describe('abis/yearn/3/strategy/event/hook', function() {
-  it('extracts totalDebt', async function() {
+  it.skipIf(!hasPolygon)('extracts totalDebt', async function() {
     const debt = await totalAssets(mock())
     expect(debt).to.equal(10489089449n)
   })
@@ -35,7 +39,7 @@ describe('abis/yearn/3/strategy/event/hook', function() {
     expect(apr.net).to.equal(0)
   })
 
-  it('computes gross and net apr on profit', async function() {
+  it.skipIf(!hasPolygon)('computes gross and net apr on profit', async function() {
     const latest = {
       ...mock(),
       blockNumber: 51916666n,
@@ -53,7 +57,7 @@ describe('abis/yearn/3/strategy/event/hook', function() {
     expect(apr.net).to.equal(0.04795259723804295)
   })
 
-  it('computes gross and net apr on loss', async function() {
+  it.skipIf(!hasPolygon)('computes gross and net apr on loss', async function() {
     const latest = {
       ...mock(),
       blockNumber: 51916666n,

--- a/packages/ingest/abis/yearn/3/vault/snapshot/hook.spec.ts
+++ b/packages/ingest/abis/yearn/3/vault/snapshot/hook.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai'
-import { extractComposition } from './hook'
+import process, { extractComposition } from './hook'
 import db, { toUpsertSql } from '../../../../../db'
 
 describe('abis/yearn/3/vault/snapshot/hook', function() {
@@ -117,6 +117,35 @@ describe('abis/yearn/3/vault/snapshot/hook', function() {
       expect(composition[0].performance?.estimated?.apr).to.equal(0.03)
       expect(composition[0].performance?.estimated?.apy).to.equal(0.031)
       expect(composition[0].performance?.estimated?.components).to.deep.equal({})
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  it('echoes snapshot pricePerShare to override stale hook keys', async function() {
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = (async () => ({
+      json: async () => []
+    })) as unknown as typeof fetch
+
+    const chainId = 1337
+    const vault = '0x5000000000000000000000000000000000000005'
+    const asset = '0x6000000000000000000000000000000000000006'
+    const pricePerShare = 1021955n
+    const assetData = {
+      chain_id: chainId,
+      address: asset,
+      label: 'erc20',
+      defaults: { name: 'USD Coin', symbol: 'USDC', decimals: 6 }
+    }
+    await db.query(toUpsertSql('thing', 'chain_id, address, label', assetData), Object.values(assetData))
+
+    try {
+      const composition = await extractComposition(chainId, vault, [], [])
+      const hook = await process(chainId, vault, { asset, pricePerShare })
+
+      expect(composition).to.have.length(0)
+      expect(hook.pricePerShare).to.equal(pricePerShare)
     } finally {
       globalThis.fetch = originalFetch
     }

--- a/packages/ingest/abis/yearn/3/vault/snapshot/hook.ts
+++ b/packages/ingest/abis/yearn/3/vault/snapshot/hook.ts
@@ -88,7 +88,8 @@ export const SnapshotSchema = z.object({
   accountant: EvmAddressSchema.optional(),
   role_manager: EvmAddressSchema.optional(),
   use_default_queue: z.boolean().optional(),
-  get_default_queue: EvmAddressSchema.array().optional()
+  get_default_queue: EvmAddressSchema.array().optional(),
+  pricePerShare: z.bigint({ coerce: true }).optional()
 })
 
 type Snapshot = z.infer<typeof SnapshotSchema>
@@ -159,6 +160,9 @@ export default async function process(chainId: number, address: `0x${string}`, d
     sparklines,
     tvl: sparklines.tvl[0],
     apy,
+    // echo contract state so stale hook.pricePerShare from the erc4626 hook
+    // (written before a vault turned yearn: true) gets overwritten on merge
+    pricePerShare: snapshot.pricePerShare,
     performance: {
       estimated: estimatedApr ?? undefined,
       oracle: {

--- a/packages/ingest/abis/yearn/3/vault/timeseries/pps/hook.spec.ts
+++ b/packages/ingest/abis/yearn/3/vault/timeseries/pps/hook.spec.ts
@@ -1,0 +1,51 @@
+import { expect } from 'chai'
+import { polygon } from 'viem/chains'
+import { chains } from 'lib'
+import { ThingSchema } from 'lib/types'
+import { addresses } from '../../../../../../test-addresses'
+import * as shared from '../../../../2/vault/timeseries/pps/hook'
+import process from './hook'
+
+const hasPolygon = chains.some(chain => chain.id === polygon.id)
+
+describe('abis/yearn/3/vault/timeseries/pps/hook', function() {
+  it.skipIf(!hasPolygon)('reads and humanizes pricePerShare for a v3 vault', async function() {
+    const vault = ThingSchema.parse({
+      chainId: polygon.id,
+      address: addresses.v3.yvusdca,
+      label: 'vault',
+      defaults: { decimals: 6 }
+    })
+    const pps = await shared._compute(vault, 52031869n)
+
+    expect(pps.raw).to.equal(1027028n)
+    expect(pps.humanized).to.equal(1.027028)
+  })
+
+  it('forwards timeseries requests to the shared Yearn vault hook', async function() {
+    const output = {
+      chainId: polygon.id,
+      address: addresses.v3.yvusdca,
+      label: 'pps',
+      component: 'raw',
+      value: 1027028,
+      blockNumber: 52031869n,
+      blockTime: 1704600807n
+    }
+    const data = {
+      abiPath: 'yearn/3/vault',
+      chainId: polygon.id,
+      address: addresses.v3.yvusdca,
+      outputLabel: 'pps',
+      blockTime: 1704600807n
+    }
+    const delegate = vi.spyOn(shared, 'default').mockResolvedValue([output])
+
+    try {
+      expect(await process(polygon.id, addresses.v3.yvusdca, data)).to.deep.equal([output])
+      expect(delegate.mock.calls).to.deep.equal([[polygon.id, addresses.v3.yvusdca, data]])
+    } finally {
+      delegate.mockRestore()
+    }
+  })
+})

--- a/packages/ingest/abis/yearn/lib/apy.spec.ts
+++ b/packages/ingest/abis/yearn/lib/apy.spec.ts
@@ -1,10 +1,13 @@
 import { expect } from 'chai'
 import { addresses } from '../../../test-addresses'
 import { mainnet, polygon } from 'viem/chains'
+import { chains } from 'lib'
 import { _compute, computeApy, computeNetApr, extractFees__v2, extractFees__v3, extractLockedProfit__v2, extractLockedProfit__v3 } from './apy'
 import { EvmLogSchema, ThingSchema } from 'lib/types'
 import { upsertBatch } from '../../../load'
 import db from '../../../db'
+
+const hasPolygon = chains.some(chain => chain.id === polygon.id)
 
 describe('abis/yearn/lib/apy', () => {
   beforeAll(async () => {
@@ -128,20 +131,20 @@ describe('abis/yearn/lib/apy', () => {
     expect(Number(apy.inceptionBlockNumber)).to.be.closeTo(15243268, 4)
   }, 20_000)
 
-  it('extracts v3 vault fees', async () => {
+  it.skipIf(!hasPolygon)('extracts v3 vault fees', async () => {
     const strategies: `0x${string}`[] = [addresses.v3.aaveV3UsdcLender, addresses.v3.compoundV3UsdcLender, addresses.v3.stargateUsdcStaker]
     const fees = await extractFees__v3(polygon.id, addresses.v3.yvusdca, strategies, 52031869n)
     expect(fees.management).to.eq(0)
     expect(fees.performance).to.eq(.1)
   }, 20_000)
 
-  it('extracts v3 tokenized strat fees', async () => {
+  it.skipIf(!hasPolygon)('extracts v3 tokenized strat fees', async () => {
     const fees = await extractFees__v3(polygon.id, addresses.v3.aaveV3UsdcLender, [], 52031869n)
     expect(fees.management).to.eq(0)
     expect(fees.performance).to.eq(.05)
   }, 20_000)
 
-  it('extracts v3 locked profit', async () => {
+  it.skipIf(!hasPolygon)('extracts v3 locked profit', async () => {
     const lotsOfLockedProfit = await extractLockedProfit__v3(polygon.id, addresses.v3.yvusdca, 52031869n)
     expect(lotsOfLockedProfit).to.eq(1340884331n)
 
@@ -149,7 +152,7 @@ describe('abis/yearn/lib/apy', () => {
     expect(noLockedProfit).to.eq(0n)
   }, 20_000)
 
-  it('yvUSDCA 3.0.1 @ block 52031869n', async () => {
+  it.skipIf(!hasPolygon)('yvUSDCA 3.0.1 @ block 52031869n', async () => {
     const blockNumber = 52031869n
     const strategies: `0x${string}`[] = [addresses.v3.aaveV3UsdcLender, addresses.v3.compoundV3UsdcLender, addresses.v3.stargateUsdcStaker]
     const yvusdca = ThingSchema.parse({

--- a/packages/ingest/abiutil.spec.ts
+++ b/packages/ingest/abiutil.spec.ts
@@ -19,6 +19,12 @@ describe('abiutil', function() {
     expect(fields.length).to.eq(8)
   })
 
+  it('includes pricePerShare in the Yearn v3 vault fields', async function() {
+    const abi = await abiutil.load('yearn/3/vault')
+    const fields = abiutil.fields(abi)
+    expect(fields.some(field => field.name === 'pricePerShare')).to.equal(true)
+  })
+
   it('excludes events', async function() {
     const abi = await abiutil.load('yearn/3/strategy')
     const events = abiutil.events(abi)

--- a/packages/ingest/extract/snapshot.spec.ts
+++ b/packages/ingest/extract/snapshot.spec.ts
@@ -1,0 +1,52 @@
+import { expect } from 'chai'
+import { mq } from 'lib'
+import * as blocks from 'lib/blocks'
+import { rpcs } from 'lib/rpcs'
+import abiutil from '../abiutil'
+import { SnapshotExtractor } from './snapshot'
+
+const ADDRESS = '0x696d02db93291651ed510704c9b286841d506987' as `0x${string}`
+
+describe('SnapshotExtractor', function() {
+  it('stores the Yearn v3 pricePerShare returned by the snapshot multicall', async function() {
+    const fields = [
+      { type: 'function', stateMutability: 'view', name: 'pricePerShare', inputs: [], outputs: [] },
+      { type: 'function', stateMutability: 'view', name: 'totalAssets', inputs: [], outputs: [] }
+    ]
+    const block = { chainId: 1, number: 123n, timestamp: 456n }
+    const multicall = vi.fn().mockResolvedValue([
+      { result: 1021955n },
+      { result: 900n }
+    ])
+    const add = vi.spyOn(mq, 'add').mockResolvedValue({} as never)
+    vi.spyOn(abiutil, 'load').mockResolvedValue(fields)
+    vi.spyOn(abiutil, 'fields').mockReturnValue(fields)
+    vi.spyOn(blocks, 'getBlock').mockResolvedValue(block)
+    vi.spyOn(rpcs, 'next').mockReturnValue({ multicall } as never)
+
+    try {
+      const extractor = new SnapshotExtractor()
+      extractor.resolveHooks = () => []
+      await extractor.extract({
+        abi: { abiPath: 'yearn/3/vault', sources: [], skip: false, only: false },
+        source: { chainId: 1, address: ADDRESS, inceptBlock: 0n, skip: false, only: false }
+      })
+
+      expect(add.mock.calls).to.have.length(1)
+      const [job, payload] = add.mock.calls[0] as [unknown, {
+        snapshot: Record<string, unknown>
+        hook: Record<string, unknown>
+      }]
+      expect(job).to.equal(mq.job.load.snapshot)
+      expect(payload.snapshot).to.include({
+        blockNumber: 123n,
+        blockTime: 456n,
+        pricePerShare: 1021955n,
+        totalAssets: 900n
+      })
+      expect(payload.hook).to.deep.equal({})
+    } finally {
+      vi.restoreAllMocks()
+    }
+  })
+})

--- a/packages/ingest/yvusd-estimated-apr.containers.spec.ts
+++ b/packages/ingest/yvusd-estimated-apr.containers.spec.ts
@@ -1,6 +1,10 @@
 import { expect } from 'chai'
 import { TestEnvironment, createTestPool, pollForRow, triggerFanout } from 'lib/helpers/containers'
+import Redis from 'ioredis'
 import { Pool } from 'pg'
+import { getSnapshotKey } from '../web/app/api/rest/snapshot/redis'
+
+const CHAIN_ID = 1
 
 // Issue #409: yvusd-estimated-apr leaking into non-yvUSD vault context.
 //
@@ -21,7 +25,6 @@ import { Pool } from 'pg'
 // strategy's yvUSD-scoped estimate), plus REST/GraphQL read-time parity. The
 // pure debtRatio-filter logic is unit-tested in helpers/apy-apr.spec.ts.
 
-const CHAIN_ID = 1
 const LABEL = 'yvusd-estimated-apr'
 
 // vault-level rows only (no debtRatio) -> KEEPS the estimate, and scopes its
@@ -102,6 +105,30 @@ async function fetchGqlEstimated(webUrl: string, address: string): Promise<Estim
   expect(res.status).to.equal(200)
   const body = await res.json() as { data?: { vault?: { performance?: { estimated?: Estimated } } } }
   return body.data?.vault?.performance?.estimated
+}
+
+type GqlVaultState = {
+  pricePerShare?: unknown
+  asset?: { symbol?: string, decimals?: number }
+}
+
+async function fetchGqlVaultState(webUrl: string, address: string): Promise<GqlVaultState | undefined> {
+  const res = await fetch(`${webUrl}/api/gql`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      query: `query($chainId: Int!, $address: String!) {
+        vault(chainId: $chainId, address: $address) {
+          pricePerShare
+          asset { symbol decimals }
+        }
+      }`,
+      variables: { chainId: CHAIN_ID, address },
+    }),
+  })
+  expect(res.status).to.equal(200)
+  const body = await res.json() as { data?: { vault?: GqlVaultState } }
+  return body.data?.vault
 }
 
 // Gate: composition fully assembled. yvUSD ($2) must resolve the strategy ($4)
@@ -234,4 +261,140 @@ describe('e2e: yvusd-estimated-apr scoping (issue #409)', () => {
     expect(gql?.apr).to.equal(performance?.estimated?.apr)
     expect(gql?.apy).to.equal(performance?.estimated?.apy)
   })
+})
+
+// Stale hook.pricePerShare shadowing fresh contract state (yvUSD & friends, up to 2.6x off).
+//
+// Vaults discovered via the erc4626 abi path (before their registry endorsement
+// set yearn: true) got a pricePerShare written into snapshot.hook from the pps
+// sparkline. Once the yearn/3/vault snapshot hook took over it never emitted the
+// key, and upsertSnapshot's shallow hook merge kept the stale value forever. The
+// API merged defaults < snapshot < hook, so the dead hook key shadowed the fresh
+// multicalled snapshot.pricePerShare.
+//
+// The fix flips the REST read-layer merge (mergeSnapshot) so contract state wins
+// over hook keys, with `asset` kept hook-won (the enriched erc20 object must beat
+// the raw asset() address). Both REST and GraphQL resolvers now use the same merge.
+// This suite seeds the exact prod row shape (no ingest, no RPC) and
+// asserts REST serves the fresh state value while `asset` stays enriched.
+
+const ASSET = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'
+
+const STALE_PPS = 1002336
+const FRESH_PPS = '1021955'
+
+const ASSET_ERC20 = { chainId: CHAIN_ID, address: ASSET, name: 'USD Coin', symbol: 'USDC', decimals: 6 }
+
+describe('e2e: contract state wins over stale hook keys', () => {
+  let env: TestEnvironment
+  let webUrl: string
+  let pool: Pool
+  let redis: Redis
+
+  beforeAll(async () => {
+    env = new TestEnvironment({
+      // POSTGRES_SSL is baked truthy in the image's .env; '' forces the web db
+      // pool to skip SSL against the test Postgres (which has none).
+      web: { env: { POSTGRES_SSL: '' } },
+    })
+
+    const result = await env.start()
+    webUrl = result.webUrl
+    pool = createTestPool()
+    redis = new Redis(process.env.REST_CACHE_REDIS_URL || 'redis://localhost:6379')
+
+    await pool.query(
+      `INSERT INTO thing (chain_id, address, label, defaults)
+       VALUES ($1, $2, 'vault', $3::jsonb)`,
+      [CHAIN_ID, YVUSD_VAULT, JSON.stringify({ yearn: true, origin: 'yearn', erc4626: true, apiVersion: '3.0.4', inceptBlock: YVUSD_INCEPT })],
+    )
+
+    // The prod row shape: fresh contract state (incl. pricePerShare from the
+    // multicall) + a hook blob carrying the erc4626-era stale pricePerShare
+    // alongside the hook's own enrichments.
+    await pool.query(
+      `INSERT INTO snapshot (chain_id, address, snapshot, hook, block_number, block_time)
+       VALUES ($1, $2, $3::jsonb, $4::jsonb, 25655096, now())`,
+      [
+        CHAIN_ID, YVUSD_VAULT,
+        JSON.stringify({
+          name: 'USD yVault', symbol: 'yvUSD', decimals: 6, apiVersion: '3.0.4',
+          asset: ASSET, pricePerShare: FRESH_PPS,
+          totalAssets: '9254763666617', totalSupply: '9055945416998',
+        }),
+        JSON.stringify({
+          pricePerShare: STALE_PPS,
+          asset: ASSET_ERC20,
+          tvl: { close: 9253324.98 },
+        }),
+      ],
+    )
+
+    await env.runScript('packages/web/app/api/rest/refresh-vaults.ts')
+  })
+
+  afterAll(async () => {
+    await pool?.end()
+    await redis?.quit()
+    await env?.stop()
+  })
+
+  it('REST snapshot serves state pricePerShare, not the stale hook key', async function() {
+    const res = await fetch(`${webUrl}/api/rest/snapshot/${CHAIN_ID}/${YVUSD_VAULT.toLowerCase()}`)
+    expect(res.status).to.equal(200)
+    const snapshot = await res.json() as { pricePerShare?: unknown, asset?: { symbol?: string, decimals?: number } }
+    expect(snapshot.pricePerShare).to.equal(FRESH_PPS)
+    // asset stays the hook-enriched erc20 object, not the raw asset() address
+    expect(snapshot.asset?.symbol).to.equal('USDC')
+    expect(snapshot.asset?.decimals).to.equal(6)
+  })
+
+  it('REST vault list serves state pricePerShare, not the stale hook key', async function() {
+    const res = await fetch(`${webUrl}/api/rest/list/vaults`)
+    expect(res.status).to.equal(200)
+    const vaults = await res.json() as Array<{ address?: string, pricePerShare?: unknown }>
+    const vault = vaults.find((item) => item.address?.toLowerCase() === YVUSD_VAULT.toLowerCase())
+
+    expect(vault).to.not.equal(undefined)
+    expect(String(vault?.pricePerShare)).to.equal(FRESH_PPS)
+  })
+
+  it('GraphQL vault query serves state pricePerShare, not the stale hook key', async function() {
+    const vault = await fetchGqlVaultState(webUrl, YVUSD_VAULT)
+
+    expect(vault?.pricePerShare).to.equal('1021955')
+    expect(vault?.asset?.symbol).to.equal('USDC')
+    expect(vault?.asset?.decimals).to.equal(6)
+  })
+
+  it('cached snapshot payload for yvUSD contains state price & enriched asset', async function() {
+    const raw = await redis.get(getSnapshotKey(CHAIN_ID, YVUSD_VAULT))
+    expect(raw).to.not.equal(null)
+    const snapshot = JSON.parse(raw!).value
+
+    expect(snapshot.chainId).to.equal(1)
+    expect(snapshot.address).to.equal(YVUSD_VAULT)
+    expect(snapshot.pricePerShare).to.equal(FRESH_PPS)
+    expect(snapshot.asset?.symbol).to.equal('USDC')
+    expect(snapshot.asset?.decimals).to.equal(6)
+    expect(snapshot.tvl?.close).to.equal(9253324.98)
+  })
+
+  it('cached list payloads for rest:list:vaults contain state price & enriched asset', async function() {
+    const chainRaw = await redis.get('rest:list:vaults:1')
+    const allRaw = await redis.get('rest:list:vaults:all')
+    expect(chainRaw).to.not.equal(null)
+    expect(allRaw).to.not.equal(null)
+
+    const chainVaults = JSON.parse(chainRaw!).value as Array<{ address: string, pricePerShare: number, asset?: { symbol?: string } }>
+    const allVaults = JSON.parse(allRaw!).value as Array<{ address: string, pricePerShare: number, asset?: { symbol?: string } }>
+
+    for (const vaults of [chainVaults, allVaults]) {
+      const vault = vaults.find(item => item.address.toLowerCase() === YVUSD_VAULT.toLowerCase())
+      expect(vault).to.not.equal(undefined)
+      expect(vault?.pricePerShare).to.equal(1021955)
+      expect(vault?.asset?.symbol).to.equal('USDC')
+    }
+  })
+
 })

--- a/packages/web/app/api/gql/resolvers/accountStrategies.ts
+++ b/packages/web/app/api/gql/resolvers/accountStrategies.ts
@@ -1,4 +1,5 @@
 import db from '@/app/api/db'
+import { mergeSnapshot } from '@/lib/mergeSnapshot'
 
 const accountStrategies = async (_: object, args: { chainId?: number, account: `0x${string}` }) => {
   const { chainId, account } = args
@@ -39,9 +40,7 @@ const accountStrategies = async (_: object, args: { chainId?: number, account: `
     return result.rows.map(row => ({
       chainId: row.chain_id,
       address: row.address,
-      ...row.defaults,
-      ...row.snapshot,
-      ...row.hook
+      ...mergeSnapshot(row.defaults, row.snapshot, row.hook)
     }))
 
   } catch (error) {

--- a/packages/web/app/api/gql/resolvers/accountVaults.ts
+++ b/packages/web/app/api/gql/resolvers/accountVaults.ts
@@ -1,4 +1,5 @@
 import db from '@/app/api/db'
+import { mergeSnapshot } from '@/lib/mergeSnapshot'
 
 const accountVaults = async (_: object, args: { chainId?: number, account: `0x${string}` }) => {
   const { chainId, account } = args
@@ -26,9 +27,7 @@ const accountVaults = async (_: object, args: { chainId?: number, account: `0x${
     return result.rows.map(row => ({
       chainId: row.chain_id,
       address: row.address,
-      ...row.defaults,
-      ...row.snapshot,
-      ...row.hook
+      ...mergeSnapshot(row.defaults, row.snapshot, row.hook)
     }))
 
   } catch (error) {

--- a/packages/web/app/api/gql/resolvers/accountant.ts
+++ b/packages/web/app/api/gql/resolvers/accountant.ts
@@ -1,5 +1,6 @@
 import db from '@/app/api/db'
 import { EvmAddress } from 'lib/types'
+import { mergeSnapshot } from '@/lib/mergeSnapshot'
 
 const accountant = async (_: object, args: { chainId: number, address: EvmAddress }) => {
   const { chainId, address } = args
@@ -24,9 +25,7 @@ const accountant = async (_: object, args: { chainId: number, address: EvmAddres
     const [first] = result.rows.map(row => ({
       chainId: row.chain_id,
       address: row.address,
-      ...row.defaults,
-      ...row.snapshot,
-      ...row.hook
+      ...mergeSnapshot(row.defaults, row.snapshot, row.hook)
     }))
 
     return first

--- a/packages/web/app/api/gql/resolvers/accountants.ts
+++ b/packages/web/app/api/gql/resolvers/accountants.ts
@@ -1,4 +1,5 @@
 import db from '@/app/api/db'
+import { mergeSnapshot } from '@/lib/mergeSnapshot'
 
 const accountants = async (_: object, args: { chainId?: number }) => {
   const { chainId } = args
@@ -21,9 +22,7 @@ const accountants = async (_: object, args: { chainId?: number }) => {
     return result.rows.map(row => ({
       chainId: row.chain_id,
       address: row.address,
-      ...row.defaults,
-      ...row.snapshot,
-      ...row.hook
+      ...mergeSnapshot(row.defaults, row.snapshot, row.hook)
     }))
 
   } catch (error) {

--- a/packages/web/app/api/gql/resolvers/strategies.ts
+++ b/packages/web/app/api/gql/resolvers/strategies.ts
@@ -1,5 +1,6 @@
 import db from '@/app/api/db'
 import { compare } from '@/lib/compare'
+import { mergeSnapshot, SnapshotRow } from '@/lib/mergeSnapshot'
 
 const strategies = async (_: object, args: { chainId?: number, apiVersion?: string, erc4626?: boolean }) => {
   const { chainId, apiVersion, erc4626 } = args
@@ -20,17 +21,16 @@ const strategies = async (_: object, args: { chainId?: number, apiVersion?: stri
     ORDER BY snapshot.hook->>'totalDebtUsd' DESC`,
     ['strategy', chainId])
 
-    let rows = result.rows.map(row => ({
+    let rows: SnapshotRow[] = result.rows.map(row => ({
       chainId: row.chain_id,
       address: row.address,
-      ...row.defaults,
-      ...row.snapshot,
-      ...row.hook
+      ...mergeSnapshot(row.defaults, row.snapshot, row.hook)
     }))
 
     if (apiVersion) {
       rows = rows.filter(row => {
-        return !row.apiVersion || compare(row.apiVersion, apiVersion, '>=')
+        const rowApiVersion = row.apiVersion
+        return typeof rowApiVersion !== 'string' || !rowApiVersion || compare(rowApiVersion, apiVersion, '>=')
       })
     }
 

--- a/packages/web/app/api/gql/resolvers/strategy.ts
+++ b/packages/web/app/api/gql/resolvers/strategy.ts
@@ -1,4 +1,5 @@
 import db from '@/app/api/db'
+import { mergeSnapshot } from '@/lib/mergeSnapshot'
 import { getAddress } from 'viem'
 
 const strategy = async (_: object, args: { chainId: number, address: `0x${string}` }) => {
@@ -23,9 +24,7 @@ const strategy = async (_: object, args: { chainId: number, address: `0x${string
     const [first] = result.rows.map(row => ({
       chainId: row.chain_id,
       address: row.address,
-      ...row.defaults,
-      ...row.snapshot,
-      ...row.hook
+      ...mergeSnapshot(row.defaults, row.snapshot, row.hook)
     }))
 
     return first

--- a/packages/web/app/api/gql/resolvers/vault.ts
+++ b/packages/web/app/api/gql/resolvers/vault.ts
@@ -1,4 +1,5 @@
 import db from '@/app/api/db'
+import { mergeSnapshot } from '@/lib/mergeSnapshot'
 import { getAddress } from 'viem'
 
 const vault = async (_: object, args: { chainId: number, address: `0x${string}` }) => {
@@ -24,9 +25,7 @@ const vault = async (_: object, args: { chainId: number, address: `0x${string}` 
     const [first] = result.rows.map(row => ({
       chainId: row.chain_id,
       address: row.address,
-      ...row.defaults,
-      ...row.snapshot,
-      ...row.hook
+      ...mergeSnapshot(row.defaults, row.snapshot, row.hook)
     }))
 
     return first

--- a/packages/web/app/api/gql/resolvers/vaultStrategies.ts
+++ b/packages/web/app/api/gql/resolvers/vaultStrategies.ts
@@ -1,4 +1,5 @@
 import db from '@/app/api/db'
+import { mergeSnapshot } from '@/lib/mergeSnapshot'
 import { getAddress } from 'viem'
 
 const vaultStrategies = async (_: object, args: { chainId: number, vault: string }) => {
@@ -37,9 +38,7 @@ const vaultStrategies = async (_: object, args: { chainId: number, vault: string
     return result.rows.map(row => ({
       chainId: row.chain_id,
       address: row.address,
-      ...row.defaults,
-      ...row.snapshot,
-      ...row.hook
+      ...mergeSnapshot(row.defaults, row.snapshot, row.hook)
     }))
 
   } catch (error) {

--- a/packages/web/app/api/gql/resolvers/vaults.ts
+++ b/packages/web/app/api/gql/resolvers/vaults.ts
@@ -1,6 +1,9 @@
 import db from '@/app/api/db'
 import { compare } from '@/lib/compare'
+import { mergeSnapshot, SnapshotRow } from '@/lib/mergeSnapshot'
 import { DefaultRiskScore, EvmAddressSchema } from 'lib/types'
+
+type VaultRow = SnapshotRow & { risk: typeof DefaultRiskScore }
 
 const vaults = async (_: object, args: {
   chainId?: number,
@@ -33,12 +36,10 @@ const vaults = async (_: object, args: {
     ORDER BY (snapshot.hook->'tvl'->>'close')::numeric DESC`,
     ['vault', chainId])
 
-    let rows = result.rows.map(row => ({
+    let rows: VaultRow[] = result.rows.map(row => ({
       chainId: row.chain_id,
       address: row.address,
-      ...row.defaults,
-      ...row.snapshot,
-      ...row.hook,
+      ...mergeSnapshot(row.defaults, row.snapshot, row.hook),
       risk: row.hook.risk ?? DefaultRiskScore
     }))
 
@@ -57,7 +58,8 @@ const vaults = async (_: object, args: {
 
     if (apiVersion !== undefined) {
       rows = rows.filter(row => {
-        return compare(row.apiVersion ?? '0', apiVersion, '>=')
+        const rowApiVersion = row.apiVersion
+        return compare(typeof rowApiVersion === 'string' ? rowApiVersion : '0', apiVersion, '>=')
       })
     }
 

--- a/packages/web/app/api/rest/list/db.ts
+++ b/packages/web/app/api/rest/list/db.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { mergeSnapshot } from '../../../../lib/mergeSnapshot'
 import db from '../../db'
 import type { VaultSnapshot } from '../snapshot/db'
 
@@ -234,14 +235,11 @@ export async function getVaultsWithSnapshots(): Promise<VaultWithSnapshot[]> {
     const { _defaults, _snapshot, _hook, _hasSnapshot, ...listColumns } = row
     const parsedListItem = VaultListItemSchema.safeParse(listColumns)
 
-    // Mirror the snapshot endpoint's merge: defaults < snapshot < hook.
     const snapshot: VaultSnapshot | null = _hasSnapshot
       ? {
         chainId: row.chainId,
         address: row.address,
-        ...(_defaults ?? {}),
-        ...(_snapshot ?? {}),
-        ...(_hook ?? {}),
+        ...mergeSnapshot(_defaults, _snapshot, _hook),
       }
       : null
 

--- a/packages/web/app/api/rest/snapshot/db.ts
+++ b/packages/web/app/api/rest/snapshot/db.ts
@@ -1,5 +1,1 @@
-export type VaultSnapshot = {
-  chainId: number
-  address: string
-  [key: string]: unknown
-}
+export type { SnapshotRow as VaultSnapshot } from '@/lib/mergeSnapshot'

--- a/packages/web/components/LatestBlocks.tsx
+++ b/packages/web/components/LatestBlocks.tsx
@@ -13,7 +13,7 @@ export default function LatestBlocks() {
   }, [data])
   return <div className={'w-full flex flex-col items-start'}>
     <div id="latest-blocks" className="font-bold text-xl">Latest Blocks</div>
-    {chains.map((chain, index) => <div key={chain.id} className="w-full flex items-center justify-between">
+    {chains.map(chain => <div key={chain.id} className="w-full flex items-center justify-between">
       <div className="text-yellow-700 whitespace-nowrap">{chain.name.toLowerCase()}</div>
       <Frosty _key={latestBlock(chain.id) as string}>{formatLineItemValue(Number(latestBlock(chain.id)))}</Frosty>
     </div>)}

--- a/packages/web/lib/mergeSnapshot.spec.ts
+++ b/packages/web/lib/mergeSnapshot.spec.ts
@@ -1,0 +1,41 @@
+import { strict as assert } from 'node:assert'
+import { describe, it } from 'vitest'
+import { mergeSnapshot } from './mergeSnapshot'
+
+describe('mergeSnapshot', () => {
+  it('lets contract state override stale hook keys while retaining hook-only data', () => {
+    const result = mergeSnapshot(
+      { origin: 'yearn', defaultOnly: true },
+      { pricePerShare: 'fresh', snapshotOnly: true },
+      { pricePerShare: 'stale', hookOnly: true }
+    )
+
+    assert.deepEqual(result, {
+      origin: 'yearn',
+      defaultOnly: true,
+      pricePerShare: 'fresh',
+      snapshotOnly: true,
+      hookOnly: true
+    })
+  })
+
+  it('keeps the hook-enriched asset over the raw contract asset', () => {
+    const result = mergeSnapshot(
+      { asset: '0xdefault' },
+      { asset: '0xraw', pricePerShare: 'fresh' },
+      { asset: { address: '0xasset', symbol: 'USDC', decimals: 6 } }
+    )
+
+    assert.deepEqual(result.asset, { address: '0xasset', symbol: 'USDC', decimals: 6 })
+    assert.equal(result.pricePerShare, 'fresh')
+  })
+
+  it('falls back to the contract asset when the hook asset is null or undefined', () => {
+    assert.equal(mergeSnapshot({}, { asset: '0xraw' }, { asset: null }).asset, '0xraw')
+    assert.equal(mergeSnapshot({}, { asset: '0xraw' }, { asset: undefined }).asset, '0xraw')
+  })
+
+  it('handles missing blobs without throwing', () => {
+    assert.deepEqual(mergeSnapshot(undefined, { pricePerShare: 'fresh' }, null), { pricePerShare: 'fresh' })
+  })
+})

--- a/packages/web/lib/mergeSnapshot.ts
+++ b/packages/web/lib/mergeSnapshot.ts
@@ -1,0 +1,22 @@
+type Blob = Record<string, unknown> | null | undefined
+
+export type SnapshotRow = {
+  chainId: number
+  address: string
+  [key: string]: unknown
+}
+
+// Merge a thing's blobs into the shape the API serves. Contract state must not
+// be shadowed by hook keys — hooks that stop running for a thing (e.g. the
+// erc4626 hook after a vault turns yearn: true) leave stale keys behind in the
+// hook blob, since upsertSnapshot merges hooks shallowly. `asset` is the one
+// exception: hooks enrich it into an erc20 object that must win over the raw
+// asset() address in contract state.
+export function mergeSnapshot(defaults: Blob, snapshot: Blob, hook: Blob): Record<string, unknown> {
+  return {
+    ...(defaults ?? {}),
+    ...(hook ?? {}),
+    ...(snapshot ?? {}),
+    ...(hook?.asset != null ? { asset: hook.asset } : {}),
+  }
+}


### PR DESCRIPTION
### Summary

REST vault list and snapshot responses could serve a stale top-level pricePerShare from snapshot.hook. Vaults first indexed through the erc4626 ABI stored the PPS sparkline value in that blob. When yearn/3/vault took over, the old key remained, and the previous merge order (defaults < snapshot < hook) let it override the current multicall value.

This PR adds mergeSnapshot, which merges defaults < hook < snapshot and then restores the hook-enriched asset object when the hook holds a non-null asset; a null or missing hook asset falls back to contract state. It is used in the REST vault list/snapshot cache builder (getVaultsWithSnapshots) and in the nine GraphQL resolvers that build entities from the same three blobs (vault, vaults, accountVaults, strategy, strategies, vaultStrategies, accountStrategies, accountant, accountants).

One data-at-rest fix is included: the yearn/3/vault snapshot hook now echoes pricePerShare from contract state, so the stale hook key gets overwritten naturally on the next snapshot pass — no migration needed. erc4626-only vaults, whose state has no pricePerShare, keep serving their hook value.

Also removes an unused map index param in LatestBlocks.tsx, restyles the erc4626 PPS spec to Vitest timeout options, and gates four ingest specs that hit polygon/base RPC with it.skipIf on the configured chains, so mainnet-only chains.local.yaml runs skip them instead of failing while CI's full chains.yaml still runs them.

### How to review

- packages/web/lib/mergeSnapshot.ts: merge order and the asset exception.
- packages/web/app/api/rest/list/db.ts and packages/web/app/api/gql/resolvers/*: the call sites. The strategies resolver keeps the pre-existing falsy short-circuit on the apiVersion filter, so empty-string apiVersion rows are still kept.
- packages/web/app/api/rest/snapshot/db.ts: VaultSnapshot is now an alias of SnapshotRow.
- packages/ingest/abis/yearn/3/vault/snapshot/hook.ts: the pricePerShare echo.
- packages/web/lib/mergeSnapshot.spec.ts: unit coverage for precedence, asset preservation, and missing blobs.
- packages/ingest/yvusd-estimated-apr.containers.spec.ts: the seeded stale-hook suite (Postgres, no RPC) covers REST snapshot, REST list, the GraphQL vault query, and the cached Redis payloads (snapshot + list keys), next to the issue #409 suite.
- Additional ingest specs cover v3 PPS hook delegation, the snapshot hook echo, snapshot multicall field extraction, and ABI field discovery.

### Automated tests

- [x] bun --filter web test: 16 tests passed (incl. lib/mergeSnapshot.spec.ts).
- [x] packages/ingest unit suite: 22 files passed, 109 tests passed, 11 skipped (chain and env gates).
- [x] bun --filter ingest test:containers -- yvusd-estimated-apr.containers.spec.ts: 8 tests passed (3 issue-#409 + 5 stale-hook). One earlier run flaked in the issue-#409 beforeAll — in-flight ingest re-created orphan name-less vault things between the cleanup DELETE and refresh-vaults; pre-existing race in that suite's setup, rerun green.

### Manual test

Reproduces the stale-hook suite in yvusd-estimated-apr.containers.spec.ts by hand, against yvUSD on mainnet.

1. Config overrides — create these three files:

   `config/chains.local.yaml`
   ```yaml
   chains: ['mainnet']
   ```

   `config/abis.local.yaml`
   ```yaml
   abis:
     - abiPath: yearn/3/vault
       sources:
         - chainId: 1
           address: '0x696d02Db93291651ED510704c9b286841d506987'
           inceptBlock: 24271831
   ```

   `config/manuals.local.yaml`
   ```yaml
   manuals:
     - chainId: 1
       address: '0x696d02Db93291651ED510704c9b286841d506987'
       label: vault
       defaults: { inceptBlock: 24271831, origin: yearn, apiVersion: '3.0.4' }
   ```

2. Run ingest: `make dev`, then in the terminal UI select `ingest` → `fanout abis`. Re-run fanout until the snapshot row lands:
   ```sql
   SELECT snapshot->>'pricePerShare' FROM snapshot
   WHERE chain_id = 1 AND address = '0x696d02Db93291651ED510704c9b286841d506987';
   ```
   Should show the fresh multicalled value (uint256 string, e.g. `1021955...`).

3. Plant the erc4626-era stale key into the hook blob (the prod row shape the bug depends on):
   ```sql
   UPDATE snapshot SET hook = hook || '{"pricePerShare": 1002336}'::jsonb
   WHERE chain_id = 1 AND address = '0x696d02Db93291651ED510704c9b286841d506987';
   ```

4. Rebuild the REST cache: `bun packages/web/app/api/rest/refresh-vaults.ts` (web must be running — `make dev` starts it on :3001).

5. REST snapshot:
   ```
   curl -s localhost:3001/api/rest/snapshot/1/0x696d02db93291651ed510704c9b286841d506987 | jq '{pricePerShare, asset}'
   ```
   pricePerShare must be the fresh state value from step 2, NOT `1002336`; asset must stay the hook-enriched erc20 object (symbol/decimals), not a raw address.

6. REST list:
   ```
   curl -s localhost:3001/api/rest/list/vaults | jq '.[] | select(.address | ascii_downcase == "0x696d02db93291651ed510704c9b286841d506987") | .pricePerShare'
   ```
   Same fresh value.

7. GraphQL (http://localhost:3001/api/gql):
   ```graphql
   { vault(chainId: 1, address: "0x696d02Db93291651ED510704c9b286841d506987") { pricePerShare asset { symbol decimals } } }
   ```
   Same fresh value, enriched asset.

8. On main, steps 5–7 return `1002336` instead — that's the bug.

### Risk / impact

The merge change covers the REST caches and GraphQL. When snapshot and hook keys overlap, snapshot state wins except for asset, which stays hook-enriched. For vaults that previously served the stale hook value, pricePerShare changes from a number to the uint256 string form contract state uses; consumers should already tolerate both since pure-erc4626 vaults keep serving a number. Stale hook keys are not deleted at rest; the v3 snapshot hook echo overwrites them on the next snapshot pass, and reverting the code simply restores the previous merge behavior.
