### PR TITLE
fix(ingest): classify v3/yearn vaults consistently across discovery paths

### DIFF
--- a/config/manuals.yaml
+++ b/config/manuals.yaml
@@ -8,6 +8,7 @@ manuals:
       origin: 'yearn',
       asset: '0x0CA1C1eC4EBf3CC67a9f545fF90a3795b318cA4a',
       apiVersion: '3.0.2',
+      v3: true,
       decimals: 18,
       inceptBlock: 32996757,
       inceptTime: 1710788115
@@ -22,6 +23,7 @@ manuals:
       origin: 'yearn',
       asset: '0x0CA1C1eC4EBf3CC67a9f545fF90a3795b318cA4a',
       apiVersion: '3.0.2',
+      v3: true,
       decimals: 18,
       inceptBlock: 32996757,
       inceptTime: 1710788115
@@ -36,6 +38,7 @@ manuals:
       origin: 'yearn',
       asset: '0xcB444e90D8198415266c6a2724b7900fb12FC56E',
       apiVersion: '3.0.1',
+      v3: true,
       decimals: 18,
       inceptBlock: 33306010,
       inceptTime: 1712407830
@@ -50,6 +53,7 @@ manuals:
       origin: 'yearn',
       asset: '0xcB444e90D8198415266c6a2724b7900fb12FC56E',
       apiVersion: '3.0.1',
+      v3: true,
       decimals: 18,
       inceptBlock: 33349837,
       inceptTime: 1712636500
@@ -64,6 +68,7 @@ manuals:
       origin: 'yearn',
       asset: '0xcB444e90D8198415266c6a2724b7900fb12FC56E',
       apiVersion: '3.0.2',
+      v3: true,
       decimals: 18,
       inceptBlock: 32895582,
       inceptTime: 1712636500
@@ -78,6 +83,7 @@ manuals:
       origin: 'yearn',
       asset: '0xcB444e90D8198415266c6a2724b7900fb12FC56E',
       apiVersion: '3.0.2',
+      v3: true,
       decimals: 18,
       inceptBlock: 32895582,
       inceptTime: 1712636500
@@ -92,6 +98,7 @@ manuals:
       origin: 'yearn',
       asset: '0xcB444e90D8198415266c6a2724b7900fb12FC56E',
       apiVersion: '3.0.2',
+      v3: true,
       decimals: 18,
       inceptBlock: 32945516,
       inceptTime: 1710521005
@@ -106,6 +113,7 @@ manuals:
       origin: 'yearn',
       asset: '0xcB444e90D8198415266c6a2724b7900fb12FC56E',
       apiVersion: '3.0.2',
+      v3: true,
       decimals: 18,
       inceptBlock: 32945516,
       inceptTime: 1710521005

--- a/packages/ingest/abis/yearn/3/roleManager/event/hook.ts
+++ b/packages/ingest/abis/yearn/3/roleManager/event/hook.ts
@@ -59,6 +59,7 @@ export default async function process(chainId: number, address: `0x${string}`, d
     label: 'vault',
     defaults: {
       erc4626: true,
+      yearn: true,
       v3: true,
       vaultType: '1',
       category,

--- a/packages/ingest/abis/yearn/3/vault/event/StrategyChanged/hook.spec.ts
+++ b/packages/ingest/abis/yearn/3/vault/event/StrategyChanged/hook.spec.ts
@@ -110,4 +110,25 @@ describe('StrategyChanged hook', function() {
       apiVersion: '3.0.2'
     })
   })
+
+  it('keeps erc4626 defaults with no yearn/v3/apiVersion when apiVersion is below 3.0.0', async function() {
+    mockChain({ tokenized: false, apiVersion: '0.4.6' })
+    const add = vi.spyOn(mq, 'add').mockResolvedValue({} as never)
+
+    await process(1, STRATEGY, {
+      blockNumber: 123n,
+      args: { strategy: STRATEGY }
+    })
+
+    expect(add.mock.calls).to.have.length(1)
+    const [, payload] = add.mock.calls[0] as [unknown, { defaults: Record<string, unknown> }]
+    expect(payload.defaults).to.not.have.any.keys('yearn', 'v3', 'apiVersion')
+    expect(payload.defaults).to.deep.equal({
+      erc4626: true,
+      asset: '0xasset000000000000000000000000000000001',
+      decimals: 18,
+      inceptBlock: 1n,
+      inceptTime: 2n
+    })
+  })
 })

