### PR TITLE
fix(ingest): exponential backoff on price-service negative cache

### DIFF
--- a/packages/ingest/fanout/abis.ts
+++ b/packages/ingest/fanout/abis.ts
@@ -1,5 +1,6 @@
 import { abisConfig, chains, mq, sentry } from 'lib'
 import * as things from '../things'
+import { clearNegativePriceCache } from '../prices'
 import WebhookCollector from './webhooks'
 import { findBusyMatch } from './isBusy'
 
@@ -15,6 +16,8 @@ export default class AbisFanout {
       })
       return
     }
+
+    if ((data as { replay?: { enabled?: boolean } }).replay?.enabled) await clearNegativePriceCache()
 
     const webhookCollector = new WebhookCollector()
 

--- a/packages/ingest/prices.service-cache.mock.spec.ts
+++ b/packages/ingest/prices.service-cache.mock.spec.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { cacheGet, cacheSet, blockTime, wrapStore, wrapTtls } = vi.hoisted(() => ({
-  cacheGet: vi.fn(), cacheSet: vi.fn(), blockTime: vi.fn(),
+const { cacheGet, cacheSet, cacheDel, cacheKeys, blockTime, wrapStore, wrapTtls } = vi.hoisted(() => ({
+  cacheGet: vi.fn(), cacheSet: vi.fn(), cacheDel: vi.fn(), cacheKeys: vi.fn(), blockTime: vi.fn(),
   wrapStore: new Map<string, unknown>(), wrapTtls: [] as unknown[]
 }))
 
@@ -14,6 +14,8 @@ vi.mock('lib/cache', () => ({
   cache: {
     get: cacheGet,
     set: cacheSet,
+    del: cacheDel,
+    keys: cacheKeys,
     wrap: async (key: string, fn: () => Promise<unknown>, ttl?: unknown) => {
       wrapTtls.push(ttl)
       if (!wrapStore.has(key)) wrapStore.set(key, await fn())
@@ -22,7 +24,7 @@ vi.mock('lib/cache', () => ({
   }
 }))
 
-import { fetchErc20PriceUsd } from './prices'
+import { clearNegativePriceCache, fetchErc20PriceUsd } from './prices'
 
 const WETH = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2' as const
 const WETH_COIN = 'polygon:0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
@@ -66,6 +68,8 @@ describe('fetchErc20PriceUsd (USE_PRICE_SERVICE, past-day path)', () => {
 
     cacheGet.mockReset().mockResolvedValue(undefined)
     cacheSet.mockReset()
+    cacheDel.mockReset()
+    cacheKeys.mockReset().mockResolvedValue([])
     blockTime.mockReset().mockResolvedValue(1700000000n)
     wrapStore.clear()
     wrapTtls.length = 0
@@ -173,6 +177,22 @@ describe('fetchErc20PriceUsd (USE_PRICE_SERVICE, past-day path)', () => {
 
     expect(markerTtls.slice(0, 3)).to.deep.equal([120_000, 240_000, 480_000])
     expect(markerTtls.at(-1)).to.equal(6 * 60 * 60 * 1000)
+  })
+
+  it('clears negative markers and attempt counters, keeps cached prices', async () => {
+    const prefix = 'fetchErc20PriceUsd:service:v2:137:'
+    const store = new Map<string, unknown>([
+      [`${prefix}${WETH}:1699920000`, { type: 'price-service-negative', priceSource: 'unavailable' }],
+      [`${prefix}${WETH}:1699920000:attempts`, 5],
+      [`${prefix}${WETH}:1699833600`, { chainId: CHAIN_ID, address: WETH, priceUsd: 2, priceSource: 'priceservice', blockNumber: 1n, blockTime: 1699833600n }]
+    ])
+    cacheKeys.mockResolvedValue([...store.keys()])
+    cacheGet.mockImplementation(async (key: string) => store.get(key))
+    cacheDel.mockImplementation(async (key: string) => { store.delete(key) })
+
+    await clearNegativePriceCache()
+
+    expect([...store.keys()]).to.deep.equal([`${prefix}${WETH}:1699833600`])
   })
 
   it('returns a cached value without refetching', async () => {

--- a/packages/ingest/prices.service-cache.mock.spec.ts
+++ b/packages/ingest/prices.service-cache.mock.spec.ts
@@ -114,12 +114,16 @@ describe('fetchErc20PriceUsd (USE_PRICE_SERVICE, past-day path)', () => {
 
     expect(priceSource).to.equal('na')
     expect(priceUsd).to.equal(0)
-    expect(cacheSet).toHaveBeenCalledTimes(1)
+    expect(cacheSet).toHaveBeenCalledTimes(2)
     const [key, marker, ttl] = cacheSet.mock.calls[0]
     expect(key).toContain(':service:')
     expect(marker).to.deep.equal({ type: 'price-service-negative', priceSource: 'na' })
     expect(ttl).to.equal(120_000)
     expect(ttl).not.to.equal(24 * 60 * 60 * 1000)
+    const [attemptsKey, attempts, attemptsTtl] = cacheSet.mock.calls[1]
+    expect(attemptsKey).to.equal(`${key}:attempts`)
+    expect(attempts).to.equal(1)
+    expect(attemptsTtl).to.equal(24 * 60 * 60 * 1000)
   })
 
   it('does not promote a literal zero price into the day cache', async () => {
@@ -129,7 +133,7 @@ describe('fetchErc20PriceUsd (USE_PRICE_SERVICE, past-day path)', () => {
 
     expect(priceSource).to.equal('na')
     expect(priceUsd).to.equal(0)
-    expect(cacheSet).toHaveBeenCalledTimes(1)
+    expect(cacheSet).toHaveBeenCalledTimes(2)
     const [, marker, ttl] = cacheSet.mock.calls[0]
     expect(marker).to.deep.equal({ type: 'price-service-negative', priceSource: 'na' })
     expect(ttl).to.equal(120_000)
@@ -147,7 +151,28 @@ describe('fetchErc20PriceUsd (USE_PRICE_SERVICE, past-day path)', () => {
     expect(second.priceSource).to.equal('na')
     expect(callsAfterFirst).to.equal(2) // batch miss, then the exact endpoint
     expect(fetchMock.mock.calls.length).to.equal(callsAfterFirst)
-    expect(cacheSet).toHaveBeenCalledTimes(2)
+    expect(cacheSet).toHaveBeenCalledTimes(4)
+  })
+
+  it('doubles the negative ttl on repeat failures, capped at 6h', async () => {
+    const store = new Map<string, unknown>()
+    cacheGet.mockImplementation(async (key: string) => store.get(key))
+    const markerTtls: number[] = []
+    cacheSet.mockImplementation(async (key: string, value: unknown, ttl?: number) => {
+      store.set(key, value)
+      if (!key.endsWith(':attempts')) markerTtls.push(ttl as number)
+    })
+    vi.stubGlobal('fetch', batchMissThenExact({ ok: false, status: 503 }))
+
+    for (let attempt = 0; attempt < 10; attempt++) {
+      const { priceSource } = await fetchErc20PriceUsd(CHAIN_ID, WETH, 1n)
+      expect(priceSource).to.equal('unavailable')
+      for (const key of store.keys()) if (!key.endsWith(':attempts')) store.delete(key)
+      wrapStore.clear()
+    }
+
+    expect(markerTtls.slice(0, 3)).to.deep.equal([120_000, 240_000, 480_000])
+    expect(markerTtls.at(-1)).to.equal(6 * 60 * 60 * 1000)
   })
 
   it('returns a cached value without refetching', async () => {

--- a/packages/ingest/prices.ts
+++ b/packages/ingest/prices.ts
@@ -25,6 +25,7 @@ const BLOCK_CACHE_TTL_MS = 30_000
 // lib/blocks pins the head block for 15m and the service refreshes today's row hourly, so a 30s
 // ttl re-fetched an unchanged value ~120x/h per token.
 const SERVICE_BLOCK_CACHE_TTL_MS = 15 * 60 * 1000
+const CLEAR_BATCH_SIZE = 100
 
 /** When true, indexer reads prices from yearn-prices and skips the Postgres price table. */
 export function usePriceService(): boolean {
@@ -101,9 +102,13 @@ async function setNegativeDayCache(key: string, priceSource: string) {
 // keeps cached prices.
 export async function clearNegativePriceCache() {
   const keys = await cache.keys(`${SERVICE_DAY_KEY_PREFIX}*`)
-  for (const key of keys) {
-    if (key.endsWith(':attempts')) { await cache.del(key); continue }
-    if (isPriceServiceNegativeCacheMarker(await cache.get(key))) await cache.del(key)
+  for (let i = 0; i < keys.length; i += CLEAR_BATCH_SIZE) {
+    const batch = keys.slice(i, i + CLEAR_BATCH_SIZE)
+    const attempts = batch.filter(key => key.endsWith(':attempts'))
+    const markers = batch.filter(key => !key.endsWith(':attempts'))
+    const cached = await Promise.all(markers.map(key => cache.get(key)))
+    const stale = markers.filter((_, index) => isPriceServiceNegativeCacheMarker(cached[index]))
+    await Promise.all([...attempts, ...stale].map(key => cache.del(key)))
   }
 }
 

--- a/packages/ingest/prices.ts
+++ b/packages/ingest/prices.ts
@@ -16,6 +16,8 @@ export const lens = {
 }
 
 const DAY_SECONDS = 86_400
+// v2: don't reuse entries a prior trial wrote under the old key.
+const SERVICE_DAY_KEY_PREFIX = 'fetchErc20PriceUsd:service:v2:'
 const PAST_DAY_CACHE_TTL_MS = 24 * 60 * 60 * 1000
 const PAST_DAY_NEGATIVE_CACHE_TTL_MS = 120_000
 const PAST_DAY_NEGATIVE_CACHE_MAX_TTL_MS = 6 * 60 * 60 * 1000
@@ -58,8 +60,7 @@ export async function fetchErc20PriceUsd(chainId: number, token: `0x${string}`, 
     const blockTime = await getBlockTime(chainId, blockNumber)
     if (!isCurrentUtcDay(blockTime)) {
       const day = utcDayStart(blockTime)
-      // v2: don't reuse entries a prior trial wrote under the old key.
-      const key = `fetchErc20PriceUsd:service:v2:${chainId}:${token}:${day}`
+      const key = `${SERVICE_DAY_KEY_PREFIX}${chainId}:${token}:${day}`
       const cached = await cache.get(key)
       if (isPriceServiceNegativeCacheMarker(cached)) return { priceUsd: 0, priceSource: cached.priceSource }
       const parsed = PriceSchema.safeParse(cached)
@@ -93,6 +94,17 @@ async function setNegativeDayCache(key: string, priceSource: string) {
   const ttl = Math.min(PAST_DAY_NEGATIVE_CACHE_TTL_MS * 2 ** attempts, PAST_DAY_NEGATIVE_CACHE_MAX_TTL_MS)
   await cache.set(key, { type: 'price-service-negative', priceSource }, ttl)
   await cache.set(attemptsKey, attempts + 1, PAST_DAY_CACHE_TTL_MS)
+}
+
+// A replay must heal NULL days on its first run: an escalated negative marker (up to 6h)
+// would otherwise turn the replay into a silent no-op. Drops markers and attempt counters,
+// keeps cached prices.
+export async function clearNegativePriceCache() {
+  const keys = await cache.keys(`${SERVICE_DAY_KEY_PREFIX}*`)
+  for (const key of keys) {
+    if (key.endsWith(':attempts')) { await cache.del(key); continue }
+    if (isPriceServiceNegativeCacheMarker(await cache.get(key))) await cache.del(key)
+  }
 }
 
 // Misses keep the short negative ttl so a transient outage can't stick tvl=0 for 15 minutes.

--- a/packages/ingest/prices.ts
+++ b/packages/ingest/prices.ts
@@ -18,6 +18,7 @@ export const lens = {
 const DAY_SECONDS = 86_400
 const PAST_DAY_CACHE_TTL_MS = 24 * 60 * 60 * 1000
 const PAST_DAY_NEGATIVE_CACHE_TTL_MS = 120_000
+const PAST_DAY_NEGATIVE_CACHE_MAX_TTL_MS = 6 * 60 * 60 * 1000
 const BLOCK_CACHE_TTL_MS = 30_000
 // lib/blocks pins the head block for 15m and the service refreshes today's row hourly, so a 30s
 // ttl re-fetched an unchanged value ~120x/h per token.
@@ -71,7 +72,7 @@ export async function fetchErc20PriceUsd(chainId: number, token: `0x${string}`, 
       // Only a day-granular service result is safe under a day key: a transient miss must
       // not stick tvl=0 for the whole day.
       if (result.priceSource === 'priceservice') await cache.set(key, result, PAST_DAY_CACHE_TTL_MS)
-      else await cache.set(key, { type: 'price-service-negative', priceSource: result.priceSource }, PAST_DAY_NEGATIVE_CACHE_TTL_MS)
+      else await setNegativeDayCache(key, result.priceSource)
       return result
     }
   }
@@ -81,6 +82,17 @@ export async function fetchErc20PriceUsd(chainId: number, token: `0x${string}`, 
     async () => __fetchErc20PriceUsd(chainId, token, blockNumber!, latest),
     blockCacheTtl()
   )
+}
+
+// Backoff: first failure retries in 2m (transient outage), each repeat doubles the ttl up to 6h,
+// so a persistently failing key spins ~13 attempts/day instead of 720. The attempt counter lives
+// under its own key so it survives the negative marker's expiry.
+async function setNegativeDayCache(key: string, priceSource: string) {
+  const attemptsKey = `${key}:attempts`
+  const attempts = Number(await cache.get(attemptsKey)) || 0
+  const ttl = Math.min(PAST_DAY_NEGATIVE_CACHE_TTL_MS * 2 ** attempts, PAST_DAY_NEGATIVE_CACHE_MAX_TTL_MS)
+  await cache.set(key, { type: 'price-service-negative', priceSource }, ttl)
+  await cache.set(attemptsKey, attempts + 1, PAST_DAY_CACHE_TTL_MS)
 }
 
 // Misses keep the short negative ttl so a transient outage can't stick tvl=0 for 15 minutes.

--- a/packages/lib/cache.ts
+++ b/packages/lib/cache.ts
@@ -4,7 +4,12 @@ import { Cache, caching } from 'cache-manager'
 import { redisStore } from 'cache-manager-redis-yet'
 
 class __Cache {
-  private __store: { client: { quit: () => Promise<string> } } | undefined
+  private __store: {
+    client: {
+      quit: () => Promise<string>
+      scanIterator: (options: { MATCH: string, COUNT: number }) => AsyncIterable<string>
+    }
+  } | undefined
   private __cache: Cache | undefined
 
   get del() {
@@ -18,9 +23,13 @@ class __Cache {
   }
 
   get keys() {
-    return this.__cache
-      ? (this.__cache as Cache).store.keys.bind((this.__cache as Cache).store)
-      : async (_pattern?: string) => [] as string[]
+    const client = this.__store?.client
+    if (!client) return async (_pattern?: string) => [] as string[]
+    return async (pattern = '*') => {
+      const result: string[] = []
+      for await (const key of client.scanIterator({ MATCH: pattern, COUNT: 1000 })) result.push(key)
+      return result
+    }
   }
 
   get reset() {

--- a/packages/lib/cache.ts
+++ b/packages/lib/cache.ts
@@ -17,6 +17,12 @@ class __Cache {
       : async (_key: string) => undefined
   }
 
+  get keys() {
+    return this.__cache
+      ? (this.__cache as Cache).store.keys.bind((this.__cache as Cache).store)
+      : async (_pattern?: string) => [] as string[]
+  }
+
   get reset() {
     return (this.__cache as Cache).reset.bind(this.__cache)
   }


### PR DESCRIPTION
## What

Retry loop against prices.yearn.dev: kong re-requests the same failing historical prices every ~2 minutes, each attempt costing ~14 metered drpc calls (~1.5M/day vs ~700 baseline). #462 bounded the loop; this stops the spin.

Root cause is a cache-ttl asymmetry in `packages/ingest/prices.ts`: a successful past-day price caches for 24h, a failed one for 2m. With the service failing ~51% of requests, every failure returned to the queue almost immediately — 720 attempts/day per failing key.

## How

- Repeat failures on the same day key double the negative-cache ttl: 2m → 4m → 8m → … capped at 6h (~13 attempts/day worst case).
- First failure still retries in 2m, so a transient outage can't stick tvl=0 for hours.
- Attempt counter lives under a separate key with a 24h ttl so it survives the negative marker's expiry.
- A replay fanout (`fanout replays`) now flushes the price-service negative markers and attempt counters from Redis before enqueuing, so an escalated 6h marker can't turn the replay into a no-op. Cached real prices are kept.
- `packages/lib/cache.ts` gains a `keys(pattern)` accessor for that flush, backed by node-redis `scanIterator` (non-blocking SCAN, not KEYS); deletes run in batches of 100.

## Tests

- Updated `prices.service-cache.mock.spec.ts` for the extra attempts-key write.
- New test: repeat failures escalate the ttl 2m/4m/8m and cap at 6h.
- New test: replay clear removes negative markers and attempt counters, keeps cached prices.
- `bun --filter ingest test`: 179 passed. `bun --filter lib test`: 29 passed.
