### PR TITLE
feat(web): expose katana debt-coverage components over graphql

### DIFF
--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -1092,6 +1092,9 @@ Returns [`[RiskScoreLegacy]`](#riskscorelegacy).
 | `cvxAPR` | `Float` | Convex APR |
 | `keepCRV` | `Float` | Keep CRV |
 | `keepVelo` | `Float` | Keep VELO |
+| `estimatedDebtCoverage` | `Float` | Share of active debt backed by a live Morpho estimate (0–1); remainder falls back to Kong's APR oracle |
+| `morphoBaseAPY` | `Float` | Debt-weighted Morpho base APY leg |
+| `morphoRewardsAPR` | `Float` | Debt-weighted Morpho rewards APR leg |
 
 ### Historical
 

--- a/packages/ingest/helpers/apy-apr.spec.ts
+++ b/packages/ingest/helpers/apy-apr.spec.ts
@@ -223,6 +223,28 @@ describe('getLatestEstimatedAprV3', function() {
     expect(result!.apy).to.equal(0.031)
     expect(result!.components).to.deep.equal({})
   })
+
+  it('returns debt-coverage components unchanged for katana-estimated-apr rows', async function() {
+    const t = new Date()
+    const KATANA_LABEL = 'katana-estimated-apr'
+
+    await insertOutput(VAULT_ADDR, KATANA_LABEL, 'netAPR', 0.062, t)
+    await insertOutput(VAULT_ADDR, KATANA_LABEL, 'netAPY', 0.064, t)
+    await insertOutput(VAULT_ADDR, KATANA_LABEL, 'estimatedDebtCoverage', 0.75, t)
+    await insertOutput(VAULT_ADDR, KATANA_LABEL, 'morphoBaseAPY', 0.041, t)
+    await insertOutput(VAULT_ADDR, KATANA_LABEL, 'morphoRewardsAPR', 0.019, t)
+
+    const result = await getLatestEstimatedAprV3(TEST_CHAIN, VAULT_ADDR)
+    expect(result).to.not.be.undefined
+    expect(result!.type).to.equal(KATANA_LABEL)
+    expect(result!.apr).to.equal(0.062)
+    expect(result!.apy).to.equal(0.064)
+    expect(result!.components).to.deep.equal({
+      estimatedDebtCoverage: 0.75,
+      morphoBaseAPY: 0.041,
+      morphoRewardsAPR: 0.019
+    })
+  })
 })
 
 describe('getLatestApy', function() {

--- a/packages/web/app/api/gql/typeDefs/vault.ts
+++ b/packages/web/app/api/gql/typeDefs/vault.ts
@@ -123,6 +123,9 @@ type EstimatedAprComponents {
   baseNetAPY: Float
   lockerBonusAPR: Float
   lockerBonusAPY: Float
+  estimatedDebtCoverage: Float
+  morphoBaseAPY: Float
+  morphoRewardsAPR: Float
 }
 
 type EstimatedApr {


### PR DESCRIPTION
### Summary
katana-apr-service will emit three new vault-addressed estimated-APR components:
`estimatedDebtCoverage` (share of active debt backed by a live Morpho estimate vs oracle
fallback), `morphoBaseAPY`, and `morphoRewardsAPR`. Ingestion and both REST paths already
pass arbitrary component keys through, but GraphQL's `EstimatedAprComponents` is a fixed
field list and drops undeclared keys. This declares the three fields so they serialize,
and documents them.

### How to review
- `packages/web/app/api/gql/typeDefs/vault.ts`: three fields added to
  `EstimatedAprComponents`, nothing else.
- `packages/ingest/helpers/apy-apr.spec.ts`: new case proving
  `getLatestEstimatedAprV3` returns the three components unchanged for a
  katana-labelled row set.
- `docs/graphql.md`: three table rows.
- No change to `getLatestEstimatedAprV3`, resolvers, REST schemas, or promotion;
  no DB migration.

### Test plan
- [ ] Automated: `bun --filter ingest test -- helpers/apy-apr.spec.ts` (18 pass)

### Risk / impact
Additive GraphQL fields; null until the katana-apr-service side ships, so existing
consumers see unchanged output. No rollback steps needed beyond revert.