### PR TITLE
Add bounded batch PPS endpoint

### DIFF
--- a/docs/rest.md
+++ b/docs/rest.md
@@ -189,6 +189,53 @@ curl -s https://kong.yearn.fi/api/rest/timeseries/pps/1/0x6faf8b7ffee3306efcfc2b
 
 ---
 
+#### `POST /api/rest/timeseries/pps/v2`
+
+Bounded PPS history for vaults on one or more chains. Timestamps are inclusive,
+UTC-day-aligned Unix seconds. If no point exists at `start`, the nearest earlier
+point is included as an anchor.
+
+```bash
+curl -s https://kong.yearn.fi/api/rest/timeseries/pps/v2 \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "start": 1785628800,
+    "finish": 1785715200,
+    "addresses": [
+      "1:0x0000000000000000000000000000000000000000",
+      "137:0x0123000000000000000000000000000000000123"
+    ]
+  }' | jq
+```
+
+**Illustrative response**
+
+```json
+{
+  "1:0x0000000000000000000000000000000000000000": [
+    {
+      "time": 1785628800,
+      "value": "2.5705114630967140"
+    }
+  ],
+  "137:0x0123000000000000000000000000000000000123": [
+    {
+      "time": 1785715200,
+      "value": "2.5714560633226657"
+    }
+  ]
+}
+```
+
+Response keys are normalized to `<chainId>:<lowercase-address>`. Results contain
+only humanized PPS points, ordered by time. Recent cached points override
+historical points at the same timestamp. Missing series return an empty array.
+Requests accept 1–50 addresses and a range of at most 10 calendar years.
+
+**Errors**: `400` invalid request, `413` request or response too large, `500` cache read failure.
+
+---
+
 ### Vault Reports
 
 #### `GET /api/rest/reports/:chainId/:address`

--- a/packages/web/app/api/rest/timeseries/pps/v2/contract.ts
+++ b/packages/web/app/api/rest/timeseries/pps/v2/contract.ts
@@ -1,0 +1,133 @@
+const DAY_SECONDS = 86_400
+const MAX_ADDRESSES = 50
+const MAX_RANGE_YEARS = 10
+const MAX_CHAIN_ID = 2_147_483_647
+const ADDRESS_PATTERN = /^0x[0-9a-fA-F]{40}$/
+const QUALIFIED_ADDRESS_PATTERN = /^([1-9][0-9]*):(0x[0-9a-fA-F]{40})$/
+const REQUEST_FIELDS = new Set(['start', 'finish', 'addresses'])
+
+export type PpsAddress = {
+  key: string
+  chainId: number
+  address: string
+}
+
+export type PpsBatchRequest = {
+  start: number
+  finish: number
+  addresses: PpsAddress[]
+}
+
+export type PpsPoint = {
+  time: number
+  value: string
+}
+
+export type PpsBatchResponse = Record<string, PpsPoint[]>
+
+export type ParsePpsBatchRequestResult =
+  | { success: true; data: PpsBatchRequest }
+  | { success: false; error: string }
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isUtcDayTimestamp(value: unknown): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0 && value % DAY_SECONDS === 0
+}
+
+function isWithinRangeLimit(start: number, finish: number): boolean {
+  const startDate = new Date(start * 1_000)
+  if (!Number.isFinite(startDate.getTime())) return false
+
+  const targetYear = startDate.getUTCFullYear() + MAX_RANGE_YEARS
+  const targetMonth = startDate.getUTCMonth()
+  const lastTargetDay = new Date(Date.UTC(targetYear, targetMonth + 1, 0)).getUTCDate()
+  const targetDay = Math.min(startDate.getUTCDate(), lastTargetDay)
+  const maximumFinish = Date.UTC(targetYear, targetMonth, targetDay) / 1_000
+
+  return finish <= maximumFinish
+}
+
+function parseQualifiedAddress(value: unknown): PpsAddress | undefined {
+  if (typeof value !== 'string') return undefined
+
+  const match = QUALIFIED_ADDRESS_PATTERN.exec(value)
+  if (!match) return undefined
+
+  const chainId = Number(match[1])
+  const address = match[2].toLowerCase()
+
+  if (
+    !Number.isSafeInteger(chainId) ||
+    chainId <= 0 ||
+    chainId > MAX_CHAIN_ID ||
+    !ADDRESS_PATTERN.test(address)
+  ) {
+    return undefined
+  }
+
+  return {
+    key: `${chainId}:${address}`,
+    chainId,
+    address,
+  }
+}
+
+export function parsePpsBatchRequest(input: unknown): ParsePpsBatchRequestResult {
+  if (!isRecord(input)) {
+    return { success: false, error: 'Request body must be a JSON object' }
+  }
+
+  const fields = Object.keys(input)
+  if (fields.length !== REQUEST_FIELDS.size || fields.some((field) => !REQUEST_FIELDS.has(field))) {
+    return { success: false, error: 'Request body must contain only start, finish, and addresses' }
+  }
+
+  if (!isUtcDayTimestamp(input.start) || !isUtcDayTimestamp(input.finish)) {
+    return {
+      success: false,
+      error: 'start and finish must be non-negative UTC-day Unix timestamps',
+    }
+  }
+
+  if (input.start > input.finish) {
+    return { success: false, error: 'start must be less than or equal to finish' }
+  }
+
+  if (!isWithinRangeLimit(input.start, input.finish)) {
+    return { success: false, error: 'Requested range must not exceed 10 years' }
+  }
+
+  if (!Array.isArray(input.addresses) || input.addresses.length === 0) {
+    return { success: false, error: 'addresses must contain at least one item' }
+  }
+
+  if (input.addresses.length > MAX_ADDRESSES) {
+    return { success: false, error: `addresses must contain at most ${MAX_ADDRESSES} items` }
+  }
+
+  const parsedAddresses = input.addresses.map(parseQualifiedAddress)
+  if (parsedAddresses.some((address) => address === undefined)) {
+    return {
+      success: false,
+      error: 'Each address must use the format <chainId>:<0x-address>',
+    }
+  }
+
+  const addresses = Array.from(
+    new Map(
+      (parsedAddresses as PpsAddress[]).map((address) => [address.key, address]),
+    ).values(),
+  )
+
+  return {
+    success: true,
+    data: {
+      start: input.start,
+      finish: input.finish,
+      addresses,
+    },
+  }
+}

