### PR TITLE
perf(prices): batch price service lookups and extend block cache ttl

### DIFF
--- a/packages/ingest/prices.service-cache.mock.spec.ts
+++ b/packages/ingest/prices.service-cache.mock.spec.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { cacheGet, cacheSet, blockTime, wrapStore } = vi.hoisted(() => ({
-  cacheGet: vi.fn(), cacheSet: vi.fn(), blockTime: vi.fn(), wrapStore: new Map<string, unknown>()
+const { cacheGet, cacheSet, blockTime, wrapStore, wrapTtls } = vi.hoisted(() => ({
+  cacheGet: vi.fn(), cacheSet: vi.fn(), blockTime: vi.fn(),
+  wrapStore: new Map<string, unknown>(), wrapTtls: [] as unknown[]
 }))
 
 vi.mock('lib/blocks', () => ({
@@ -13,7 +14,8 @@ vi.mock('lib/cache', () => ({
   cache: {
     get: cacheGet,
     set: cacheSet,
-    wrap: async (key: string, fn: () => Promise<unknown>) => {
+    wrap: async (key: string, fn: () => Promise<unknown>, ttl?: unknown) => {
+      wrapTtls.push(ttl)
       if (!wrapStore.has(key)) wrapStore.set(key, await fn())
       return wrapStore.get(key)
     }
@@ -23,7 +25,34 @@ vi.mock('lib/cache', () => ({
 import { fetchErc20PriceUsd } from './prices'
 
 const WETH = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2' as const
+const WETH_COIN = 'polygon:0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
 const CHAIN_ID = 137 // polygon — not in the on-chain `lens` map
+
+const endOfDay = (timestamp: number) => Math.floor(timestamp / 86400) * 86400 + 86399
+
+// Mirrors batchHistorical: echoes the requested keys, answers at end-of-day.
+function batchHit(price: number) {
+  return vi.fn(async (url: string) => {
+    const coins = JSON.parse(decodeURIComponent(new URL(url).searchParams.get('coins')!)) as Record<string, number[]>
+    return {
+      ok: true,
+      json: async () => ({
+        coins: Object.fromEntries(Object.entries(coins).map(([coinId, timestamps]) => [
+          coinId,
+          { symbol: 'TOKEN', prices: timestamps.map(timestamp => ({ timestamp: endOfDay(timestamp), price })) }
+        ]))
+      })
+    }
+  })
+}
+
+function batchMissThenExact(exact: { ok: boolean, status?: number, price?: number }) {
+  return vi.fn(async (url: string) => url.includes('batchHistorical')
+    ? { ok: true, json: async () => ({ coins: {} }) }
+    : exact.ok
+      ? { ok: true, json: async () => ({ coins: { [WETH_COIN]: { symbol: 'WETH', price: exact.price } } }) }
+      : { ok: false, status: exact.status })
+}
 
 describe('fetchErc20PriceUsd (USE_PRICE_SERVICE, past-day path)', () => {
   const originalUsePriceService = process.env.USE_PRICE_SERVICE
@@ -39,6 +68,7 @@ describe('fetchErc20PriceUsd (USE_PRICE_SERVICE, past-day path)', () => {
     cacheSet.mockReset()
     blockTime.mockReset().mockResolvedValue(1700000000n)
     wrapStore.clear()
+    wrapTtls.length = 0
   })
 
   afterEach(() => {
@@ -53,17 +83,7 @@ describe('fetchErc20PriceUsd (USE_PRICE_SERVICE, past-day path)', () => {
   })
 
   it('caches a service hit under the day key', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => ({
-      ok: true,
-      json: async () => ({
-        coins: {
-          ['polygon:0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2']: {
-            symbol: 'WETH',
-            price: 2
-          }
-        }
-      })
-    })))
+    vi.stubGlobal('fetch', batchHit(2))
 
     const { priceSource, priceUsd } = await fetchErc20PriceUsd(CHAIN_ID, WETH, 1n)
 
@@ -75,8 +95,20 @@ describe('fetchErc20PriceUsd (USE_PRICE_SERVICE, past-day path)', () => {
     expect(key).toContain(':137:')
   })
 
+  it('holds a service hit in the block cache for the head-block window', async () => {
+    vi.stubGlobal('fetch', batchHit(2))
+
+    await fetchErc20PriceUsd(CHAIN_ID, WETH, 1n)
+
+    const ttl = wrapTtls.at(-1) as (result: { priceSource: string }) => number
+    expect(typeof ttl).to.equal('function')
+    expect(ttl({ priceSource: 'priceservice' })).to.equal(15 * 60 * 1000)
+    expect(ttl({ priceSource: 'na' })).to.equal(120_000)
+    expect(ttl({ priceSource: 'unavailable' })).to.equal(120_000)
+  })
+
   it('caches an unknown result under a short-lived negative marker', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, status: 404 })))
+    vi.stubGlobal('fetch', batchMissThenExact({ ok: false, status: 404 }))
 
     const { priceSource, priceUsd } = await fetchErc20PriceUsd(CHAIN_ID, WETH, 1n)
 
@@ -91,14 +123,7 @@ describe('fetchErc20PriceUsd (USE_PRICE_SERVICE, past-day path)', () => {
   })
 
   it('does not promote a literal zero price into the day cache', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => ({
-      ok: true,
-      json: async () => ({
-        coins: {
-          ['polygon:0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2']: { symbol: 'WETH', price: 0 }
-        }
-      })
-    })))
+    vi.stubGlobal('fetch', batchHit(0))
 
     const { priceSource, priceUsd } = await fetchErc20PriceUsd(CHAIN_ID, WETH, 1n)
 
@@ -110,16 +135,18 @@ describe('fetchErc20PriceUsd (USE_PRICE_SERVICE, past-day path)', () => {
     expect(ttl).to.equal(120_000)
   })
 
-  it('issues one fetch for repeat misses of the same block', async () => {
-    const fetchMock = vi.fn(async () => ({ ok: false, status: 404 }))
+  it('issues no further calls for repeat misses of the same block', async () => {
+    const fetchMock = batchMissThenExact({ ok: false, status: 404 })
     vi.stubGlobal('fetch', fetchMock)
 
     const first = await fetchErc20PriceUsd(CHAIN_ID, WETH, 1n)
+    const callsAfterFirst = fetchMock.mock.calls.length
     const second = await fetchErc20PriceUsd(CHAIN_ID, WETH, 1n)
 
     expect(first.priceSource).to.equal('na')
     expect(second.priceSource).to.equal('na')
-    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(callsAfterFirst).to.equal(2) // batch miss, then the exact endpoint
+    expect(fetchMock.mock.calls.length).to.equal(callsAfterFirst)
     expect(cacheSet).toHaveBeenCalledTimes(2)
   })
 
@@ -146,17 +173,7 @@ describe('fetchErc20PriceUsd (USE_PRICE_SERVICE, past-day path)', () => {
     cacheGet.mockImplementation(async (key: string) => store.get(key))
     cacheSet.mockImplementation(async (key: string, value: unknown) => { store.set(key, value) })
 
-    const fetchMock = vi.fn(async () => ({
-      ok: true,
-      json: async () => ({
-        coins: {
-          ['polygon:0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2']: {
-            symbol: 'WETH',
-            price: 2
-          }
-        }
-      })
-    }))
+    const fetchMock = batchHit(2)
     vi.stubGlobal('fetch', fetchMock)
 
     for (const blockNumber of [1n, 2n, 3n, 4n]) {
@@ -167,11 +184,11 @@ describe('fetchErc20PriceUsd (USE_PRICE_SERVICE, past-day path)', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 
-  it('issues one fetch for distinct past-day blocks after an unavailable response', async () => {
+  it('stops calling out for distinct past-day blocks after an unavailable response', async () => {
     const store = new Map<string, unknown>()
     cacheGet.mockImplementation(async (key: string) => store.get(key))
     cacheSet.mockImplementation(async (key: string, value: unknown) => { store.set(key, value) })
-    const fetchMock = vi.fn(async () => ({ ok: false, status: 503 }))
+    const fetchMock = batchMissThenExact({ ok: false, status: 503 })
     vi.stubGlobal('fetch', fetchMock)
 
     for (const blockNumber of [1n, 2n, 3n, 4n]) {
@@ -180,24 +197,14 @@ describe('fetchErc20PriceUsd (USE_PRICE_SERVICE, past-day path)', () => {
       expect(priceUsd).to.equal(0)
     }
 
-    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledTimes(2) // batch miss, then the exact endpoint
   })
 
-  it('skips the day key for a current-day block (routes through the 30s cache)', async () => {
+  it('skips the day key for a current-day block (routes through the block cache)', async () => {
     const nowSec = Math.floor(Date.now() / 1000)
     blockTime.mockResolvedValue(BigInt(nowSec))
 
-    const fetchMock = vi.fn(async () => ({
-      ok: true,
-      json: async () => ({
-        coins: {
-          ['polygon:0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2']: {
-            symbol: 'WETH',
-            price: 2
-          }
-        }
-      })
-    }))
+    const fetchMock = batchHit(2)
     vi.stubGlobal('fetch', fetchMock)
 
     const { priceSource, priceUsd } = await fetchErc20PriceUsd(CHAIN_ID, WETH, 1n)
@@ -211,17 +218,7 @@ describe('fetchErc20PriceUsd (USE_PRICE_SERVICE, past-day path)', () => {
   it('skips the day cache entirely with no blockNumber (latest path)', async () => {
     blockTime.mockResolvedValue(1700000000n) // past day — would hit the day-cache branch if latest weren't set
 
-    const fetchMock = vi.fn(async () => ({
-      ok: true,
-      json: async () => ({
-        coins: {
-          ['polygon:0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2']: {
-            symbol: 'WETH',
-            price: 2
-          }
-        }
-      })
-    }))
+    const fetchMock = batchHit(2)
     vi.stubGlobal('fetch', fetchMock)
 
     const { priceSource, priceUsd } = await fetchErc20PriceUsd(CHAIN_ID, WETH)

--- a/packages/ingest/prices.service.mock.spec.ts
+++ b/packages/ingest/prices.service.mock.spec.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { blockTime, first, mqAdd, multicall } = vi.hoisted(() => ({
-  blockTime: vi.fn(), first: vi.fn(), mqAdd: vi.fn(), multicall: vi.fn()
+const { blockTime, first, mqAdd, multicall, query } = vi.hoisted(() => ({
+  blockTime: vi.fn(), first: vi.fn(), mqAdd: vi.fn(), multicall: vi.fn(), query: vi.fn()
 }))
 
 vi.mock('lib', () => ({
@@ -24,7 +24,7 @@ vi.mock('lib/cache', () => ({
 }))
 
 vi.mock('./db', () => ({
-  default: { query: vi.fn() },
+  default: { query },
   first
 }))
 
@@ -221,5 +221,42 @@ describe('fetchErc20PriceUsd (USE_PRICE_SERVICE=true)', () => {
 
     expect(price.priceSource).to.equal('na')
     expect(outputs).not.to.deep.equal([])
+  })
+})
+
+describe('fetchErc20PriceUsd (USE_PRICE_SERVICE=false)', () => {
+  const originalUsePriceService = process.env.USE_PRICE_SERVICE
+  const originalApiKey = process.env.PRICE_SERVICE_API_KEY
+
+  beforeEach(() => {
+    process.env.USE_PRICE_SERVICE = 'false'
+    process.env.PRICE_SERVICE_API_KEY = 'test-key'
+    mqAdd.mockReset()
+    query.mockReset().mockResolvedValue({ rows: [] })
+    blockTime.mockReset().mockResolvedValue(1700000000n)
+  })
+
+  afterEach(() => {
+    if (originalUsePriceService === undefined) delete process.env.USE_PRICE_SERVICE
+    else process.env.USE_PRICE_SERVICE = originalUsePriceService
+    if (originalApiKey === undefined) delete process.env.PRICE_SERVICE_API_KEY
+    else process.env.PRICE_SERVICE_API_KEY = originalApiKey
+    vi.unstubAllGlobals()
+  })
+
+  it('reaches the price service through the exact endpoint, never the batch route', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ coins: { [WETH_COIN]: { symbol: 'WETH', price: 3 } } })
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { priceSource, priceUsd } = await fetchErc20PriceUsd(CHAIN_ID, WETH, 1n)
+
+    expect(priceSource).to.equal('priceservice')
+    expect(priceUsd).to.equal(3)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0][0]).toContain('/api/prices/historical/1700000000/')
+    expect(fetchMock.mock.calls.some(([url]) => String(url).includes('batchHistorical'))).to.equal(false)
   })
 })

--- a/packages/ingest/prices.service.mock.spec.ts
+++ b/packages/ingest/prices.service.mock.spec.ts
@@ -42,6 +42,23 @@ import processTvl from './abis/yearn/lib/tvl'
 const WETH = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2' as const
 const VAULT = '0x1111111111111111111111111111111111111111' as const
 const CHAIN_ID = 137 // polygon — not in the on-chain `lens` map
+const WETH_COIN = 'polygon:0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
+const DAY_END = 1700006399
+
+function batchResponse(prices: Record<string, number>) {
+  return {
+    ok: true,
+    json: async () => ({
+      coins: Object.fromEntries(Object.entries(prices).map(([coinId, price]) => [
+        coinId, { symbol: 'TOKEN', prices: [{ timestamp: DAY_END, price }] }
+      ]))
+    })
+  }
+}
+
+function decodeCoins(url: string) {
+  return JSON.parse(decodeURIComponent(new URL(url).searchParams.get('coins')!))
+}
 
 describe('fetchErc20PriceUsd (USE_PRICE_SERVICE=true)', () => {
   const originalUsePriceService = process.env.USE_PRICE_SERVICE
@@ -71,18 +88,10 @@ describe('fetchErc20PriceUsd (USE_PRICE_SERVICE=true)', () => {
     vi.unstubAllGlobals()
   })
 
-  it('returns the price service value and never enqueues', async () => {
-    const fetchMock = vi.fn(async () => ({
-      ok: true,
-      json: async () => ({
-        coins: {
-          ['polygon:0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2']: {
-            symbol: 'WETH',
-            price: 2
-          }
-        }
-      })
-    }))
+  it('returns the price service value from one batch call and never enqueues', async () => {
+    const fetchMock = vi.fn(async (requested: string) => requested.includes('batchHistorical')
+      ? batchResponse({ [WETH_COIN]: 2 })
+      : { ok: false, status: 500 })
     vi.stubGlobal('fetch', fetchMock)
 
     const { priceSource, priceUsd } = await fetchErc20PriceUsd(CHAIN_ID, WETH, 1n)
@@ -91,12 +100,31 @@ describe('fetchErc20PriceUsd (USE_PRICE_SERVICE=true)', () => {
     expect(priceUsd).to.equal(2)
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(mqAdd).not.toHaveBeenCalled()
-    expect(fetchMock.mock.calls[0][0]).to.equal('https://prices.yearn.dev/api/prices/historical/1700000000/polygon:0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2')
-    expect(fetchMock.mock.calls[0][0]).not.toContain('source=')
+    const url = fetchMock.mock.calls[0][0]
+    expect(url).toContain('https://prices.yearn.dev/api/prices/batchHistorical?coins=')
+    expect(decodeCoins(url)).to.deep.equal({ [WETH_COIN]: [1700000000] })
+    expect(url).not.toContain('source=')
   })
 
-  it('returns na when the service says the price is missing — no fallback, no enqueue', async () => {
-    const fetchMock = vi.fn(async () => ({ ok: false, status: 404 }))
+  it('falls back to the exact endpoint when the batch has no row for the day', async () => {
+    const fetchMock = vi.fn(async (url: string) => url.includes('batchHistorical')
+      ? batchResponse({})
+      : {
+        ok: true,
+        json: async () => ({ coins: { [WETH_COIN]: { symbol: 'WETH', price: 3 } } })
+      })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { priceSource, priceUsd } = await fetchErc20PriceUsd(CHAIN_ID, WETH, 1n)
+
+    expect(priceSource).to.equal('priceservice')
+    expect(priceUsd).to.equal(3)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(fetchMock.mock.calls[1][0]).to.equal(`https://prices.yearn.dev/api/prices/historical/1700000000/${WETH_COIN}`)
+  })
+
+  it('returns na without an exact call when the batch stores a zero price', async () => {
+    const fetchMock = vi.fn(async () => batchResponse({ [WETH_COIN]: 0 }))
     vi.stubGlobal('fetch', fetchMock)
 
     const { priceSource, priceUsd } = await fetchErc20PriceUsd(CHAIN_ID, WETH, 1n)
@@ -104,6 +132,68 @@ describe('fetchErc20PriceUsd (USE_PRICE_SERVICE=true)', () => {
     expect(priceSource).to.equal('na')
     expect(priceUsd).to.equal(0)
     expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to the exact endpoint when the batch call fails', async () => {
+    const fetchMock = vi.fn(async (url: string) => url.includes('batchHistorical')
+      ? { ok: false, status: 500 }
+      : { ok: true, json: async () => ({ coins: { [WETH_COIN]: { symbol: 'WETH', price: 4 } } }) })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { priceSource, priceUsd } = await fetchErc20PriceUsd(CHAIN_ID, WETH, 1n)
+
+    expect(priceSource).to.equal('priceservice')
+    expect(priceUsd).to.equal(4)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('coalesces concurrent lookups into one batch call', async () => {
+    const other = '0x2222222222222222222222222222222222222222' as const
+    const otherCoin = `polygon:${other.toLowerCase()}`
+    const fetchMock = vi.fn(async (requested: string) => requested.includes('batchHistorical')
+      ? batchResponse({ [WETH_COIN]: 2, [otherCoin]: 7 })
+      : { ok: false, status: 500 })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const [weth, second, duplicate] = await Promise.all([
+      fetchErc20PriceUsd(CHAIN_ID, WETH, 1n),
+      fetchErc20PriceUsd(CHAIN_ID, other, 2n),
+      fetchErc20PriceUsd(CHAIN_ID, WETH, 3n)
+    ])
+
+    expect(weth.priceUsd).to.equal(2)
+    expect(second.priceUsd).to.equal(7)
+    expect(duplicate.priceUsd).to.equal(2)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(Object.keys(decodeCoins(fetchMock.mock.calls[0][0]))).to.have.lengthOf(2)
+  })
+
+  it('splits more than 50 queued tokens across batch calls', async () => {
+    const fetchMock = vi.fn(async (requested: string) => requested.includes('batchHistorical')
+      ? batchResponse({})
+      : { ok: false, status: 404 })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const tokens = Array.from({ length: 51 }, (_, index) =>
+      `0x${(index + 1).toString(16).padStart(40, '0')}` as `0x${string}`)
+
+    await Promise.all(tokens.map(token => fetchErc20PriceUsd(CHAIN_ID, token, 1n)))
+
+    const batchCalls = fetchMock.mock.calls.filter(([url]) => url.includes('batchHistorical'))
+    expect(batchCalls).to.have.lengthOf(2)
+  })
+
+  it('returns na when both the batch and the exact endpoint have nothing — no enqueue', async () => {
+    const fetchMock = vi.fn(async (url: string) => url.includes('batchHistorical')
+      ? batchResponse({})
+      : { ok: false, status: 404 })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { priceSource, priceUsd } = await fetchErc20PriceUsd(CHAIN_ID, WETH, 1n)
+
+    expect(priceSource).to.equal('na')
+    expect(priceUsd).to.equal(0)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
     expect(mqAdd).not.toHaveBeenCalled()
   })
 

--- a/packages/ingest/prices.ts
+++ b/packages/ingest/prices.ts
@@ -19,6 +19,9 @@ const DAY_SECONDS = 86_400
 const PAST_DAY_CACHE_TTL_MS = 24 * 60 * 60 * 1000
 const PAST_DAY_NEGATIVE_CACHE_TTL_MS = 120_000
 const BLOCK_CACHE_TTL_MS = 30_000
+// lib/blocks pins the head block for 15m and the service refreshes today's row hourly, so a 30s
+// ttl re-fetched an unchanged value ~120x/h per token.
+const SERVICE_BLOCK_CACHE_TTL_MS = 15 * 60 * 1000
 
 /** When true, indexer reads prices from yearn-prices and skips the Postgres price table. */
 export function usePriceService(): boolean {
@@ -63,7 +66,7 @@ export async function fetchErc20PriceUsd(chainId: number, token: `0x${string}`, 
       const result = await cache.wrap(
         blockCacheKey,
         async () => __fetchErc20PriceUsd(chainId, token, blockNumber!, latest, blockTime),
-        BLOCK_CACHE_TTL_MS
+        blockCacheTtl()
       )
       // Only a day-granular service result is safe under a day key: a transient miss must
       // not stick tvl=0 for the whole day.
@@ -76,8 +79,16 @@ export async function fetchErc20PriceUsd(chainId: number, token: `0x${string}`, 
   return cache.wrap(
     blockCacheKey,
     async () => __fetchErc20PriceUsd(chainId, token, blockNumber!, latest),
-    BLOCK_CACHE_TTL_MS
+    blockCacheTtl()
   )
+}
+
+// Misses keep the short negative ttl so a transient outage can't stick tvl=0 for 15 minutes.
+function blockCacheTtl() {
+  if (!usePriceService()) return BLOCK_CACHE_TTL_MS
+  return (result: { priceSource: string }) => result.priceSource === 'priceservice'
+    ? SERVICE_BLOCK_CACHE_TTL_MS
+    : PAST_DAY_NEGATIVE_CACHE_TTL_MS
 }
 
 async function __fetchErc20PriceUsd(
@@ -206,25 +217,116 @@ async function fetchPriceServiceUsdResult(chainId: number, token: `0x${string}`,
   try {
     const blockTime = knownBlockTime ?? await getBlockTime(chainId, blockNumber)
     const coinId = `${chainName}:${token.toLowerCase()}`
-    const url = `${baseUrl}/api/prices/historical/${Number(blockTime)}/${coinId}`
+
+    const batched = await enqueuePriceServiceBatch(coinId, Number(blockTime))
+    if (batched.found) {
+      const priceUsd = batched.priceUsd
+      // A stored zero is an answer, not a gap: the exact endpoint would read the same row.
+      if (!priceUsd || !Number.isFinite(priceUsd)) { warn('empty coins'); return { type: 'missing' } }
+      return { type: 'price', price: PriceSchema.parse({ chainId, address: token, priceUsd, priceSource: 'priceservice', blockNumber, blockTime }) }
+    }
+
+    // batchHistorical reads the table only; the exact route also resolves upstream on a table miss.
+    return await fetchPriceServiceExactResult({ chainId, token, blockNumber, blockTime, coinId, baseUrl, warn })
+  } catch (error) {
+    console.warn('🚨', 'price service failed', chainId, token, blockNumber, error)
+    return { type: 'unavailable' }
+  }
+}
+
+async function fetchPriceServiceExactResult(request: {
+  chainId: number
+  token: `0x${string}`
+  blockNumber: bigint
+  blockTime: bigint
+  coinId: string
+  baseUrl: string
+  warn: (reason: string, detail?: unknown) => void
+}): Promise<PriceServiceResult> {
+  const { chainId, token, blockNumber, blockTime, coinId, baseUrl, warn } = request
+  const url = `${baseUrl}/api/prices/historical/${Number(blockTime)}/${coinId}`
+
+  const response = await fetch(url, {
+    headers: { Authorization: `Bearer ${process.env.PRICE_SERVICE_API_KEY}` }
+  })
+  if (!response.ok) {
+    warn('http', response.status)
+    return response.status === 404 ? { type: 'missing' } : { type: 'unavailable' }
+  }
+
+  const data = await response.json() as { coins: Record<string, { price: number }> }
+  const coinData = data.coins[coinId]
+  const priceUsd = coinData?.price
+  if (!priceUsd || !Number.isFinite(priceUsd)) { warn('empty coins'); return { type: 'missing' } }
+
+  return { type: 'price', price: PriceSchema.parse({ chainId, address: token, priceUsd, priceSource: 'priceservice', blockNumber, blockTime }) }
+}
+
+type PriceServiceBatchOutcome = { found: true, priceUsd: number } | { found: false }
+
+type PriceServiceBatchEntry = {
+  coinId: string
+  timestamp: number
+  promise: Promise<PriceServiceBatchOutcome>
+  resolve: (outcome: PriceServiceBatchOutcome) => void
+}
+
+const BATCH_FLUSH_MS = 25
+// Capping queued entries also caps distinct coins and per-coin timestamps, the service's two limits.
+const BATCH_MAX_ENTRIES = 50
+
+const pendingBatch = new Map<string, PriceServiceBatchEntry>()
+let batchTimer: ReturnType<typeof setTimeout> | undefined
+
+function enqueuePriceServiceBatch(coinId: string, timestamp: number): Promise<PriceServiceBatchOutcome> {
+  const key = `${coinId}:${utcDayStart(timestamp)}`
+  const queued = pendingBatch.get(key)
+  if (queued) return queued.promise
+
+  let resolve!: (outcome: PriceServiceBatchOutcome) => void
+  const promise = new Promise<PriceServiceBatchOutcome>(_resolve => { resolve = _resolve })
+  pendingBatch.set(key, { coinId, timestamp, promise, resolve })
+
+  if (pendingBatch.size >= BATCH_MAX_ENTRIES) flushPriceServiceBatch()
+  else if (!batchTimer) batchTimer = setTimeout(flushPriceServiceBatch, BATCH_FLUSH_MS)
+
+  return promise
+}
+
+function flushPriceServiceBatch() {
+  if (batchTimer) { clearTimeout(batchTimer); batchTimer = undefined }
+  const entries = [...pendingBatch.values()]
+  pendingBatch.clear()
+  for (let i = 0; i < entries.length; i += BATCH_MAX_ENTRIES) {
+    void sendPriceServiceBatch(entries.slice(i, i + BATCH_MAX_ENTRIES))
+  }
+}
+
+// Never throws: an unresolved entry falls through to the exact endpoint, same as a table miss.
+async function sendPriceServiceBatch(entries: PriceServiceBatchEntry[]) {
+  try {
+    const coins: Record<string, number[]> = {}
+    for (const entry of entries) (coins[entry.coinId] ??= []).push(entry.timestamp)
+
+    const baseUrl = process.env.PRICE_SERVICE_URL || PRICE_SERVICE_DEFAULT_URL
+    const url = `${baseUrl}/api/prices/batchHistorical?coins=${encodeURIComponent(JSON.stringify(coins))}`
 
     const response = await fetch(url, {
       headers: { Authorization: `Bearer ${process.env.PRICE_SERVICE_API_KEY}` }
     })
-    if (!response.ok) {
-      warn('http', response.status)
-      return response.status === 404 ? { type: 'missing' } : { type: 'unavailable' }
+    if (!response.ok) throw new Error(`batchHistorical ${response.status}`)
+
+    const data = await response.json() as { coins?: Record<string, { prices?: { timestamp: number, price: number }[] }> }
+    // The service echoes the key it parsed, which checksums the address.
+    const byCoin = new Map(Object.entries(data.coins ?? {}).map(([key, value]) => [key.toLowerCase(), value]))
+
+    for (const entry of entries) {
+      const day = utcDayStart(entry.timestamp)
+      const hit = byCoin.get(entry.coinId)?.prices?.find(price => utcDayStart(price.timestamp) === day)
+      entry.resolve(hit ? { found: true, priceUsd: hit.price } : { found: false })
     }
-
-    const data = await response.json() as { coins: Record<string, { price: number }> }
-    const coinData = data.coins[coinId]
-    const priceUsd = coinData?.price
-    if (!priceUsd || !Number.isFinite(priceUsd)) { warn('empty coins'); return { type: 'missing' } }
-
-    return { type: 'price', price: PriceSchema.parse({ chainId, address: token, priceUsd, priceSource: 'priceservice', blockNumber, blockTime }) }
-  } catch (error) {
-    console.warn('🚨', 'price service failed', chainId, token, blockNumber, error)
-    return { type: 'unavailable' }
+  } catch {
+    for (const entry of entries) entry.resolve({ found: false })
   }
 }
 

--- a/packages/ingest/prices.ts
+++ b/packages/ingest/prices.ts
@@ -218,7 +218,11 @@ async function fetchPriceServiceUsdResult(chainId: number, token: `0x${string}`,
     const blockTime = knownBlockTime ?? await getBlockTime(chainId, blockNumber)
     const coinId = `${chainName}:${token.toLowerCase()}`
 
-    const batched = await enqueuePriceServiceBatch(coinId, Number(blockTime))
+    // Batching is service-mode only: the legacy path hits this as a rare last resort, where a
+    // flush window buys nothing and the kill switch should take the whole layer with it.
+    const batched = usePriceService()
+      ? await enqueuePriceServiceBatch(coinId, Number(blockTime))
+      : { found: false } as const
     if (batched.found) {
       const priceUsd = batched.priceUsd
       // A stored zero is an answer, not a gap: the exact endpoint would read the same row.
@@ -314,7 +318,7 @@ async function sendPriceServiceBatch(entries: PriceServiceBatchEntry[]) {
     const response = await fetch(url, {
       headers: { Authorization: `Bearer ${process.env.PRICE_SERVICE_API_KEY}` }
     })
-    if (!response.ok) throw new Error(`batchHistorical ${response.status}`)
+    if (!response.ok) throw new Error(`batchHistorical ${response.status} ${url}`)
 
     const data = await response.json() as { coins?: Record<string, { prices?: { timestamp: number, price: number }[] }> }
     // The service echoes the key it parsed, which checksums the address.
@@ -325,7 +329,9 @@ async function sendPriceServiceBatch(entries: PriceServiceBatchEntry[]) {
       const hit = byCoin.get(entry.coinId)?.prices?.find(price => utcDayStart(price.timestamp) === day)
       entry.resolve(hit ? { found: true, priceUsd: hit.price } : { found: false })
     }
-  } catch {
+  } catch (error) {
+    // Distinguish a broken batch route from a legitimate table miss, which resolves the same way.
+    console.warn('🚨', 'price service batch failed', entries.length, error)
     for (const entry of entries) entry.resolve({ found: false })
   }
 }


### PR DESCRIPTION
### Summary
The indexer hit `/api/prices/historical` once per token per block, and cached each answer for 30 seconds.
Since lib/blocks pins the head block for 15 minutes and the price service refreshes today's row hourly,
that TTL re-fetched an unchanged value roughly 120 times an hour per token. This coalesces concurrent
lookups into one `batchHistorical` call and holds a service hit for 15 minutes.

### How to review
Start with `packages/ingest/prices.ts`:

- `enqueuePriceServiceBatch` / `flushPriceServiceBatch` / `sendPriceServiceBatch` — the batching layer.
  Entries are keyed by `coinId:utcDay`, flushed after 25ms or at 50 queued entries, whichever comes first.
  Note that `sendPriceServiceBatch` never throws: on any failure it resolves every entry as `found: false`.
- `fetchPriceServiceExactResult` — the prior per-token path, extracted unchanged. `batchHistorical` reads
  the service's table only, so a batch miss still falls through here, where the service resolves upstream.
- `blockCacheTtl()` — returns a function under `USE_PRICE_SERVICE` so hits get the 15m TTL while misses
  keep the short negative TTL. A transient outage must not stick `tvl=0` for 15 minutes.

Two behaviors worth a second look: a stored zero comes back as `missing` without an exact-endpoint call
(the exact route would read the same row), and batch response keys are lowercased on read because the
service echoes the checksummed address.

### Test plan
- [ ] Manual: run the indexer with `USE_PRICE_SERVICE=true` against a chain with several vaults and
      confirm one `batchHistorical` request per flush window instead of one `historical` request per token.
- [ ] Automated (when applicable): `bun --filter ingest test` — not run.

### Risk / impact
Priced data feeds TVL, so a wrong or missing price shows up in user-facing numbers. Guards against that:
batch failures degrade to the existing exact endpoint rather than a miss, and negative results keep the
short TTL. `USE_PRICE_SERVICE` is the kill switch — off, `blockCacheTtl()` returns the old 30s constant
and none of the batching code runs.