--- a/packages/ingest/abis/yearn/3/vault/event/StrategyChanged/hook.spec.ts
+++ b/packages/ingest/abis/yearn/3/vault/event/StrategyChanged/hook.spec.ts
@@ -1,0 +1,113 @@
+import { expect } from 'chai'
+import { mq } from 'lib'
+import * as blocks from 'lib/blocks'
+import { rpcs } from '../../../../../../rpcs'
+import process from './hook'
+
+const STRATEGY = '0x111111111111111111111111111111111111111d' as `0x${string}`
+
+function mockChain({ tokenized, apiVersion }: { tokenized: boolean, apiVersion?: string }) {
+  const readContract = vi.fn()
+    .mockResolvedValueOnce('0xasset000000000000000000000000000000001')
+    .mockResolvedValueOnce(18)
+
+  const successes = tokenized
+    ? [{ status: 'success' }, { status: 'success' }, { status: 'success' }, { status: 'success' }, { status: 'success' }]
+    : [{ status: 'failure' }, { status: 'success' }, { status: 'success' }, { status: 'success' }, { status: 'success' }]
+
+  const apiVersionResult = apiVersion === undefined
+    ? { status: 'failure' }
+    : { status: 'success', result: apiVersion }
+
+  const multicall = vi.fn().mockResolvedValue([...successes, apiVersionResult])
+
+  vi.spyOn(rpcs, 'next').mockReturnValue({ readContract, multicall } as never)
+  vi.spyOn(blocks, 'estimateCreationBlock').mockResolvedValue({ number: 1n, timestamp: 2n, chainId: 1 })
+}
+
+describe('StrategyChanged hook', function() {
+  afterEach(() => vi.restoreAllMocks())
+
+  it('merges classifyVault output into the vault thing when the probe fails but apiVersion resolves', async function() {
+    mockChain({ tokenized: false, apiVersion: '3.0.2' })
+    const add = vi.spyOn(mq, 'add').mockResolvedValue({} as never)
+
+    await process(1, STRATEGY, {
+      blockNumber: 123n,
+      args: { strategy: STRATEGY }
+    })
+
+    expect(add.mock.calls).to.have.length(1)
+    const [, payload] = add.mock.calls[0] as [unknown, { defaults: Record<string, unknown> }]
+    expect(payload.defaults).to.include({
+      yearn: true,
+      v3: true,
+      apiVersion: '3.0.2',
+      erc4626: true
+    })
+  })
+
+  it('omits yearn/v3 when the probe fails and apiVersion does not resolve', async function() {
+    mockChain({ tokenized: false, apiVersion: undefined })
+    const add = vi.spyOn(mq, 'add').mockResolvedValue({} as never)
+
+    await process(1, STRATEGY, {
+      blockNumber: 123n,
+      args: { strategy: STRATEGY }
+    })
+
+    expect(add.mock.calls).to.have.length(1)
+    const [, payload] = add.mock.calls[0] as [unknown, { defaults: Record<string, unknown> }]
+    expect(payload.defaults).to.not.have.any.keys('yearn', 'v3')
+    expect(payload.defaults).to.deep.equal({
+      erc4626: true,
+      asset: '0xasset000000000000000000000000000000001',
+      decimals: 18,
+      inceptBlock: 1n,
+      inceptTime: 2n
+    })
+  })
+
+  it('keeps erc4626 defaults with no yearn/v3 when the probe fails and apiVersion is garbage', async function() {
+    mockChain({ tokenized: false, apiVersion: 'yVault' })
+    const add = vi.spyOn(mq, 'add').mockResolvedValue({} as never)
+
+    await process(1, STRATEGY, {
+      blockNumber: 123n,
+      args: { strategy: STRATEGY }
+    })
+
+    expect(add.mock.calls).to.have.length(1)
+    const [, payload] = add.mock.calls[0] as [unknown, { defaults: Record<string, unknown> }]
+    expect(payload.defaults).to.not.have.any.keys('yearn', 'v3')
+    expect(payload.defaults).to.deep.equal({
+      erc4626: true,
+      asset: '0xasset000000000000000000000000000000001',
+      decimals: 18,
+      inceptBlock: 1n,
+      inceptTime: 2n
+    })
+  })
+
+  it('adds yearn to the vault thing on the tokenized branch alongside existing keys', async function() {
+    mockChain({ tokenized: true, apiVersion: '3.0.2' })
+    const add = vi.spyOn(mq, 'add').mockResolvedValue({} as never)
+
+    await process(1, STRATEGY, {
+      blockNumber: 123n,
+      args: { strategy: STRATEGY }
+    })
+
+    expect(add.mock.calls).to.have.length(2)
+    const [, strategyPayload] = add.mock.calls[0] as [unknown, { defaults: Record<string, unknown> }]
+    const [, vaultPayload] = add.mock.calls[1] as [unknown, { defaults: Record<string, unknown> }]
+
+    expect(strategyPayload.defaults).to.not.have.key('yearn')
+    expect(vaultPayload.defaults).to.include({
+      yearn: true,
+      v3: true,
+      erc4626: true,
+      apiVersion: '3.0.2'
+    })
+  })
+})

