### PR TITLE
fix(ingest): stop timeseries fanout loop on unavailable prices

### DIFF
--- a/packages/ingest/abis/yearn/lib/tvl.ts
+++ b/packages/ingest/abis/yearn/lib/tvl.ts
@@ -34,16 +34,24 @@ export default async function _process(chainId: number, address: `0x${string}`, 
 
   // extractTotalAssets returns undefined on multicall failure; skip emitting a false zero (a genuine empty vault is 0n)
   if (totalAssets === undefined) return []
-  if (priceSource === 'unavailable') return []
+
+  // 'unavailable' (transient price service failure) still writes rows for past days:
+  // null for the usd components, real values for the on-chain ones. Returning []
+  // left the day permanently missing, so every fanout cycle re-enqueued it forever
+  // (fanout/timeseries.ts). Null days heal only by replay. The current day is the
+  // exception: fanout re-extracts it every cycle anyway, and a null row at today's
+  // series_time would shadow yesterday's real value in latest-row queries.
+  const unavailable = priceSource === 'unavailable'
+  if (unavailable && latest) return []
 
   if (components) {
     // componentized outputs
     return OutputSchema.array().parse([{
       chainId, address, blockNumber, blockTime: data.blockTime, label: data.outputLabel,
-      component: 'tvl', value: tvl
+      component: 'tvl', value: unavailable ? null : tvl
     }, {
       chainId, address, blockNumber, blockTime: data.blockTime, label: data.outputLabel,
-      component: 'delegated', value: delegatedTvl
+      component: 'delegated', value: unavailable ? null : delegatedTvl
     }, {
       chainId, address, blockNumber, blockTime: data.blockTime, label: data.outputLabel,
       component: 'totalAssets', value: normalize(totalAssets, decimals) || 0
@@ -52,14 +60,14 @@ export default async function _process(chainId: number, address: `0x${string}`, 
       component: 'delegatedAssets', value: normalize(delegatedAssets, decimals) || 0
     }, {
       chainId, address, blockNumber, blockTime: data.blockTime, label: data.outputLabel,
-      component: 'priceUsd', value: priceUsd
+      component: 'priceUsd', value: unavailable ? null : priceUsd
     }])
 
   } else {
     // legacy tvl output
     return OutputSchema.array().parse([{
       chainId, address, blockNumber, blockTime: data.blockTime, label: data.outputLabel,
-      component: 'tvl', value: tvl
+      component: 'tvl', value: unavailable ? null : tvl
     }])
 
   }

--- a/packages/ingest/abis/yearn/lib/tvl.ts
+++ b/packages/ingest/abis/yearn/lib/tvl.ts
@@ -8,7 +8,8 @@ import { normalize, priced } from 'lib/math'
 import { extractWithdrawalQueue } from '../2/vault/snapshot/hook'
 import { Data } from '../../../extract/timeseries'
 import { estimateHeight, getBlock } from 'lib/blocks'
-import { first } from '../../../db'
+import { first, some } from '../../../db'
+import { endOfDay } from 'lib/dates'
 
 export default async function _process(chainId: number, address: `0x${string}`, data: Data, components?: boolean): Promise<Output[]> {
   console.info('🧮', data.outputLabel, chainId, address, (new Date(Number(data.blockTime) * 1000)).toDateString())
@@ -35,23 +36,31 @@ export default async function _process(chainId: number, address: `0x${string}`, 
   // extractTotalAssets returns undefined on multicall failure; skip emitting a false zero (a genuine empty vault is 0n)
   if (totalAssets === undefined) return []
 
-  // 'unavailable' (transient price service failure) still writes rows for past days:
-  // null for the usd components, real values for the on-chain ones. Returning []
-  // left the day permanently missing, so every fanout cycle re-enqueued it forever
-  // (fanout/timeseries.ts). Null days heal only by replay. The current day is the
-  // exception: fanout re-extracts it every cycle anyway, and a null row at today's
-  // series_time would shadow yesterday's real value in latest-row queries.
-  const unavailable = priceSource === 'unavailable'
-  if (unavailable && latest) return []
+  // 'unavailable' (price service failure) still writes rows for past days: null for
+  // the usd components, real values for the on-chain ones. Returning [] left the day
+  // permanently missing, so every fanout cycle re-enqueued it forever. Null days heal
+  // by replay (fanout/timeseries.ts).
+  const priceUnavailable = priceSource === 'unavailable'
+
+  // The current day is skipped outright: fanout re-extracts it every cycle anyway, and
+  // a null row at today's series_time would shadow yesterday's real value in
+  // latest-row queries.
+  if (priceUnavailable && latest) return []
+
+  const usdUnknown = priceUnavailable && totalAssets !== 0n
+
+  // findMissingDays counts a null row as computed, so overwriting a real value here
+  // would lose it for good.
+  if (usdUnknown && await hasComputedTvl(chainId, address, data.outputLabel, data.blockTime)) return []
 
   if (components) {
     // componentized outputs
     return OutputSchema.array().parse([{
       chainId, address, blockNumber, blockTime: data.blockTime, label: data.outputLabel,
-      component: 'tvl', value: unavailable ? null : tvl
+      component: 'tvl', value: usdUnknown ? null : tvl
     }, {
       chainId, address, blockNumber, blockTime: data.blockTime, label: data.outputLabel,
-      component: 'delegated', value: unavailable ? null : delegatedTvl
+      component: 'delegated', value: usdUnknown ? null : delegatedTvl
     }, {
       chainId, address, blockNumber, blockTime: data.blockTime, label: data.outputLabel,
       component: 'totalAssets', value: normalize(totalAssets, decimals) || 0
@@ -60,17 +69,26 @@ export default async function _process(chainId: number, address: `0x${string}`, 
       component: 'delegatedAssets', value: normalize(delegatedAssets, decimals) || 0
     }, {
       chainId, address, blockNumber, blockTime: data.blockTime, label: data.outputLabel,
-      component: 'priceUsd', value: unavailable ? null : priceUsd
+      component: 'priceUsd', value: priceUnavailable ? null : priceUsd
     }])
 
   } else {
     // legacy tvl output
     return OutputSchema.array().parse([{
       chainId, address, blockNumber, blockTime: data.blockTime, label: data.outputLabel,
-      component: 'tvl', value: unavailable ? null : tvl
+      component: 'tvl', value: usdUnknown ? null : tvl
     }])
 
   }
+}
+
+async function hasComputedTvl(chainId: number, address: `0x${string}`, label: string, blockTime: bigint) {
+  return await some(
+    `SELECT 1 FROM output
+     WHERE chain_id = $1 AND address = $2 AND label = $3 AND component = 'tvl'
+       AND series_time = to_timestamp($4::double precision) AND value IS NOT NULL`,
+    [chainId, address, label, Number(endOfDay(blockTime))]
+  )
 }
 
 export async function _compute(vault: Thing, blockNumber: bigint, latest = false) {

--- a/packages/ingest/abis/yearn/lib/tvl.ts
+++ b/packages/ingest/abis/yearn/lib/tvl.ts
@@ -51,7 +51,7 @@ export default async function _process(chainId: number, address: `0x${string}`, 
 
   // findMissingDays counts a null row as computed, so overwriting a real value here
   // would lose it for good.
-  if (usdUnknown && await hasComputedTvl(chainId, address, data.outputLabel, data.blockTime)) return []
+  if (priceUnavailable && await hasComputedTvl(chainId, address, data.outputLabel, data.blockTime)) return []
 
   if (components) {
     // componentized outputs

--- a/packages/ingest/abis/yearn/lib/tvl.unavailable.mock.spec.ts
+++ b/packages/ingest/abis/yearn/lib/tvl.unavailable.mock.spec.ts
@@ -4,12 +4,14 @@ vi.mock('../../../prices', () => ({
   fetchErc20PriceUsd: vi.fn(async () => ({ priceUsd: 0, priceSource: 'unavailable' }))
 }))
 
+const { someMock, totalAssets } = vi.hoisted(() => ({ someMock: vi.fn(async () => false), totalAssets: { value: 5000000000000000000n } }))
+
 vi.mock('../../../rpcs', () => ({
   rpcs: {
     next: () => ({
       multicall: async ({ contracts }: { contracts: { functionName: string }[] }) =>
         contracts.map(contract => contract.functionName === 'totalAssets'
-          ? { status: 'success', result: 5000000000000000000n }
+          ? { status: 'success', result: totalAssets.value }
           : { status: 'failure' })
     })
   }
@@ -22,6 +24,7 @@ vi.mock('lib/blocks', () => ({
 
 vi.mock('../../../db', () => ({
   default: {},
+  some: someMock,
   first: vi.fn(async () => ({
     chainId: 1,
     address: '0xdA816459F1AB5631232FE5e97a05BBBb94970c95',
@@ -41,6 +44,7 @@ vi.mock('../2/vault/snapshot/hook', () => ({
 import _process from './tvl'
 import { fetchErc20PriceUsd } from '../../../prices'
 import { Data } from '../../../extract/timeseries'
+import { endOfDay } from 'lib/dates'
 
 const VAULT = '0xdA816459F1AB5631232FE5e97a05BBBb94970c95' as const
 const data = { outputLabel: 'tvl', blockTime: 1600000000n } as Data
@@ -48,6 +52,9 @@ const data = { outputLabel: 'tvl', blockTime: 1600000000n } as Data
 describe('tvl hook on price service unavailable', () => {
   beforeEach(() => {
     vi.mocked(fetchErc20PriceUsd).mockResolvedValue({ priceUsd: 0, priceSource: 'unavailable' })
+    someMock.mockReset()
+    someMock.mockResolvedValue(false)
+    totalAssets.value = 5000000000000000000n
   })
 
   it('still writes component rows, null for usd components, real on-chain values', async () => {
@@ -80,5 +87,38 @@ describe('tvl hook on price service unavailable', () => {
     const byComponent = Object.fromEntries(outputs.map(o => [o.component, o.value]))
     expect(byComponent['tvl']).to.equal(10)
     expect(byComponent['priceUsd']).to.equal(2)
+  })
+
+  it('skips a past day that already holds a real tvl', async () => {
+    someMock.mockResolvedValue(true)
+    expect(await _process(1, VAULT, data, true)).to.deep.equal([])
+
+    const [, params] = someMock.mock.calls[0]
+    expect(params[3]).to.equal(Number(endOfDay(1600000000n)))
+  })
+
+  it('writes null again when the stored day is already null', async () => {
+    someMock.mockResolvedValue(false)
+    const outputs = await _process(1, VAULT, data, true)
+    expect(outputs).to.have.length(5)
+
+    const byComponent = Object.fromEntries(outputs.map(o => [o.component, o.value]))
+    expect(byComponent['tvl']).to.equal(null)
+  })
+
+  it('writes zero tvl for an empty vault when the price is unavailable', async () => {
+    totalAssets.value = 0n
+    const outputs = await _process(1, VAULT, data, true)
+    const byComponent = Object.fromEntries(outputs.map(o => [o.component, o.value]))
+    expect(byComponent['tvl']).to.equal(0)
+    expect(byComponent['delegated']).to.equal(0)
+    expect(byComponent['priceUsd']).to.equal(null)
+    expect(someMock).not.toHaveBeenCalled()
+  })
+
+  it('does not query for an already-computed day when the price resolves', async () => {
+    vi.mocked(fetchErc20PriceUsd).mockResolvedValue({ priceUsd: 2, priceSource: 'priceservice' })
+    await _process(1, VAULT, data, true)
+    expect(someMock).not.toHaveBeenCalled()
   })
 })

--- a/packages/ingest/abis/yearn/lib/tvl.unavailable.mock.spec.ts
+++ b/packages/ingest/abis/yearn/lib/tvl.unavailable.mock.spec.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../prices', () => ({
+  fetchErc20PriceUsd: vi.fn(async () => ({ priceUsd: 0, priceSource: 'unavailable' }))
+}))
+
+vi.mock('../../../rpcs', () => ({
+  rpcs: {
+    next: () => ({
+      multicall: async ({ contracts }: { contracts: { functionName: string }[] }) =>
+        contracts.map(contract => contract.functionName === 'totalAssets'
+          ? { status: 'success', result: 5000000000000000000n }
+          : { status: 'failure' })
+    })
+  }
+}))
+
+vi.mock('lib/blocks', () => ({
+  estimateHeight: vi.fn(async () => 100n),
+  getBlock: vi.fn(async () => ({ number: 100n, timestamp: 1700000000n }))
+}))
+
+vi.mock('../../../db', () => ({
+  default: {},
+  first: vi.fn(async () => ({
+    chainId: 1,
+    address: '0xdA816459F1AB5631232FE5e97a05BBBb94970c95',
+    label: 'vault',
+    defaults: {
+      apiVersion: '3.0.0',
+      asset: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+      decimals: 18
+    }
+  }))
+}))
+
+vi.mock('../2/vault/snapshot/hook', () => ({
+  extractWithdrawalQueue: vi.fn(async () => [])
+}))
+
+import _process from './tvl'
+import { fetchErc20PriceUsd } from '../../../prices'
+import { Data } from '../../../extract/timeseries'
+
+const VAULT = '0xdA816459F1AB5631232FE5e97a05BBBb94970c95' as const
+const data = { outputLabel: 'tvl', blockTime: 1600000000n } as Data
+
+describe('tvl hook on price service unavailable', () => {
+  beforeEach(() => {
+    vi.mocked(fetchErc20PriceUsd).mockResolvedValue({ priceUsd: 0, priceSource: 'unavailable' })
+  })
+
+  it('still writes component rows, null for usd components, real on-chain values', async () => {
+    const outputs = await _process(1, VAULT, data, true)
+    expect(outputs).to.have.length(5)
+
+    const byComponent = Object.fromEntries(outputs.map(o => [o.component, o.value]))
+    expect(byComponent['tvl']).to.equal(null)
+    expect(byComponent['delegated']).to.equal(null)
+    expect(byComponent['priceUsd']).to.equal(null)
+    expect(byComponent['totalAssets']).to.equal(5)
+    expect(byComponent['delegatedAssets']).to.equal(0)
+  })
+
+  it('still writes the legacy tvl row with a null value', async () => {
+    const outputs = await _process(1, VAULT, data, false)
+    expect(outputs).to.have.length(1)
+    expect(outputs[0].component).to.equal('tvl')
+    expect(outputs[0].value).to.equal(null)
+  })
+
+  it('writes nothing for the current day, so latest-row queries keep yesterday', async () => {
+    const outputs = await _process(1, VAULT, { outputLabel: 'tvl', blockTime: 9999999999n } as Data, true)
+    expect(outputs).to.deep.equal([])
+  })
+
+  it('writes real values when the price resolves', async () => {
+    vi.mocked(fetchErc20PriceUsd).mockResolvedValue({ priceUsd: 2, priceSource: 'priceservice' })
+    const outputs = await _process(1, VAULT, data, true)
+    const byComponent = Object.fromEntries(outputs.map(o => [o.component, o.value]))
+    expect(byComponent['tvl']).to.equal(10)
+    expect(byComponent['priceUsd']).to.equal(2)
+  })
+})

--- a/packages/ingest/abis/yearn/lib/tvl.unavailable.mock.spec.ts
+++ b/packages/ingest/abis/yearn/lib/tvl.unavailable.mock.spec.ts
@@ -106,14 +106,19 @@ describe('tvl hook on price service unavailable', () => {
     expect(byComponent['tvl']).to.equal(null)
   })
 
-  it('writes zero tvl for an empty vault when the price is unavailable', async () => {
+  it('writes zero tvl for an empty vault when the price is unavailable and the day is uncomputed', async () => {
     totalAssets.value = 0n
     const outputs = await _process(1, VAULT, data, true)
     const byComponent = Object.fromEntries(outputs.map(o => [o.component, o.value]))
     expect(byComponent['tvl']).to.equal(0)
     expect(byComponent['delegated']).to.equal(0)
     expect(byComponent['priceUsd']).to.equal(null)
-    expect(someMock).not.toHaveBeenCalled()
+  })
+
+  it('skips an already-computed day for an empty vault, preserving its stored priceUsd', async () => {
+    totalAssets.value = 0n
+    someMock.mockResolvedValue(true)
+    expect(await _process(1, VAULT, data, true)).to.deep.equal([])
   })
 
   it('does not query for an already-computed day when the price resolves', async () => {

--- a/packages/ingest/db.spec.ts
+++ b/packages/ingest/db.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai'
 import { types } from 'lib'
-import db, { upsertThingDefaults } from './db'
+import db, { getSparkline, upsertThingDefaults } from './db'
 
 // upsertThingDefaults replaced a SELECT ... FOR UPDATE + read-modify-write
 // transaction with a single INSERT ... ON CONFLICT DO UPDATE that merges
@@ -86,5 +86,59 @@ describe('upsertThingDefaults', () => {
     expect(defaults.project).to.deep.equal({ id: '0xproject-b' })
     expect(defaults.roleManagerFactory).to.equal('0xfactory')
     expect(defaults.inceptBlock).to.equal(100)
+  })
+})
+
+// A 7-day bucket holding only null values (price service outage) must drop out of
+// the sparkline entirely — COALESCE would otherwise close it at 0, which flows to
+// snapshot.hook.tvl, gql vault.tvl, and the vault-list sort key.
+describe('getSparkline', () => {
+  const CHAIN_ID = 1
+  const ADDRESS = '0xsparkline'
+  const LABEL = 'tvl'
+
+  // time_bucket('7 day') aligns to the timescale origin 2000-01-03T00:00Z (946857600);
+  // anchor mid-bucket so rows 60s apart never straddle a boundary.
+  const WEEK = 7 * 86400
+  const nowish = Math.floor(Date.now() / 1000) - 30 * 86400
+  const b1 = 946857600 + Math.floor((nowish - 946857600) / WEEK) * WEEK + 3600
+  const b2 = b1 + WEEK
+  const b3 = b2 + WEEK
+
+  async function insert(value: number | null, blockNumber: number, time: number) {
+    await db.query(`
+      INSERT INTO output (chain_id, address, label, component, value, block_number, block_time, series_time)
+      VALUES ($1, $2, $3, 'tvl', $4, $5, to_timestamp($6), to_timestamp($6))`,
+    [CHAIN_ID, ADDRESS, LABEL, value, blockNumber, time])
+  }
+
+  afterEach(async () => {
+    await db.query('DELETE FROM output WHERE chain_id = $1 AND address = $2 AND label = $3',
+      [CHAIN_ID, ADDRESS, LABEL])
+  })
+
+  it('omits an all-null newest bucket instead of closing it at 0', async () => {
+    await insert(10, 1, b1)
+    await insert(20, 2, b2)
+    await insert(null, 3, b3)
+    await insert(null, 4, b3 + 60)
+
+    const rows = await getSparkline(CHAIN_ID, ADDRESS, LABEL, 'tvl')
+    expect(rows.map(row => row.close)).to.deep.equal([20, 10])
+  })
+
+  it('closes a mixed bucket on its last real value', async () => {
+    await insert(20, 2, b2)
+    await insert(null, 3, b2 + 60)
+
+    const rows = await getSparkline(CHAIN_ID, ADDRESS, LABEL, 'tvl')
+    expect(rows[0].close).to.equal(20)
+  })
+
+  it('closes a genuine zero at 0', async () => {
+    await insert(0, 1, b2)
+
+    const rows = await getSparkline(CHAIN_ID, ADDRESS, LABEL, 'tvl')
+    expect(rows[0].close).to.equal(0)
   })
 })

--- a/packages/ingest/db.ts
+++ b/packages/ingest/db.ts
@@ -94,6 +94,7 @@ export async function getSparkline(chainId: number, address: string, label: stri
     WHERE chain_id = $1 AND address = $2 AND label = $3 AND (component = $4 OR $4 IS NULL)
       ${floor}
     GROUP BY "blockTime"
+    HAVING COUNT(value) > 0
     ORDER BY "blockTime" DESC
     LIMIT 3;
   `

--- a/packages/ingest/db.ts
+++ b/packages/ingest/db.ts
@@ -87,7 +87,9 @@ export async function getSparkline(chainId: number, address: string, label: stri
       CAST($3 AS text) AS label,
       CAST($4 AS text) AS component,
       time_bucket(CAST('7 day' AS interval), block_time) AS "blockTime",
-      COALESCE(LAST(NULLIF(value, 0), block_number), 0) AS close
+      -- LAST does not skip nulls: without FILTER an outage row at the bucket's max
+      -- block collapses close to 0
+      COALESCE(LAST(NULLIF(value, 0), block_number) FILTER (WHERE value IS NOT NULL), 0) AS close
     FROM output
     WHERE chain_id = $1 AND address = $2 AND label = $3 AND (component = $4 OR $4 IS NULL)
       ${floor}

--- a/packages/ingest/fanout/timeseries.replay.mock.spec.ts
+++ b/packages/ingest/fanout/timeseries.replay.mock.spec.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const { queryMock, mqAdd, blockTimes } = vi.hoisted(() => ({
+  queryMock: vi.fn(async () => ({ rows: [] as { day: string }[] })),
+  mqAdd: vi.fn(async () => undefined),
+  blockTimes: {} as Record<string, bigint>
+}))
+
+vi.mock('../db', () => ({
+  default: { query: queryMock }
+}))
+
+vi.mock('lib', () => ({
+  math: { max: (...args: bigint[]) => args.reduce((a, b) => (a > b ? a : b)) },
+  mq: {
+    add: mqAdd,
+    job: {
+      fanout: { timeseries: { queue: 'fanout', name: 'timeseries' } },
+      extract: { timeseries: { queue: 'extract', name: 'timeseries', bychain: true } }
+    }
+  },
+  multicall3: { getActivation: vi.fn(() => 0n) }
+}))
+
+vi.mock('lib/blocks', () => ({
+  getBlockNumber: vi.fn(async () => 3n),
+  getBlockTime: vi.fn(async (_chainId: number, blockNumber: bigint) => blockTimes[blockNumber.toString()]),
+  getDefaultStartBlockNumber: vi.fn(async () => 0n)
+}))
+
+vi.mock('../abis', () => ({
+  requireHooks: vi.fn(async () => () => [
+    { type: 'timeseries', abiPath: 'yearn/lib', module: { outputLabel: 'tvl', default: vi.fn() } }
+  ])
+}))
+
+import TimeseriesFanout from './timeseries'
+import { endOfStringDay } from 'lib/dates'
+
+const CHAIN_ID = 1
+const ADDRESS = '0x1111111111111111111111111111111111111111' as const
+
+const DAY1 = endOfStringDay('2024-01-01')
+const DAY2 = endOfStringDay('2024-01-02')
+const DAY3 = endOfStringDay('2024-01-03')
+
+blockTimes['1'] = DAY1
+blockTimes['3'] = DAY3
+
+function source(overrides: Partial<{ startBlock: bigint, endBlock: bigint }> = {}) {
+  return { chainId: CHAIN_ID, address: ADDRESS, inceptBlock: 0n, startBlock: 1n, endBlock: 3n, ...overrides }
+}
+
+describe('TimeseriesFanout replay', () => {
+  it('replay enqueues every day in range, bypassing the anti-join', async () => {
+    mqAdd.mockClear()
+    queryMock.mockClear()
+
+    const fanout = new TimeseriesFanout()
+    await fanout.fanout({ abi: { abiPath: 'yearn/lib' }, source: source(), replay: { enabled: true } })
+
+    expect(mqAdd).toHaveBeenCalledTimes(3)
+    expect(queryMock).not.toHaveBeenCalled()
+
+    const enqueuedDays = mqAdd.mock.calls.map(call => call[1].blockTime)
+    expect(enqueuedDays).to.deep.equal([DAY1, DAY2, DAY3])
+  })
+
+  it('replay honours since', async () => {
+    mqAdd.mockClear()
+    queryMock.mockClear()
+
+    const fanout = new TimeseriesFanout()
+    await fanout.fanout({ abi: { abiPath: 'yearn/lib' }, source: source(), replay: { enabled: true, since: DAY2 } })
+
+    expect(mqAdd).toHaveBeenCalledTimes(2)
+    const enqueuedDays = mqAdd.mock.calls.map(call => call[1].blockTime)
+    expect(enqueuedDays).to.deep.equal([DAY2, DAY3])
+  })
+
+  it('a normal cycle uses the anti-join', async () => {
+    mqAdd.mockClear()
+    queryMock.mockClear()
+    queryMock.mockResolvedValueOnce({ rows: [{ day: DAY1.toString() }, { day: DAY3.toString() }] })
+
+    const fanout = new TimeseriesFanout()
+    await fanout.fanout({ abi: { abiPath: 'yearn/lib' }, source: source() })
+
+    expect(queryMock).toHaveBeenCalledTimes(1)
+    expect(mqAdd).toHaveBeenCalledTimes(2)
+    const enqueuedDays = mqAdd.mock.calls.map(call => call[1].blockTime)
+    expect(enqueuedDays).to.deep.equal([DAY1, DAY3])
+  })
+})

--- a/packages/ingest/fanout/timeseries.spec.ts
+++ b/packages/ingest/fanout/timeseries.spec.ts
@@ -1,0 +1,78 @@
+import { expect } from 'chai'
+import db from '../db'
+import { findMissingDays } from './timeseries'
+import { upsertBatchOutput } from '../load'
+
+const CHAIN_ID = 1
+const ADDRESS = '0xdA816459F1AB5631232FE5e97a05BBBb94970c95' as const
+const LABEL = 'tvl'
+
+// TZ=UTC is pinned in vitest.config.ts, so endOfDay(n * 86400) = n * 86400 + 86399
+const day = (n: number) => BigInt(n * 86400 + 86399)
+
+async function seed(days: bigint[]) {
+  for (const d of days) {
+    await db.query(`
+      INSERT INTO output (chain_id, address, label, component, value, block_number, block_time, series_time)
+      VALUES ($1, $2, $3, 'tvl', 1, 1, to_timestamp($4), to_timestamp($4))`,
+    [CHAIN_ID, ADDRESS, LABEL, Number(d)])
+  }
+}
+
+async function selectValue() {
+  const result = await db.query(
+    'SELECT value FROM output WHERE chain_id = $1 AND address = $2 AND label = $3',
+    [CHAIN_ID, ADDRESS, LABEL])
+  return result.rows[0]?.value
+}
+
+describe('fanout/timeseries', () => {
+  afterEach(async () => {
+    await db.query('DELETE FROM output WHERE chain_id = $1 AND address = $2', [CHAIN_ID, ADDRESS])
+  })
+
+  describe('findMissingDays', () => {
+    it('returns only the gaps', async () => {
+      await seed([day(1), day(2), day(4)])
+      const missing = await findMissingDays(CHAIN_ID, ADDRESS, LABEL, day(1), day(5))
+      expect(missing).to.deep.equal([day(3), day(5)])
+    })
+
+    it('returns nothing when every day is computed', async () => {
+      await seed([day(1), day(2), day(3)])
+      const missing = await findMissingDays(CHAIN_ID, ADDRESS, LABEL, day(1), day(3))
+      expect(missing).to.deep.equal([])
+    })
+
+    it('counts a null-value row as computed', async () => {
+      await seed([day(1), day(3)])
+      await db.query(`
+        INSERT INTO output (chain_id, address, label, component, value, block_number, block_time, series_time)
+        VALUES ($1, $2, $3, 'tvl', NULL, 1, to_timestamp($4), to_timestamp($4))`,
+      [CHAIN_ID, ADDRESS, LABEL, Number(day(2))])
+      const missing = await findMissingDays(CHAIN_ID, ADDRESS, LABEL, day(1), day(3))
+      expect(missing).to.deep.equal([])
+    })
+  })
+
+  describe('null output upsert', () => {
+    // Mimic the real path: hook output → redis json roundtrip → load worker upsert.
+    const roundtrip = (batch: object[]) => JSON.parse(JSON.stringify(batch))
+
+    const output = (value: number | null, blockNumber: bigint) => ({
+      chainId: CHAIN_ID, address: ADDRESS, label: LABEL, component: 'tvl',
+      value, blockNumber, blockTime: day(1)
+    })
+
+    it('writes null over an existing value and a value over null', async () => {
+      await upsertBatchOutput(roundtrip([output(123, 1n)]))
+      expect(Number(await selectValue())).to.equal(123)
+
+      await upsertBatchOutput(roundtrip([output(null, 2n)]))
+      expect(await selectValue()).to.equal(null)
+
+      await upsertBatchOutput(roundtrip([output(456, 3n)]))
+      expect(Number(await selectValue())).to.equal(456)
+    })
+  })
+})

--- a/packages/ingest/fanout/timeseries.ts
+++ b/packages/ingest/fanout/timeseries.ts
@@ -9,7 +9,7 @@ import { endOfDay, makeTimeline } from 'lib/dates'
 export default class TimeseriesFanout {
   resolveHooks: ResolveHooks | undefined
 
-  async fanout(data: { abi: AbiConfig, source: SourceConfig, replay?: boolean }) {
+  async fanout(data: { abi: AbiConfig, source: SourceConfig, replay?: { enabled: boolean, since?: bigint } }) {
     if (!this.resolveHooks) this.resolveHooks = await requireHooks()
     const { chainId, address, inceptBlock, startBlock, endBlock } = SourceConfigSchema.parse(data.source)
     const { abiPath } = AbiConfigSchema.parse(data.abi)
@@ -27,7 +27,12 @@ export default class TimeseriesFanout {
       const start = endOfDay(await getBlockTime(chainId, from))
       const end = endOfDay(await getBlockTime(chainId, to))
 
-      const missing = await findMissingDays(chainId, address, outputLabel, start, end)
+      // Replay is the only path back for days the anti-join counts as computed but
+      // hold a null value (abis/yearn/lib/tvl.ts).
+      const missing = data.replay?.enabled
+        ? makeTimeline(data.replay.since ?? start, end)
+        : await findMissingDays(chainId, address, outputLabel, start, end)
+
       if (missing.length === 0 || missing[missing.length - 1] !== end) {
         missing.push(end)
       }

--- a/packages/ingest/fanout/timeseries.ts
+++ b/packages/ingest/fanout/timeseries.ts
@@ -4,7 +4,7 @@ import { getBlockNumber, getBlockTime, getDefaultStartBlockNumber } from 'lib/bl
 import db from '../db'
 import { requireHooks } from '../abis'
 import { ResolveHooks } from '../abis/types'
-import { endOfDay, findMissingTimestamps } from 'lib/dates'
+import { endOfDay, makeTimeline } from 'lib/dates'
 
 export default class TimeseriesFanout {
   resolveHooks: ResolveHooks | undefined
@@ -27,20 +27,7 @@ export default class TimeseriesFanout {
       const start = endOfDay(await getBlockTime(chainId, from))
       const end = endOfDay(await getBlockTime(chainId, to))
 
-      // series_time is endOfDay(block_time) at write time
-      // (packages/ingest/load/index.ts). Filtering on series_time within
-      // [start, end] lets Timescale prune chunks; pairs with index
-      // idx_output_chain_address_label_series_time for an index-only scan.
-      const computed = (await db.query(`
-      SELECT DISTINCT FLOOR(EXTRACT(EPOCH FROM series_time))::bigint AS series_time
-      FROM output
-      WHERE chain_id = $1 AND address = $2 AND label = $3
-        AND series_time BETWEEN to_timestamp($4::double precision) AND to_timestamp($5::double precision)
-      ORDER BY series_time ASC`,
-      [chainId, address, outputLabel, Number(start), Number(end)]))
-        .rows.map(row => BigInt(row.series_time))
-
-      const missing = findMissingTimestamps(start, end, computed)
+      const missing = await findMissingDays(chainId, address, outputLabel, start, end)
       if (missing.length === 0 || missing[missing.length - 1] !== end) {
         missing.push(end)
       }
@@ -53,4 +40,25 @@ export default class TimeseriesFanout {
       }
     }
   }
+}
+
+// series_time is endOfDay(block_time) at write time (packages/ingest/load/index.ts).
+// The anti-join returns only the missing days, not every computed day — the full
+// computed list was ~50M calls x O(history) rows of egress per fanout cycle. The
+// BETWEEN range keeps the single prunable index-only scan on
+// idx_output_chain_address_label_series_time; NOT IN is safe because series_time
+// is NOT NULL.
+export async function findMissingDays(chainId: number, address: `0x${string}`, label: string, start: bigint, end: bigint): Promise<bigint[]> {
+  const timeline = makeTimeline(start, end)
+  return (await db.query(`
+  SELECT t.day FROM unnest($4::bigint[]) AS t(day)
+  WHERE t.day NOT IN (
+    SELECT FLOOR(EXTRACT(EPOCH FROM series_time))::bigint
+    FROM output
+    WHERE chain_id = $1 AND address = $2 AND label = $3
+      AND series_time BETWEEN to_timestamp($5::double precision) AND to_timestamp($6::double precision)
+  )
+  ORDER BY t.day ASC`,
+  [chainId, address, label, timeline.map(String), Number(start), Number(end)]))
+    .rows.map(row => BigInt(row.day))
 }

--- a/packages/ingest/prices.service-cache.mock.spec.ts
+++ b/packages/ingest/prices.service-cache.mock.spec.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { cacheGet, cacheSet, blockTime, wrapStore } = vi.hoisted(() => ({
-  cacheGet: vi.fn(), cacheSet: vi.fn(), blockTime: vi.fn(), wrapStore: new Map<string, unknown>()
+const { cacheGet, cacheSet, blockTime, wrapStore, wrapTtls } = vi.hoisted(() => ({
+  cacheGet: vi.fn(), cacheSet: vi.fn(), blockTime: vi.fn(),
+  wrapStore: new Map<string, unknown>(), wrapTtls: [] as unknown[]
 }))
 
 vi.mock('lib/blocks', () => ({
@@ -13,7 +14,8 @@ vi.mock('lib/cache', () => ({
   cache: {
     get: cacheGet,
     set: cacheSet,
-    wrap: async (key: string, fn: () => Promise<unknown>) => {
+    wrap: async (key: string, fn: () => Promise<unknown>, ttl?: unknown) => {
+      wrapTtls.push(ttl)
       if (!wrapStore.has(key)) wrapStore.set(key, await fn())
       return wrapStore.get(key)
     }
@@ -23,7 +25,34 @@ vi.mock('lib/cache', () => ({
 import { fetchErc20PriceUsd } from './prices'
 
 const WETH = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2' as const
+const WETH_COIN = 'polygon:0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
 const CHAIN_ID = 137 // polygon — not in the on-chain `lens` map
+
+const endOfDay = (timestamp: number) => Math.floor(timestamp / 86400) * 86400 + 86399
+
+// Mirrors batchHistorical: echoes the requested keys, answers at end-of-day.
+function batchHit(price: number) {
+  return vi.fn(async (url: string) => {
+    const coins = JSON.parse(decodeURIComponent(new URL(url).searchParams.get('coins')!)) as Record<string, number[]>
+    return {
+      ok: true,
+      json: async () => ({
+        coins: Object.fromEntries(Object.entries(coins).map(([coinId, timestamps]) => [
+          coinId,
+          { symbol: 'TOKEN', prices: timestamps.map(timestamp => ({ timestamp: endOfDay(timestamp), price })) }
+        ]))
+      })
+    }
+  })
+}
+
+function batchMissThenExact(exact: { ok: boolean, status?: number, price?: number }) {
+  return vi.fn(async (url: string) => url.includes('batchHistorical')
+    ? { ok: true, json: async () => ({ coins: {} }) }
+    : exact.ok
+      ? { ok: true, json: async () => ({ coins: { [WETH_COIN]: { symbol: 'WETH', price: exact.price } } }) }
+      : { ok: false, status: exact.status })
+}
 
 describe('fetchErc20PriceUsd (USE_PRICE_SERVICE, past-day path)', () => {
   const originalUsePriceService = process.env.USE_PRICE_SERVICE
@@ -39,6 +68,7 @@ describe('fetchErc20PriceUsd (USE_PRICE_SERVICE, past-day path)', () => {
     cacheSet.mockReset()
     blockTime.mockReset().mockResolvedValue(1700000000n)
     wrapStore.clear()
+    wrapTtls.length = 0
   })
 
   afterEach(() => {
@@ -53,17 +83,7 @@ describe('fetchErc20PriceUsd (USE_PRICE_SERVICE, past-day path)', () => {
   })
 
   it('caches a service hit under the day key', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => ({
-      ok: true,
-      json: async () => ({
-        coins: {
-          ['polygon:0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2']: {
-            symbol: 'WETH',
-            price: 2
-          }
-        }
-      })
-    })))
+    vi.stubGlobal('fetch', batchHit(2))
 
     const { priceSource, priceUsd } = await fetchErc20PriceUsd(CHAIN_ID, WETH, 1n)
 
@@ -75,8 +95,20 @@ describe('fetchErc20PriceUsd (USE_PRICE_SERVICE, past-day path)', () => {
     expect(key).toContain(':137:')
   })
 
+  it('holds a service hit in the block cache for the head-block window', async () => {
+    vi.stubGlobal('fetch', batchHit(2))
+
+    await fetchErc20PriceUsd(CHAIN_ID, WETH, 1n)
+
+    const ttl = wrapTtls.at(-1) as (result: { priceSource: string }) => number
+    expect(typeof ttl).to.equal('function')
+    expect(ttl({ priceSource: 'priceservice' })).to.equal(15 * 60 * 1000)
+    expect(ttl({ priceSource: 'na' })).to.equal(120_000)
+    expect(ttl({ priceSource: 'unavailable' })).to.equal(120_000)
+  })
+
   it('caches an unknown result under a short-lived negative marker', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, status: 404 })))
+    vi.stubGlobal('fetch', batchMissThenExact({ ok: false, status: 404 }))
 
     const { priceSource, priceUsd } = await fetchErc20PriceUsd(CHAIN_ID, WETH, 1n)
 
@@ -91,14 +123,7 @@ describe('fetchErc20PriceUsd (USE_PRICE_SERVICE, past-day path)', () => {
   })
 
   it('does not promote a literal zero price into the day cache', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => ({
-      ok: true,
-      json: async () => ({
-        coins: {
-          ['polygon:0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2']: { symbol: 'WETH', price: 0 }
-        }
-      })
-    })))
+    vi.stubGlobal('fetch', batchHit(0))
 
     const { priceSource, priceUsd } = await fetchErc20PriceUsd(CHAIN_ID, WETH, 1n)
 
@@ -110,16 +135,18 @@ describe('fetchErc20PriceUsd (USE_PRICE_SERVICE, past-day path)', () => {
     expect(ttl).to.equal(120_000)
   })
 
-  it('issues one fetch for repeat misses of the same block', async () => {
-    const fetchMock = vi.fn(async () => ({ ok: false, status: 404 }))
+  it('issues no further calls for repeat misses of the same block', async () => {
+    const fetchMock = batchMissThenExact({ ok: false, status: 404 })
     vi.stubGlobal('fetch', fetchMock)
 
     const first = await fetchErc20PriceUsd(CHAIN_ID, WETH, 1n)
+    const callsAfterFirst = fetchMock.mock.calls.length
     const second = await fetchErc20PriceUsd(CHAIN_ID, WETH, 1n)
 
     expect(first.priceSource).to.equal('na')
     expect(second.priceSource).to.equal('na')
-    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(callsAfterFirst).to.equal(2) // batch miss, then the exact endpoint
+    expect(fetchMock.mock.calls.length).to.equal(callsAfterFirst)
     expect(cacheSet).toHaveBeenCalledTimes(2)
   })
 
@@ -146,17 +173,7 @@ describe('fetchErc20PriceUsd (USE_PRICE_SERVICE, past-day path)', () => {
     cacheGet.mockImplementation(async (key: string) => store.get(key))
     cacheSet.mockImplementation(async (key: string, value: unknown) => { store.set(key, value) })
 
-    const fetchMock = vi.fn(async () => ({
-      ok: true,
-      json: async () => ({
-        coins: {
-          ['polygon:0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2']: {
-            symbol: 'WETH',
-            price: 2
-          }
-        }
-      })
-    }))
+    const fetchMock = batchHit(2)
     vi.stubGlobal('fetch', fetchMock)
 
     for (const blockNumber of [1n, 2n, 3n, 4n]) {
@@ -167,11 +184,11 @@ describe('fetchErc20PriceUsd (USE_PRICE_SERVICE, past-day path)', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 
-  it('issues one fetch for distinct past-day blocks after an unavailable response', async () => {
+  it('stops calling out for distinct past-day blocks after an unavailable response', async () => {
     const store = new Map<string, unknown>()
     cacheGet.mockImplementation(async (key: string) => store.get(key))
     cacheSet.mockImplementation(async (key: string, value: unknown) => { store.set(key, value) })
-    const fetchMock = vi.fn(async () => ({ ok: false, status: 503 }))
+    const fetchMock = batchMissThenExact({ ok: false, status: 503 })
     vi.stubGlobal('fetch', fetchMock)
 
     for (const blockNumber of [1n, 2n, 3n, 4n]) {
@@ -180,24 +197,14 @@ describe('fetchErc20PriceUsd (USE_PRICE_SERVICE, past-day path)', () => {
       expect(priceUsd).to.equal(0)
     }
 
-    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledTimes(2) // batch miss, then the exact endpoint
   })
 
-  it('skips the day key for a current-day block (routes through the 30s cache)', async () => {
+  it('skips the day key for a current-day block (routes through the block cache)', async () => {
     const nowSec = Math.floor(Date.now() / 1000)
     blockTime.mockResolvedValue(BigInt(nowSec))
 
-    const fetchMock = vi.fn(async () => ({
-      ok: true,
-      json: async () => ({
-        coins: {
-          ['polygon:0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2']: {
-            symbol: 'WETH',
-            price: 2
-          }
-        }
-      })
-    }))
+    const fetchMock = batchHit(2)
     vi.stubGlobal('fetch', fetchMock)
 
     const { priceSource, priceUsd } = await fetchErc20PriceUsd(CHAIN_ID, WETH, 1n)
@@ -211,17 +218,7 @@ describe('fetchErc20PriceUsd (USE_PRICE_SERVICE, past-day path)', () => {
   it('skips the day cache entirely with no blockNumber (latest path)', async () => {
     blockTime.mockResolvedValue(1700000000n) // past day — would hit the day-cache branch if latest weren't set
 
-    const fetchMock = vi.fn(async () => ({
-      ok: true,
-      json: async () => ({
-        coins: {
-          ['polygon:0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2']: {
-            symbol: 'WETH',
-            price: 2
-          }
-        }
-      })
-    }))
+    const fetchMock = batchHit(2)
     vi.stubGlobal('fetch', fetchMock)
 
     const { priceSource, priceUsd } = await fetchErc20PriceUsd(CHAIN_ID, WETH)

--- a/packages/ingest/prices.service.mock.spec.ts
+++ b/packages/ingest/prices.service.mock.spec.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { blockTime, first, mqAdd, multicall } = vi.hoisted(() => ({
-  blockTime: vi.fn(), first: vi.fn(), mqAdd: vi.fn(), multicall: vi.fn()
+const { blockTime, first, mqAdd, multicall, query } = vi.hoisted(() => ({
+  blockTime: vi.fn(), first: vi.fn(), mqAdd: vi.fn(), multicall: vi.fn(), query: vi.fn()
 }))
 
 vi.mock('lib', () => ({
@@ -24,7 +24,7 @@ vi.mock('lib/cache', () => ({
 }))
 
 vi.mock('./db', () => ({
-  default: { query: vi.fn() },
+  default: { query },
   first
 }))
 
@@ -221,5 +221,42 @@ describe('fetchErc20PriceUsd (USE_PRICE_SERVICE=true)', () => {
 
     expect(price.priceSource).to.equal('na')
     expect(outputs).not.to.deep.equal([])
+  })
+})
+
+describe('fetchErc20PriceUsd (USE_PRICE_SERVICE=false)', () => {
+  const originalUsePriceService = process.env.USE_PRICE_SERVICE
+  const originalApiKey = process.env.PRICE_SERVICE_API_KEY
+
+  beforeEach(() => {
+    process.env.USE_PRICE_SERVICE = 'false'
+    process.env.PRICE_SERVICE_API_KEY = 'test-key'
+    mqAdd.mockReset()
+    query.mockReset().mockResolvedValue({ rows: [] })
+    blockTime.mockReset().mockResolvedValue(1700000000n)
+  })
+
+  afterEach(() => {
+    if (originalUsePriceService === undefined) delete process.env.USE_PRICE_SERVICE
+    else process.env.USE_PRICE_SERVICE = originalUsePriceService
+    if (originalApiKey === undefined) delete process.env.PRICE_SERVICE_API_KEY
+    else process.env.PRICE_SERVICE_API_KEY = originalApiKey
+    vi.unstubAllGlobals()
+  })
+
+  it('reaches the price service through the exact endpoint, never the batch route', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ coins: { [WETH_COIN]: { symbol: 'WETH', price: 3 } } })
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { priceSource, priceUsd } = await fetchErc20PriceUsd(CHAIN_ID, WETH, 1n)
+
+    expect(priceSource).to.equal('priceservice')
+    expect(priceUsd).to.equal(3)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0][0]).toContain('/api/prices/historical/1700000000/')
+    expect(fetchMock.mock.calls.some(([url]) => String(url).includes('batchHistorical'))).to.equal(false)
   })
 })

--- a/packages/ingest/prices.service.mock.spec.ts
+++ b/packages/ingest/prices.service.mock.spec.ts
@@ -42,6 +42,23 @@ import processTvl from './abis/yearn/lib/tvl'
 const WETH = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2' as const
 const VAULT = '0x1111111111111111111111111111111111111111' as const
 const CHAIN_ID = 137 // polygon — not in the on-chain `lens` map
+const WETH_COIN = 'polygon:0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
+const DAY_END = 1700006399
+
+function batchResponse(prices: Record<string, number>) {
+  return {
+    ok: true,
+    json: async () => ({
+      coins: Object.fromEntries(Object.entries(prices).map(([coinId, price]) => [
+        coinId, { symbol: 'TOKEN', prices: [{ timestamp: DAY_END, price }] }
+      ]))
+    })
+  }
+}
+
+function decodeCoins(url: string) {
+  return JSON.parse(decodeURIComponent(new URL(url).searchParams.get('coins')!))
+}
 
 describe('fetchErc20PriceUsd (USE_PRICE_SERVICE=true)', () => {
   const originalUsePriceService = process.env.USE_PRICE_SERVICE
@@ -71,18 +88,10 @@ describe('fetchErc20PriceUsd (USE_PRICE_SERVICE=true)', () => {
     vi.unstubAllGlobals()
   })
 
-  it('returns the price service value and never enqueues', async () => {
-    const fetchMock = vi.fn(async () => ({
-      ok: true,
-      json: async () => ({
-        coins: {
-          ['polygon:0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2']: {
-            symbol: 'WETH',
-            price: 2
-          }
-        }
-      })
-    }))
+  it('returns the price service value from one batch call and never enqueues', async () => {
+    const fetchMock = vi.fn(async (requested: string) => requested.includes('batchHistorical')
+      ? batchResponse({ [WETH_COIN]: 2 })
+      : { ok: false, status: 500 })
     vi.stubGlobal('fetch', fetchMock)
 
     const { priceSource, priceUsd } = await fetchErc20PriceUsd(CHAIN_ID, WETH, 1n)
@@ -91,12 +100,31 @@ describe('fetchErc20PriceUsd (USE_PRICE_SERVICE=true)', () => {
     expect(priceUsd).to.equal(2)
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(mqAdd).not.toHaveBeenCalled()
-    expect(fetchMock.mock.calls[0][0]).to.equal('https://prices.yearn.dev/api/prices/historical/1700000000/polygon:0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2')
-    expect(fetchMock.mock.calls[0][0]).not.toContain('source=')
+    const url = fetchMock.mock.calls[0][0]
+    expect(url).toContain('https://prices.yearn.dev/api/prices/batchHistorical?coins=')
+    expect(decodeCoins(url)).to.deep.equal({ [WETH_COIN]: [1700000000] })
+    expect(url).not.toContain('source=')
   })
 
-  it('returns na when the service says the price is missing — no fallback, no enqueue', async () => {
-    const fetchMock = vi.fn(async () => ({ ok: false, status: 404 }))
+  it('falls back to the exact endpoint when the batch has no row for the day', async () => {
+    const fetchMock = vi.fn(async (url: string) => url.includes('batchHistorical')
+      ? batchResponse({})
+      : {
+        ok: true,
+        json: async () => ({ coins: { [WETH_COIN]: { symbol: 'WETH', price: 3 } } })
+      })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { priceSource, priceUsd } = await fetchErc20PriceUsd(CHAIN_ID, WETH, 1n)
+
+    expect(priceSource).to.equal('priceservice')
+    expect(priceUsd).to.equal(3)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(fetchMock.mock.calls[1][0]).to.equal(`https://prices.yearn.dev/api/prices/historical/1700000000/${WETH_COIN}`)
+  })
+
+  it('returns na without an exact call when the batch stores a zero price', async () => {
+    const fetchMock = vi.fn(async () => batchResponse({ [WETH_COIN]: 0 }))
     vi.stubGlobal('fetch', fetchMock)
 
     const { priceSource, priceUsd } = await fetchErc20PriceUsd(CHAIN_ID, WETH, 1n)
@@ -104,6 +132,68 @@ describe('fetchErc20PriceUsd (USE_PRICE_SERVICE=true)', () => {
     expect(priceSource).to.equal('na')
     expect(priceUsd).to.equal(0)
     expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to the exact endpoint when the batch call fails', async () => {
+    const fetchMock = vi.fn(async (url: string) => url.includes('batchHistorical')
+      ? { ok: false, status: 500 }
+      : { ok: true, json: async () => ({ coins: { [WETH_COIN]: { symbol: 'WETH', price: 4 } } }) })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { priceSource, priceUsd } = await fetchErc20PriceUsd(CHAIN_ID, WETH, 1n)
+
+    expect(priceSource).to.equal('priceservice')
+    expect(priceUsd).to.equal(4)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('coalesces concurrent lookups into one batch call', async () => {
+    const other = '0x2222222222222222222222222222222222222222' as const
+    const otherCoin = `polygon:${other.toLowerCase()}`
+    const fetchMock = vi.fn(async (requested: string) => requested.includes('batchHistorical')
+      ? batchResponse({ [WETH_COIN]: 2, [otherCoin]: 7 })
+      : { ok: false, status: 500 })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const [weth, second, duplicate] = await Promise.all([
+      fetchErc20PriceUsd(CHAIN_ID, WETH, 1n),
+      fetchErc20PriceUsd(CHAIN_ID, other, 2n),
+      fetchErc20PriceUsd(CHAIN_ID, WETH, 3n)
+    ])
+
+    expect(weth.priceUsd).to.equal(2)
+    expect(second.priceUsd).to.equal(7)
+    expect(duplicate.priceUsd).to.equal(2)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(Object.keys(decodeCoins(fetchMock.mock.calls[0][0]))).to.have.lengthOf(2)
+  })
+
+  it('splits more than 50 queued tokens across batch calls', async () => {
+    const fetchMock = vi.fn(async (requested: string) => requested.includes('batchHistorical')
+      ? batchResponse({})
+      : { ok: false, status: 404 })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const tokens = Array.from({ length: 51 }, (_, index) =>
+      `0x${(index + 1).toString(16).padStart(40, '0')}` as `0x${string}`)
+
+    await Promise.all(tokens.map(token => fetchErc20PriceUsd(CHAIN_ID, token, 1n)))
+
+    const batchCalls = fetchMock.mock.calls.filter(([url]) => url.includes('batchHistorical'))
+    expect(batchCalls).to.have.lengthOf(2)
+  })
+
+  it('returns na when both the batch and the exact endpoint have nothing — no enqueue', async () => {
+    const fetchMock = vi.fn(async (url: string) => url.includes('batchHistorical')
+      ? batchResponse({})
+      : { ok: false, status: 404 })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { priceSource, priceUsd } = await fetchErc20PriceUsd(CHAIN_ID, WETH, 1n)
+
+    expect(priceSource).to.equal('na')
+    expect(priceUsd).to.equal(0)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
     expect(mqAdd).not.toHaveBeenCalled()
   })
 

--- a/packages/ingest/prices.service.mock.spec.ts
+++ b/packages/ingest/prices.service.mock.spec.ts
@@ -197,20 +197,29 @@ describe('fetchErc20PriceUsd (USE_PRICE_SERVICE=true)', () => {
     expect(mqAdd).not.toHaveBeenCalled()
   })
 
-  it('does not emit tvl rows when the service is unavailable', async () => {
+  it('emits a null tvl row when the service is unavailable', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, status: 401 })))
 
+    const price = await fetchErc20PriceUsd(CHAIN_ID, WETH, 1n)
     const outputs = await processTvl(CHAIN_ID, VAULT, { outputLabel: 'tvl', blockTime: 1700000000n } as never)
 
-    expect(outputs).to.deep.equal([])
+    expect(price.priceSource).to.equal('unavailable')
+    expect(outputs).to.have.length(1)
+    expect(outputs[0].component).to.equal('tvl')
+    expect(outputs[0].value).to.equal(null)
   })
 
-  it('does not emit componentized priceUsd rows when the service is unavailable', async () => {
+  it('emits null usd components when the service is unavailable', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, status: 401 })))
 
     const outputs = await processTvl(CHAIN_ID, VAULT, { outputLabel: 'tvl', blockTime: 1700000000n } as never, true)
+    const byComponent = Object.fromEntries(outputs.map(output => [output.component, output.value]))
 
-    expect(outputs).to.deep.equal([])
+    expect(byComponent['tvl']).to.equal(null)
+    expect(byComponent['delegated']).to.equal(null)
+    expect(byComponent['priceUsd']).to.equal(null)
+    expect(byComponent['totalAssets']).to.equal(1)
+    expect(byComponent['delegatedAssets']).to.equal(0)
   })
 
   it('emits rows when the service says the price is missing', async () => {

--- a/packages/ingest/prices.service.mock.spec.ts
+++ b/packages/ingest/prices.service.mock.spec.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { blockTime, first, mqAdd, multicall, query } = vi.hoisted(() => ({
-  blockTime: vi.fn(), first: vi.fn(), mqAdd: vi.fn(), multicall: vi.fn(), query: vi.fn()
+const { blockTime, first, mqAdd, multicall, query, some } = vi.hoisted(() => ({
+  blockTime: vi.fn(), first: vi.fn(), mqAdd: vi.fn(), multicall: vi.fn(), query: vi.fn(), some: vi.fn(async () => false)
 }))
 
 vi.mock('lib', () => ({
@@ -25,7 +25,8 @@ vi.mock('lib/cache', () => ({
 
 vi.mock('./db', () => ({
   default: { query },
-  first
+  first,
+  some
 }))
 
 vi.mock('./rpcs', () => ({
@@ -78,6 +79,7 @@ describe('fetchErc20PriceUsd (USE_PRICE_SERVICE=true)', () => {
       { status: 'success', result: 1_000_000_000_000_000_000n },
       { status: 'failure' }
     ])
+    some.mockReset().mockResolvedValue(false)
   })
 
   afterEach(() => {
@@ -243,6 +245,7 @@ describe('fetchErc20PriceUsd (USE_PRICE_SERVICE=false)', () => {
     mqAdd.mockReset()
     query.mockReset().mockResolvedValue({ rows: [] })
     blockTime.mockReset().mockResolvedValue(1700000000n)
+    some.mockReset().mockResolvedValue(false)
   })
 
   afterEach(() => {

--- a/packages/ingest/prices.ts
+++ b/packages/ingest/prices.ts
@@ -19,6 +19,9 @@ const DAY_SECONDS = 86_400
 const PAST_DAY_CACHE_TTL_MS = 24 * 60 * 60 * 1000
 const PAST_DAY_NEGATIVE_CACHE_TTL_MS = 120_000
 const BLOCK_CACHE_TTL_MS = 30_000
+// lib/blocks pins the head block for 15m and the service refreshes today's row hourly, so a 30s
+// ttl re-fetched an unchanged value ~120x/h per token.
+const SERVICE_BLOCK_CACHE_TTL_MS = 15 * 60 * 1000
 
 /** When true, indexer reads prices from yearn-prices and skips the Postgres price table. */
 export function usePriceService(): boolean {
@@ -63,7 +66,7 @@ export async function fetchErc20PriceUsd(chainId: number, token: `0x${string}`, 
       const result = await cache.wrap(
         blockCacheKey,
         async () => __fetchErc20PriceUsd(chainId, token, blockNumber!, latest, blockTime),
-        BLOCK_CACHE_TTL_MS
+        blockCacheTtl()
       )
       // Only a day-granular service result is safe under a day key: a transient miss must
       // not stick tvl=0 for the whole day.
@@ -76,8 +79,16 @@ export async function fetchErc20PriceUsd(chainId: number, token: `0x${string}`, 
   return cache.wrap(
     blockCacheKey,
     async () => __fetchErc20PriceUsd(chainId, token, blockNumber!, latest),
-    BLOCK_CACHE_TTL_MS
+    blockCacheTtl()
   )
+}
+
+// Misses keep the short negative ttl so a transient outage can't stick tvl=0 for 15 minutes.
+function blockCacheTtl() {
+  if (!usePriceService()) return BLOCK_CACHE_TTL_MS
+  return (result: { priceSource: string }) => result.priceSource === 'priceservice'
+    ? SERVICE_BLOCK_CACHE_TTL_MS
+    : PAST_DAY_NEGATIVE_CACHE_TTL_MS
 }
 
 async function __fetchErc20PriceUsd(
@@ -206,25 +217,116 @@ async function fetchPriceServiceUsdResult(chainId: number, token: `0x${string}`,
   try {
     const blockTime = knownBlockTime ?? await getBlockTime(chainId, blockNumber)
     const coinId = `${chainName}:${token.toLowerCase()}`
-    const url = `${baseUrl}/api/prices/historical/${Number(blockTime)}/${coinId}`
+
+    const batched = await enqueuePriceServiceBatch(coinId, Number(blockTime))
+    if (batched.found) {
+      const priceUsd = batched.priceUsd
+      // A stored zero is an answer, not a gap: the exact endpoint would read the same row.
+      if (!priceUsd || !Number.isFinite(priceUsd)) { warn('empty coins'); return { type: 'missing' } }
+      return { type: 'price', price: PriceSchema.parse({ chainId, address: token, priceUsd, priceSource: 'priceservice', blockNumber, blockTime }) }
+    }
+
+    // batchHistorical reads the table only; the exact route also resolves upstream on a table miss.
+    return await fetchPriceServiceExactResult({ chainId, token, blockNumber, blockTime, coinId, baseUrl, warn })
+  } catch (error) {
+    console.warn('🚨', 'price service failed', chainId, token, blockNumber, error)
+    return { type: 'unavailable' }
+  }
+}
+
+async function fetchPriceServiceExactResult(request: {
+  chainId: number
+  token: `0x${string}`
+  blockNumber: bigint
+  blockTime: bigint
+  coinId: string
+  baseUrl: string
+  warn: (reason: string, detail?: unknown) => void
+}): Promise<PriceServiceResult> {
+  const { chainId, token, blockNumber, blockTime, coinId, baseUrl, warn } = request
+  const url = `${baseUrl}/api/prices/historical/${Number(blockTime)}/${coinId}`
+
+  const response = await fetch(url, {
+    headers: { Authorization: `Bearer ${process.env.PRICE_SERVICE_API_KEY}` }
+  })
+  if (!response.ok) {
+    warn('http', response.status)
+    return response.status === 404 ? { type: 'missing' } : { type: 'unavailable' }
+  }
+
+  const data = await response.json() as { coins: Record<string, { price: number }> }
+  const coinData = data.coins[coinId]
+  const priceUsd = coinData?.price
+  if (!priceUsd || !Number.isFinite(priceUsd)) { warn('empty coins'); return { type: 'missing' } }
+
+  return { type: 'price', price: PriceSchema.parse({ chainId, address: token, priceUsd, priceSource: 'priceservice', blockNumber, blockTime }) }
+}
+
+type PriceServiceBatchOutcome = { found: true, priceUsd: number } | { found: false }
+
+type PriceServiceBatchEntry = {
+  coinId: string
+  timestamp: number
+  promise: Promise<PriceServiceBatchOutcome>
+  resolve: (outcome: PriceServiceBatchOutcome) => void
+}
+
+const BATCH_FLUSH_MS = 25
+// Capping queued entries also caps distinct coins and per-coin timestamps, the service's two limits.
+const BATCH_MAX_ENTRIES = 50
+
+const pendingBatch = new Map<string, PriceServiceBatchEntry>()
+let batchTimer: ReturnType<typeof setTimeout> | undefined
+
+function enqueuePriceServiceBatch(coinId: string, timestamp: number): Promise<PriceServiceBatchOutcome> {
+  const key = `${coinId}:${utcDayStart(timestamp)}`
+  const queued = pendingBatch.get(key)
+  if (queued) return queued.promise
+
+  let resolve!: (outcome: PriceServiceBatchOutcome) => void
+  const promise = new Promise<PriceServiceBatchOutcome>(_resolve => { resolve = _resolve })
+  pendingBatch.set(key, { coinId, timestamp, promise, resolve })
+
+  if (pendingBatch.size >= BATCH_MAX_ENTRIES) flushPriceServiceBatch()
+  else if (!batchTimer) batchTimer = setTimeout(flushPriceServiceBatch, BATCH_FLUSH_MS)
+
+  return promise
+}
+
+function flushPriceServiceBatch() {
+  if (batchTimer) { clearTimeout(batchTimer); batchTimer = undefined }
+  const entries = [...pendingBatch.values()]
+  pendingBatch.clear()
+  for (let i = 0; i < entries.length; i += BATCH_MAX_ENTRIES) {
+    void sendPriceServiceBatch(entries.slice(i, i + BATCH_MAX_ENTRIES))
+  }
+}
+
+// Never throws: an unresolved entry falls through to the exact endpoint, same as a table miss.
+async function sendPriceServiceBatch(entries: PriceServiceBatchEntry[]) {
+  try {
+    const coins: Record<string, number[]> = {}
+    for (const entry of entries) (coins[entry.coinId] ??= []).push(entry.timestamp)
+
+    const baseUrl = process.env.PRICE_SERVICE_URL || PRICE_SERVICE_DEFAULT_URL
+    const url = `${baseUrl}/api/prices/batchHistorical?coins=${encodeURIComponent(JSON.stringify(coins))}`
 
     const response = await fetch(url, {
       headers: { Authorization: `Bearer ${process.env.PRICE_SERVICE_API_KEY}` }
     })
-    if (!response.ok) {
-      warn('http', response.status)
-      return response.status === 404 ? { type: 'missing' } : { type: 'unavailable' }
+    if (!response.ok) throw new Error(`batchHistorical ${response.status}`)
+
+    const data = await response.json() as { coins?: Record<string, { prices?: { timestamp: number, price: number }[] }> }
+    // The service echoes the key it parsed, which checksums the address.
+    const byCoin = new Map(Object.entries(data.coins ?? {}).map(([key, value]) => [key.toLowerCase(), value]))
+
+    for (const entry of entries) {
+      const day = utcDayStart(entry.timestamp)
+      const hit = byCoin.get(entry.coinId)?.prices?.find(price => utcDayStart(price.timestamp) === day)
+      entry.resolve(hit ? { found: true, priceUsd: hit.price } : { found: false })
     }
-
-    const data = await response.json() as { coins: Record<string, { price: number }> }
-    const coinData = data.coins[coinId]
-    const priceUsd = coinData?.price
-    if (!priceUsd || !Number.isFinite(priceUsd)) { warn('empty coins'); return { type: 'missing' } }
-
-    return { type: 'price', price: PriceSchema.parse({ chainId, address: token, priceUsd, priceSource: 'priceservice', blockNumber, blockTime }) }
-  } catch (error) {
-    console.warn('🚨', 'price service failed', chainId, token, blockNumber, error)
-    return { type: 'unavailable' }
+  } catch {
+    for (const entry of entries) entry.resolve({ found: false })
   }
 }
 

--- a/packages/ingest/prices.ts
+++ b/packages/ingest/prices.ts
@@ -218,7 +218,11 @@ async function fetchPriceServiceUsdResult(chainId: number, token: `0x${string}`,
     const blockTime = knownBlockTime ?? await getBlockTime(chainId, blockNumber)
     const coinId = `${chainName}:${token.toLowerCase()}`
 
-    const batched = await enqueuePriceServiceBatch(coinId, Number(blockTime))
+    // Batching is service-mode only: the legacy path hits this as a rare last resort, where a
+    // flush window buys nothing and the kill switch should take the whole layer with it.
+    const batched = usePriceService()
+      ? await enqueuePriceServiceBatch(coinId, Number(blockTime))
+      : { found: false } as const
     if (batched.found) {
       const priceUsd = batched.priceUsd
       // A stored zero is an answer, not a gap: the exact endpoint would read the same row.
@@ -314,7 +318,7 @@ async function sendPriceServiceBatch(entries: PriceServiceBatchEntry[]) {
     const response = await fetch(url, {
       headers: { Authorization: `Bearer ${process.env.PRICE_SERVICE_API_KEY}` }
     })
-    if (!response.ok) throw new Error(`batchHistorical ${response.status}`)
+    if (!response.ok) throw new Error(`batchHistorical ${response.status} ${url}`)
 
     const data = await response.json() as { coins?: Record<string, { prices?: { timestamp: number, price: number }[] }> }
     // The service echoes the key it parsed, which checksums the address.
@@ -325,7 +329,9 @@ async function sendPriceServiceBatch(entries: PriceServiceBatchEntry[]) {
       const hit = byCoin.get(entry.coinId)?.prices?.find(price => utcDayStart(price.timestamp) === day)
       entry.resolve(hit ? { found: true, priceUsd: hit.price } : { found: false })
     }
-  } catch {
+  } catch (error) {
+    // Distinguish a broken batch route from a legitimate table miss, which resolves the same way.
+    console.warn('🚨', 'price service batch failed', entries.length, error)
     for (const entry of entries) entry.resolve({ found: false })
   }
 }

--- a/packages/lib/dates.spec.ts
+++ b/packages/lib/dates.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai'
-import { endOfDayMs, endOfStringDay, epoch, findMissingTimestamps, makeTimeline, startOfDayMs } from './dates'
+import { endOfDayMs, endOfStringDay, epoch, makeTimeline, startOfDayMs } from './dates'
 
 describe('dates', function() {
   it('computes start of day', async function() {
@@ -28,33 +28,5 @@ describe('dates', function() {
     ])
 
     expect(makeTimeline(epoch('2024-01-05'), epoch('2024-01-01'))).to.deep.equal([])
-  })
-
-  it('finds missing dates', async function() {
-    const start: bigint = endOfStringDay('2024-01-01')
-    const end: bigint = endOfStringDay('2024-01-5')
-    const outputed: bigint[] = [
-      start,
-      endOfStringDay('2024-01-3'),
-      end
-    ]
-
-    expect(findMissingTimestamps(start, end, outputed)).to.deep.equal([
-      endOfStringDay('2024-01-2'),
-      endOfStringDay('2024-01-4')
-    ])
-  })
-
-  it('finds no missing dates', async function() {
-    const start: bigint = endOfStringDay('2024-01-01')
-    const end: bigint = endOfStringDay('2024-01-5')
-    const outputed: bigint[] = [
-      start,
-      endOfStringDay('2024-01-2'),
-      endOfStringDay('2024-01-3'),
-      endOfStringDay('2024-01-4'),
-      end
-    ]
-    expect(findMissingTimestamps(start, end, outputed)).to.be.empty
   })
 })

--- a/packages/lib/dates.ts
+++ b/packages/lib/dates.ts
@@ -50,16 +50,3 @@ export function makeTimeline(start: bigint, end: bigint): bigint[] {
   return result
 }
 
-export function findMissingTimestamps(start: bigint, end: bigint, outputed: bigint[]): bigint[] {
-  const result: bigint[] = []
-  const timeline = makeTimeline(start, end)
-
-  outputed.forEach((time, index) => outputed[index] = endOfDay(time))
-
-  for (const time of timeline) {
-    const index = outputed.indexOf(time)
-    if (index === -1) result.push(time)
-  }
-
-  return result
-}

--- a/packages/scripts/src/issue-225/README.md
+++ b/packages/scripts/src/issue-225/README.md
@@ -18,7 +18,7 @@ history. Reuses the live erc4626 timeseries hooks (`apy/hook.ts`,
 Recompute here is **timeseries** data, which lives in the `output` table.
 `evmlog_strides` only gates evmlog (event) and snapshot re-indexing — the
 timeseries fanout (`ingest/fanout/timeseries.ts`) decides what to compute by
-looking for **gaps in the `output` table** (`findMissingTimestamps`), not strides.
+looking for **gaps in the `output` table** (`findMissingDays`), not strides.
 
 Consequence:
 - Editing `evmlog_strides` + rerunning fanout does **not** recompute these series —

--- a/packages/web/app/api/gql/resolvers/timeseries.spec.ts
+++ b/packages/web/app/api/gql/resolvers/timeseries.spec.ts
@@ -1,0 +1,33 @@
+import { strict as assert } from 'node:assert'
+import { beforeEach, describe, it, vi } from 'vitest'
+
+const query = vi.fn()
+
+vi.mock('@/app/api/db', () => ({
+  default: { query }
+}))
+
+// COALESCE(AVG(...), 0) reads an all-null bucket (price service outage) as 0.
+// HAVING COUNT(value) > 0 is the only thing excluding those buckets — pin it.
+describe('timeseries resolver', () => {
+  beforeEach(() => {
+    query.mockReset()
+    query.mockResolvedValue({ rows: [] })
+  })
+
+  it('alltimeseries excludes all-null buckets', async () => {
+    const { default: timeseries } = await import('./timeseries')
+    await timeseries({}, { label: 'tvl' })
+
+    const sql = query.mock.calls[0][0] as string
+    assert.equal(sql.includes('HAVING COUNT(value) > 0'), true)
+  })
+
+  it('yearntimeseries excludes all-null buckets', async () => {
+    const { default: timeseries } = await import('./timeseries')
+    await timeseries({}, { label: 'tvl', yearn: true })
+
+    const sql = query.mock.calls[0][0] as string
+    assert.equal(sql.includes('HAVING COUNT(output.value) > 0'), true)
+  })
+})

--- a/packages/web/app/api/gql/resolvers/timeseries.ts
+++ b/packages/web/app/api/gql/resolvers/timeseries.ts
@@ -54,6 +54,7 @@ async function alltimeseries(args: {
       AND (component = $4 OR $4 IS NULL)
       AND (block_time > to_timestamp($7) OR $7 IS NULL)
     GROUP BY chain_id, address, component, time
+    HAVING COUNT(value) > 0
     ORDER BY time ASC
     LIMIT $6`,
   [chainId, address ? getAddress(address) : null, label, component, period, limit, timestamp])
@@ -89,6 +90,7 @@ async function yearntimeseries(args: {
       AND (output.component = $4 OR $4 IS NULL)
       AND (output.block_time > to_timestamp($7) OR $7 IS NULL)
     GROUP BY output.chain_id, output.address, output.component, time
+    HAVING COUNT(output.value) > 0
     ORDER BY time ASC
     LIMIT $6`,
   [chainId, address, label, component, period, limit, timestamp])

--- a/packages/web/app/api/gql/resolvers/tvls.spec.ts
+++ b/packages/web/app/api/gql/resolvers/tvls.spec.ts
@@ -62,6 +62,8 @@ describe('tvls resolver', () => {
     const params = query.mock.calls[0][1] as unknown[]
     assert.equal(sql.includes('t.label = \'vault\''), true)
     assert.equal(sql.includes('ORDER BY time ASC'), true)
+    // all-null 1-day bucket (price service outage) must be excluded, not read as 0
+    assert.equal(sql.includes('HAVING COUNT(o.value) > 0'), true)
     assert.equal(params[0], 1)
     assert.equal(params[2], '1 week')
     assert.equal(params[4], 10)

--- a/packages/web/app/api/gql/resolvers/tvls.ts
+++ b/packages/web/app/api/gql/resolvers/tvls.ts
@@ -38,6 +38,7 @@ const tvls = async (_: object, args: {
       AND o.component = 'tvl'
       AND (o.block_time > to_timestamp($4) OR $4 IS NULL)
     GROUP BY o.chain_id, o.address, time
+    HAVING COUNT(o.value) > 0
     ORDER BY time ASC
     LIMIT $5`,
     [chainId, address ? getAddress(address) : null, period, timestamp, limit])

--- a/packages/web/app/api/monitor/tvl-gaps/detector.ts
+++ b/packages/web/app/api/monitor/tvl-gaps/detector.ts
@@ -60,11 +60,13 @@ async function filterByMinTvl(pool: Pool, vaults: Vault[], minTvl: number): Prom
   const addresses = vaults.map((v) => getAddress(v.address as `0x${string}`))
   const chainIds = Array.from(new Set(vaults.map((v) => v.chain_id)))
 
+  // size prefilter must be answered by the last real tvl, otherwise a nulled day hides the vault from gap detection
   const tvlResult = await pool.query<{ chain_id: number; address: string; value: string }>(
     `SELECT DISTINCT ON (chain_id, address) chain_id, address, value
     FROM output
     WHERE label = 'tvl-c' AND component = 'tvl'
       AND chain_id = ANY($1) AND address = ANY($2)
+      AND value IS NOT NULL
     ORDER BY chain_id, address, series_time DESC`,
     [chainIds, addresses]
   )

--- a/packages/web/app/api/rest/timeseries/[segment]/[chainId]/[address]/route.spec.ts
+++ b/packages/web/app/api/rest/timeseries/[segment]/[chainId]/[address]/route.spec.ts
@@ -1,0 +1,56 @@
+import { strict as assert } from 'node:assert'
+import { beforeEach, describe, it, vi } from 'vitest'
+
+const get = vi.fn()
+
+vi.mock('@/app/api/rest/cache', () => ({
+  getKeyvClient: () => ({ get })
+}))
+
+async function call(components?: string) {
+  const { GET } = await import('./route')
+  const url = `http://localhost/api/rest/timeseries/tvl/1/0x1111111111111111111111111111111111111111${components ?? ''}`
+  const response = await GET(new Request(url) as never, {
+    params: Promise.resolve({
+      segment: 'tvl',
+      chainId: '1',
+      address: '0x1111111111111111111111111111111111111111'
+    })
+  })
+  return await response.json()
+}
+
+describe('rest timeseries route', () => {
+  beforeEach(() => {
+    get.mockReset()
+  })
+
+  it('omits null-valued days instead of serving them as zero', async () => {
+    get.mockImplementation(async (key: string) =>
+      key.includes('latest') ? [] : [
+        { time: 1, component: 'tvl', value: 100 },
+        { time: 2, component: 'tvl', value: null },
+        { time: 3, component: 'tvl', value: 300 }
+      ]
+    )
+
+    const rows = await call()
+
+    assert.deepEqual(rows, [
+      { time: 1, component: 'tvl', value: 100 },
+      { time: 3, component: 'tvl', value: 300 }
+    ])
+  })
+
+  it('omits a null latest row that overrides a historical day', async () => {
+    get.mockImplementation(async (key: string) =>
+      key.includes('latest')
+        ? [{ time: 2, component: 'tvl', value: null }]
+        : [{ time: 2, component: 'tvl', value: 200 }]
+    )
+
+    const rows = await call()
+
+    assert.deepEqual(rows, [])
+  })
+})

--- a/packages/web/app/api/rest/timeseries/[segment]/[chainId]/[address]/route.ts
+++ b/packages/web/app/api/rest/timeseries/[segment]/[chainId]/[address]/route.ts
@@ -44,7 +44,7 @@ export async function GET(
     ? requestedComponents
     : [entry.defaultComponent]
 
-  type TimeseriesEntry = { time: number; component: string; value: number }
+  type TimeseriesEntry = { time: number; component: string; value: number | null }
 
   const addressLower = address.toLowerCase()
   const chainIdNum = Number(chainId)
@@ -72,7 +72,11 @@ export async function GET(
     ...latest,
   ].sort((a, b) => a.time - b.time)
 
-  const filtered = merged.filter((row) => components.includes(row.component))
+  // a null value is an ingest gap (price service outage), not a real zero: omit the
+  // point so consumers see a hole instead of a crash to $0
+  const filtered = merged.filter(
+    (row) => components.includes(row.component) && row.value !== null,
+  )
 
   return NextResponse.json(filtered, {
     status: 200,

--- a/packages/web/app/api/rest/timeseries/db.spec.ts
+++ b/packages/web/app/api/rest/timeseries/db.spec.ts
@@ -1,0 +1,35 @@
+import { strict as assert } from 'node:assert'
+import { beforeEach, describe, it, vi } from 'vitest'
+
+const query = vi.fn()
+
+vi.mock('../../db', () => ({
+  default: { query }
+}))
+
+const ADDRESS = '0x1111111111111111111111111111111111111111'
+
+// COALESCE(AVG(...), 0) reads an all-null 1-day bucket (price service outage) as 0.
+// HAVING COUNT(value) > 0 is the only thing excluding those buckets — pin it.
+describe('rest timeseries queries', () => {
+  beforeEach(() => {
+    query.mockReset()
+    query.mockResolvedValue({ rows: [] })
+  })
+
+  it('getFullTimeseries excludes all-null buckets', async () => {
+    const { getFullTimeseries } = await import('./db')
+    await getFullTimeseries(1, ADDRESS, 'tvl')
+
+    const sql = query.mock.calls[0][0] as string
+    assert.equal(sql.includes('HAVING COUNT(value) > 0'), true)
+  })
+
+  it('getRecentTimeseries excludes all-null buckets', async () => {
+    const { getRecentTimeseries } = await import('./db')
+    await getRecentTimeseries(1, ADDRESS, 'tvl')
+
+    const sql = query.mock.calls[0][0] as string
+    assert.equal(sql.includes('HAVING COUNT(value) > 0'), true)
+  })
+})

--- a/packages/web/app/api/rest/timeseries/db.ts
+++ b/packages/web/app/api/rest/timeseries/db.ts
@@ -49,6 +49,8 @@ export async function getFullTimeseries(
       AND address = $2
       AND label = $3
     GROUP BY chain_id, address, component, time
+    -- all-null bucket = ingest gap (price service outage): must read as missing, not zero
+    HAVING COUNT(value) > 0
     ORDER BY time ASC
   `,
     [chainId, getAddress(address as `0x${string}`), label],
@@ -78,6 +80,7 @@ export async function getRecentTimeseries(
       AND label = $3
       AND series_time >= date_trunc('day', NOW()) - INTERVAL '2 days'
     GROUP BY chain_id, address, component, time
+    HAVING COUNT(value) > 0
     ORDER BY time ASC
   `,
     [chainId, getAddress(address as `0x${string}`), label],


### PR DESCRIPTION
### Summary
Since #442, a day where the price service errors writes no output row (`tvl.ts` returned `[]`
on `priceSource === 'unavailable'`). The timeseries fanout treats a missing row as "not yet
computed", so it re-enqueued those days every cycle, forever. The fanout query also returned
each vault's entire computed-day history per cycle: ~50M calls and 745M rows in
`pg_stat_statements`, which pushed Neon egress from ~40 to ~230GB/day starting Aug 22.

Two changes:
- `fanout/timeseries.ts`: new `findMissingDays` anti-joins the day timeline against `output`
  and returns only the gaps, keeping the single index-only range scan on
  `idx_output_chain_address_label_series_time`.
- `abis/yearn/lib/tvl.ts`: unavailable prices on past days now write rows with null usd
  components (`tvl`, `delegated`, `priceUsd`) and real on-chain values (`totalAssets`,
  `delegatedAssets`). The row closes the day and ends the loop. The current day still skips
  the write: fanout re-extracts it every cycle anyway, and a null row at today's
  `series_time` would shadow yesterday's real value in latest-row queries.

### How to review
Start with `findMissingDays` in `packages/ingest/fanout/timeseries.ts`: the `NOT IN`
subquery must keep the `BETWEEN` range so Timescale still prunes chunks. Then the
`unavailable` branch in `packages/ingest/abis/yearn/lib/tvl.ts`. The spec
`fanout/timeseries.spec.ts` pins the subtle part: `value: null` survives zod parse, the
Redis JSON roundtrip, and the upsert (writes NULL, replay overwrites it later).

### Test plan
- [ ] Manual: after deploy, watch Neon egress and the `timeseries-*` queue depth drop once
      the null rows land
- [x] Automated: `vitest run --project mocks tvl.unavailable` (4 tests),
      `vitest run --project ingest fanout/timeseries` (4 tests, testcontainers)

### Risk / impact
Past days nulled during a transient service blip stay null until someone replays them; the
old behavior retried forever but self-healed. The current day self-heals via the
unconditional end-of-timeline re-extract. `apy.ts` keeps its own permanent `return []`
paths (`!vault`, `!apy`), so those days remain immortal, but the fanout fix caps their cost
to near-zero rows per cycle. No migration; rollback is a plain revert.