--- a/packages/web/app/api/rest/timeseries/pps/v2/route.ts
+++ b/packages/web/app/api/rest/timeseries/pps/v2/route.ts
@@ -1,0 +1,70 @@
+import { Buffer } from 'node:buffer'
+import { NextResponse } from 'next/server'
+import { parsePpsBatchRequest } from './contract'
+import { readPpsBatch } from './service'
+
+export const runtime = 'nodejs'
+
+const corsHeaders = {
+  'access-control-allow-origin': '*',
+  'access-control-allow-methods': 'POST,OPTIONS',
+  'access-control-allow-headers': 'Content-Type',
+}
+const MAX_REQUEST_BYTES = 16 * 1_024
+const MAX_RESPONSE_BYTES = 4_000_000
+
+function errorResponse(error: string, status: number) {
+  return NextResponse.json(
+    { error },
+    { status, headers: corsHeaders },
+  )
+}
+
+export async function POST(request: Request) {
+  let body: unknown
+
+  try {
+    const contentLength = Number(request.headers.get('content-length'))
+    if (Number.isFinite(contentLength) && contentLength > MAX_REQUEST_BYTES) {
+      return errorResponse('Request body is too large', 413)
+    }
+
+    const bodyText = await request.text()
+    if (new TextEncoder().encode(bodyText).byteLength > MAX_REQUEST_BYTES) {
+      return errorResponse('Request body is too large', 413)
+    }
+
+    body = JSON.parse(bodyText)
+  } catch {
+    return errorResponse('Invalid JSON', 400)
+  }
+
+  const parsed = parsePpsBatchRequest(body)
+  if (!parsed.success) {
+    return errorResponse(parsed.error, 400)
+  }
+
+  try {
+    const response = await readPpsBatch(parsed.data)
+    const serialized = JSON.stringify(response)
+    if (Buffer.byteLength(serialized) > MAX_RESPONSE_BYTES) {
+      return errorResponse('Response is too large; reduce the range or address count', 413)
+    }
+
+    return new NextResponse(serialized, {
+      status: 200,
+      headers: {
+        'content-type': 'application/json',
+        'cache-control': 'no-store',
+        ...corsHeaders,
+      },
+    })
+  } catch (error) {
+    console.error('PPS batch read failed:', error)
+    return errorResponse('Internal server error', 500)
+  }
+}
+
+export function OPTIONS() {
+  return new NextResponse(null, { status: 204, headers: corsHeaders })
+}