--- a/packages/ingest/abis/yearn/3/vault/event/StrategyChanged/hook.ts
+++ b/packages/ingest/abis/yearn/3/vault/event/StrategyChanged/hook.ts
@@ -44,6 +44,7 @@ export default async function process(chainId: number, address: `0x${string}`, d
 
   const isTokenizedStrategy = strategyCheck.slice(0, 5).every(r => r.status === 'success')
   const apiVersion = strategyCheck[5].status === 'success' ? strategyCheck[5].result as string : undefined
+  const classified = classifyVault(apiVersion)
 
   if (isTokenizedStrategy) {
     await mq.add(mq.job.load.thing, ThingSchema.parse({
@@ -80,7 +81,7 @@ export default async function process(chainId: number, address: `0x${string}`, d
       address: strategy,
       label: 'vault',
       defaults: {
-        ...(apiVersion ? classifyVault(apiVersion) ?? {} : {}),
+        ...(classified?.v3 ? classified : {}),
         erc4626: true,
         asset, decimals,
         inceptBlock,

--- a/packages/ingest/abis/yearn/3/vault/event/StrategyChanged/hook.ts
+++ b/packages/ingest/abis/yearn/3/vault/event/StrategyChanged/hook.ts
@@ -5,6 +5,7 @@ import { estimateCreationBlock } from 'lib/blocks'
 import { mq } from 'lib'
 import { rpcs } from '../../../../../../rpcs'
 import strategyAbi from '../../../strategy/abi'
+import { classifyVault } from '../../../../../../helpers/classify-vault'
 
 export const topics = [
   'event StrategyChanged(address indexed strategy, uint256 change_type)'
@@ -45,7 +46,7 @@ export default async function process(chainId: number, address: `0x${string}`, d
   const apiVersion = strategyCheck[5].status === 'success' ? strategyCheck[5].result as string : undefined
 
   if (isTokenizedStrategy) {
-    mq.add(mq.job.load.thing, ThingSchema.parse({
+    await mq.add(mq.job.load.thing, ThingSchema.parse({
       chainId,
       address: strategy,
       label: 'strategy',
@@ -59,11 +60,12 @@ export default async function process(chainId: number, address: `0x${string}`, d
       }
     }))
 
-    mq.add(mq.job.load.thing, ThingSchema.parse({
+    await mq.add(mq.job.load.thing, ThingSchema.parse({
       chainId,
       address: strategy,
       label: 'vault',
       defaults: {
+        yearn: true,
         v3: true,
         erc4626: true,
         apiVersion,
@@ -73,11 +75,12 @@ export default async function process(chainId: number, address: `0x${string}`, d
       }
     }))
   } else {
-    mq.add(mq.job.load.thing, ThingSchema.parse({
+    await mq.add(mq.job.load.thing, ThingSchema.parse({
       chainId,
       address: strategy,
       label: 'vault',
       defaults: {
+        ...(apiVersion ? classifyVault(apiVersion) ?? {} : {}),
         erc4626: true,
         asset, decimals,
         inceptBlock,

--- a/packages/ingest/abis/yearn/3/vaultFactory/event/hook.ts
+++ b/packages/ingest/abis/yearn/3/vaultFactory/event/hook.ts
@@ -41,6 +41,7 @@ export default async function process(chainId: number, address: `0x${string}`, d
     label: 'vault',
     defaults: {
       erc4626: true,
+      yearn: true,
       v3: true,
       vaultType: '1',
       asset: erc20.address,

--- a/packages/ingest/helpers/classify-vault.spec.ts
+++ b/packages/ingest/helpers/classify-vault.spec.ts
@@ -18,14 +18,21 @@ describe('classifyVault', function() {
     expect(classifyVault('0.4.6')).to.deep.equal({ yearn: true, v3: false, apiVersion: '0.4.6' })
   })
 
-  it('handles a prefixed/malformed version string', function() {
-    expect(classifyVault('v3.0.2')).to.deep.equal({ yearn: true, v3: true, apiVersion: 'v3.0.2' })
-    expect(classifyVault('0.4.6-beta')).to.deep.equal({ yearn: true, v3: false, apiVersion: '0.4.6-beta' })
+  it('returns the cleaned version so downstream compare() cannot throw', function() {
+    expect(classifyVault('v3.0.2')).to.deep.equal({ yearn: true, v3: true, apiVersion: '3.0.2' })
+    expect(classifyVault('0.4.6-beta')).to.deep.equal({ yearn: true, v3: false, apiVersion: '0.4.6' })
+    expect(classifyVault('3.0.2rc')).to.deep.equal({ yearn: true, v3: true, apiVersion: '3.0.2' })
   })
 
   it('returns undefined for unparseable input without throwing', function() {
     expect(() => classifyVault('yVault')).to.not.throw()
     expect(classifyVault('yVault')).to.equal(undefined)
     expect(classifyVault('abc')).to.equal(undefined)
+  })
+
+  it('returns undefined for empty or missing input without throwing', function() {
+    expect(() => classifyVault(undefined)).to.not.throw()
+    expect(classifyVault(undefined)).to.equal(undefined)
+    expect(classifyVault('')).to.equal(undefined)
   })
 })

--- a/packages/ingest/helpers/classify-vault.spec.ts
+++ b/packages/ingest/helpers/classify-vault.spec.ts
@@ -1,0 +1,31 @@
+import { expect } from 'chai'
+import { classifyVault } from './classify-vault'
+
+describe('classifyVault', function() {
+  it('marks v3 true for 3.0.2', function() {
+    expect(classifyVault('3.0.2')).to.deep.equal({ yearn: true, v3: true, apiVersion: '3.0.2' })
+  })
+
+  it('marks v3 true for 3.0.0', function() {
+    expect(classifyVault('3.0.0')).to.deep.equal({ yearn: true, v3: true, apiVersion: '3.0.0' })
+  })
+
+  it('marks v3 true for 10.0.0', function() {
+    expect(classifyVault('10.0.0')).to.deep.equal({ yearn: true, v3: true, apiVersion: '10.0.0' })
+  })
+
+  it('marks v3 false for 0.4.6', function() {
+    expect(classifyVault('0.4.6')).to.deep.equal({ yearn: true, v3: false, apiVersion: '0.4.6' })
+  })
+
+  it('handles a prefixed/malformed version string', function() {
+    expect(classifyVault('v3.0.2')).to.deep.equal({ yearn: true, v3: true, apiVersion: 'v3.0.2' })
+    expect(classifyVault('0.4.6-beta')).to.deep.equal({ yearn: true, v3: false, apiVersion: '0.4.6-beta' })
+  })
+
+  it('returns undefined for unparseable input without throwing', function() {
+    expect(() => classifyVault('yVault')).to.not.throw()
+    expect(classifyVault('yVault')).to.equal(undefined)
+    expect(classifyVault('abc')).to.equal(undefined)
+  })
+})

--- a/packages/ingest/helpers/classify-vault.ts
+++ b/packages/ingest/helpers/classify-vault.ts
@@ -1,13 +1,14 @@
 import { CompareOperator, compare, validate } from 'compare-versions'
 import { clean } from 'lib/version'
 
-export function classifyVault(apiVersion: string) {
+export function classifyVault(apiVersion?: string) {
+  if (!apiVersion) return undefined
   const cleaned = clean(apiVersion)
   if (!validate(cleaned)) return undefined
 
   return {
     yearn: true,
     v3: compare(cleaned, '3.0.0', '>=' as CompareOperator),
-    apiVersion
+    apiVersion: cleaned
   }
 }

--- a/packages/ingest/helpers/classify-vault.ts
+++ b/packages/ingest/helpers/classify-vault.ts
@@ -1,0 +1,13 @@
+import { CompareOperator, compare, validate } from 'compare-versions'
+import { clean } from 'lib/version'
+
+export function classifyVault(apiVersion: string) {
+  const cleaned = clean(apiVersion)
+  if (!validate(cleaned)) return undefined
+
+  return {
+    yearn: true,
+    v3: compare(cleaned, '3.0.0', '>=' as CompareOperator),
+    apiVersion
+  }
+}


### PR DESCRIPTION
### Summary
Mainnet Ondo Aggregator `0xACA399117aC588E1F48398d34eCA76CDB1E45fA5` (apiVersion 3.0.2) serves
`v3: false` on the REST vault list and `v3: null` on GraphQL because `v3`/`yearn` only exist in
`thing.defaults` and several discovery paths never write them. This adds one shared
`classifyVault(apiVersion)` helper (`{ yearn, v3: apiVersion >= 3.0.0, apiVersion }`), applies it in the
StrategyChanged else-branch, adds `yearn: true` in the vaultFactory/roleManager hooks so those vaults stop
dual-matching the generic erc4626 convention, and adds the missing `v3: true` flags in `config/manuals.yaml`.

### How to review
Start with `packages/ingest/helpers/classify-vault.ts`: version compare reuses `compare` from
`compare-versions` + `clean` from `lib/version`, the same pair as `packages/ingest/things.ts`. The helper
takes an optional string and returns `undefined` for falsy or non-semver input, so a contract returning
`apiVersion() = "yVault"` falls back to the unresolved path instead of throwing. It returns the *cleaned*
version, not the raw one — `clean()` strips non-semver characters, so a raw `3.0.2rc` would pass
`validate()` and then make the `compare()` calls in `abis/yearn/lib/tvl.ts` and `abis/yearn/lib/apy.ts`
throw on read.

Then `StrategyChanged/hook.ts`: the else-branch merges helper output only when the classification resolves
to **v3**. Anything reaching that branch is 4626-shaped, so a sub-3.0.0 classification is never the right
outcome — writing `apiVersion` alone would match the `yearn/2/vault` convention (whose hooks expect
`token()`/`pricePerShare`), and `yearn: true` alone would evict the thing from the erc4626 convention.
The tokenized branch adds `yearn: true` to the vault-labeled record only, and the three `mq.add` calls are
now awaited. The manuals.yaml edits are 8 chain-100 entries that had `apiVersion` without `v3`.

### Test plan
- [ ] Manual: after deploy, replay discovery events, drain queues, run a fresh ABI fanout, refresh the
  REST vault cache, then check Ondo on REST list / GraphQL / REST snapshot for `v3: true`.
- [x] Automated: `bunx vitest run helpers/classify-vault.spec.ts abis/yearn/3/vault/event/StrategyChanged/hook.spec.ts`
  from `packages/ingest` — 12/12 pass (helper version edges incl. the 3.0.0 boundary, cleaned-output cases
  `v3.0.2` / `0.4.6-beta` / `3.0.2rc`, garbage and empty input; hook resolved/sub-3.0.0/unresolved/garbage/
  tokenized cases).

### Risk / impact
`yearn: true` flips backfilled vaults from the erc4626 convention to yearn/3 hooks and adds them to
GraphQL `yearn: true` / origin-yearn filters and the timeseries resolver (accepted in the plan). Stale
erc4626 hook keys in snapshots are already shadowed by contract state on read. Non-yearn contracts that
expose an `apiVersion()` of 3.0.0 or above get classified as yearn (accepted); below 3.0.0 they keep their
erc4626 classification unchanged. Rollback: revert, replay, re-fanout.

### Known gaps
- The vaultFactory and roleManager `yearn: true` edits have no test, and `output`/timeseries rows already
  written under erc4626 hook keys for backfilled vaults are not graded — only snapshots are.
- `classifyVault` has one call site. vaultFactory, roleManager and the three v3 registry hooks still stamp
  `v3: true` regardless of the apiVersion they read.
- `config/manuals.yaml:37` and `:52` keep `yearn: false` alongside `apiVersion: '3.0.1'`, so they still
  dual-match erc4626 and yearn/3.
