### PR TITLE
ci: add claude code review caller workflow

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,0 +1,30 @@
+name: Claude code review
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: write
+
+jobs:
+  review:
+    # Trigger filter, not a security gate: the reusable workflow keeps all
+    # four gates and still enforces write access; the author_association
+    # check here is only a coarse pre-filter. The body match is exact on the
+    # two commands (plus a trailing-text form) so a near-miss comment like
+    # /reviews never claims the concurrency group and cancels a running
+    # review. Trade-off: a /review followed by a newline does not trigger.
+    if: >-
+      github.event.issue.pull_request &&
+      (github.event.comment.body == '/review' ||
+       startsWith(github.event.comment.body, '/review ') ||
+       github.event.comment.body == '/review-workflow' ||
+       startsWith(github.event.comment.body, '/review-workflow ')) &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+    concurrency:
+      group: claude-review-${{ github.event.issue.number }}
+      cancel-in-progress: true
+    uses: yearn/yearn-gha/.github/workflows/claude-code-review.yml@83bcb6d810e9e53f29e334ae200ab19f125d13bd

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -11,19 +11,12 @@ permissions:
 
 jobs:
   review:
-    # Trigger filter, not a security gate: the reusable workflow keeps all
-    # four gates and still enforces write access; the author_association
-    # check here is only a coarse pre-filter. The body match is exact on the
-    # two commands (plus a trailing-text form) so a near-miss comment like
-    # /reviews never claims the concurrency group and cancels a running
-    # review. Trade-off: a /review followed by a newline does not trigger.
-    if: >-
-      github.event.issue.pull_request &&
-      (github.event.comment.body == '/review' ||
-       startsWith(github.event.comment.body, '/review ') ||
-       github.event.comment.body == '/review-workflow' ||
-       startsWith(github.event.comment.body, '/review-workflow ')) &&
-      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+    # Coarse trigger filter, not a security gate: the reusable workflow keeps
+    # all four gates and still enforces write access; the author_association
+    # check here is only a coarse pre-filter. It matches the two accepted
+    # commands exactly so a near-miss comment cannot claim the concurrency
+    # group and cancel a review in flight.
+    if: ${{ github.event.issue.pull_request && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) && (github.event.comment.body == '/review' || github.event.comment.body == '/review-workflow' || startsWith(github.event.comment.body, '/review ') || startsWith(github.event.comment.body, '/review-workflow ')) }}
     concurrency:
       group: claude-review-${{ github.event.issue.number }}
       cancel-in-progress: true


### PR DESCRIPTION
### Summary

Adds a SHA-pinned caller for the shared yearn-gha Claude review. Collaborators can comment `/review` or `/review-workflow` on a PR to run it.

### How to review

`.github/workflows/review.yml` only. It should match `yearn/yearn-gha` `examples/claude-code-review/review.yml`, pinned to `83bcb6d810e9e53f29e334ae200ab19f125d13bd`.

### Test plan
- [ ] Manual: after merge, comment `/review` on a test PR and confirm a review posts. Repeat `/review-workflow`. Confirm a second command cancels the in-flight run.
- [ ] Automated: not applicable. This is a workflow caller; no app tests.

### Risk / impact

Grants `id-token: write` so the reusable workflow can fetch the Claude OAuth token from Doppler. No app code, no funds path. Rollback is deleting the caller workflow. Do not mark the review job as a required check.