--- a/packages/web/app/api/rest/timeseries/pps/v2/service.ts
+++ b/packages/web/app/api/rest/timeseries/pps/v2/service.ts
@@ -1,0 +1,133 @@
+import { createKeyv } from '@keyv/redis'
+import { getTimeseriesKey, getTimeseriesLatestKey } from '../../redis'
+import { PpsBatchRequest, PpsBatchResponse, PpsPoint } from './contract'
+
+type CacheGet = (keys: string[]) => Promise<unknown>
+
+type PpsCandidate = {
+  time: number
+  value: unknown
+}
+
+const timeseriesKeyv = createKeyv(
+  process.env.REST_CACHE_REDIS_URL || 'redis://localhost:6379',
+  { throwOnErrors: true },
+)
+const NUMERIC_STRING_PATTERN = /^-?(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)(?:[eE][+-]?[0-9]+)?$/
+const MAX_VALUE_LENGTH = 128
+const CACHE_BATCH_SERIES = 8
+
+function getCachedRows(value: unknown, key: string): unknown[] {
+  if (value === undefined) return []
+  if (!Array.isArray(value)) throw new Error(`Invalid cached timeseries value for ${key}`)
+  return value
+}
+
+function toPpsPoint(candidate: PpsCandidate): PpsPoint {
+  if (candidate.time % 86_400 !== 0) {
+    throw new Error('Invalid cached PPS timestamp')
+  }
+
+  if (typeof candidate.value === 'number') {
+    if (!Number.isFinite(candidate.value)) throw new Error('Invalid cached PPS value')
+    return { time: candidate.time, value: String(candidate.value) }
+  }
+
+  if (
+    typeof candidate.value !== 'string' ||
+    candidate.value.length === 0 ||
+    candidate.value.length > MAX_VALUE_LENGTH ||
+    !NUMERIC_STRING_PATTERN.test(candidate.value)
+  ) {
+    throw new Error('Invalid cached PPS value')
+  }
+
+  return { time: candidate.time, value: candidate.value }
+}
+
+function toPpsCandidate(value: unknown): PpsCandidate | undefined {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error('Invalid cached timeseries row')
+  }
+
+  const row = value as Record<string, unknown>
+  if (typeof row.component !== 'string') {
+    throw new Error('Invalid cached timeseries row')
+  }
+  if (row.component !== 'humanized') return undefined
+
+  if (typeof row.time !== 'number' || !Number.isSafeInteger(row.time) || row.time < 0) {
+    throw new Error('Invalid cached PPS timestamp')
+  }
+
+  return { time: row.time, value: row.value }
+}
+
+export function mergeAndSlicePps(
+  historical: unknown[],
+  latest: unknown[],
+  start: number,
+  finish: number,
+): PpsPoint[] {
+  let anchor: PpsCandidate | undefined
+  const pointsByTime = new Map<number, PpsCandidate>()
+
+  function apply(rows: unknown[]) {
+    for (const value of rows) {
+      const candidate = toPpsCandidate(value)
+      if (!candidate) continue
+
+      if (candidate.time <= start) {
+        if (!anchor || candidate.time >= anchor.time) anchor = candidate
+      } else if (candidate.time <= finish) {
+        pointsByTime.set(candidate.time, candidate)
+      }
+    }
+  }
+
+  apply(historical)
+  apply(latest)
+
+  return [
+    ...(anchor ? [toPpsPoint(anchor)] : []),
+    ...Array.from(pointsByTime.values())
+      .sort((a, b) => a.time - b.time)
+      .map(toPpsPoint),
+  ]
+}
+
+export async function readPpsBatch(
+  request: PpsBatchRequest,
+  cacheGet: CacheGet = (keys) => timeseriesKeyv.get(keys),
+): Promise<PpsBatchResponse> {
+  const entries: Array<readonly [string, PpsPoint[]]> = []
+
+  for (let offset = 0; offset < request.addresses.length; offset += CACHE_BATCH_SERIES) {
+    const addresses = request.addresses.slice(offset, offset + CACHE_BATCH_SERIES)
+    const keys = addresses.flatMap(({ chainId, address }) => [
+      getTimeseriesKey('pps', chainId, address),
+      getTimeseriesLatestKey('pps', chainId, address),
+    ])
+    const cached = await cacheGet(keys)
+    const values = cached === undefined ? Array(keys.length).fill(undefined) : cached
+
+    if (!Array.isArray(values) || values.length !== keys.length) {
+      throw new Error('Invalid PPS cache batch response')
+    }
+
+    addresses.forEach(({ key }, index) => {
+      const historicalIndex = index * 2
+      const latestIndex = historicalIndex + 1
+      const points = mergeAndSlicePps(
+        getCachedRows(values[historicalIndex], keys[historicalIndex]),
+        getCachedRows(values[latestIndex], keys[latestIndex]),
+        request.start,
+        request.finish,
+      )
+
+      entries.push([key, points])
+    })
+  }
+
+  return Object.fromEntries(entries)
+}


### PR DESCRIPTION
### Summary

Add a Redis-backed endpoint for fetching bounded PPS histories across multiple chains. This lets consumers request one shared date range for several vaults without downloading each vault’s complete timeline.

- Validate shared date ranges and chain-qualified vault addresses
- Preserve recent-over-historical precedence and predecessor anchors
- Bound request and response sizes and document the contract

### How to review

Review the implementation in this order:

1. `contract.ts` — request validation, address normalization, and limits
2. `service.ts` — Redis reads, historical/recent merging, and range selection
3. `route.ts` — HTTP handling, CORS, and payload-size protection
4. `docs/rest.md` — public request and response contract

The existing REST timeseries endpoint, GraphQL API, ingestion flow, and database schema are intentionally unchanged.

For a local smoke test:

```bash
curl -s http://localhost:3001/api/rest/timeseries/pps/v2 \
  -H 'Content-Type: application/json' \
  -d '{
    "start": 1785628800,
    "finish": 1785715200,
    "addresses": [
      "1:0x0000000000000000000000000000000000000000",
      "137:0x0123000000000000000000000000000000000123"
    ]
  }' | jq