### PR TITLE
feat: expose estimated grossAPR/grossAPY and explicit scope marker

### DIFF
--- a/docs/estimated-apr.md
+++ b/docs/estimated-apr.md
@@ -33,11 +33,12 @@ other components stay in `components`.
 
 `promoteEstimatedApr` does the promotion (`packages/ingest/helpers/apy-apr.ts:9`). Both
 the vault path (`packages/ingest/helpers/apy-apr.ts:34`) and the strategy composition
-path (`packages/ingest/abis/yearn/3/vault/snapshot/hook.ts:465`) use it.
+path (`packages/ingest/abis/yearn/3/vault/snapshot/hook.ts:469`) use it.
 
 - `apr` and `apy` come from `netAPR` and `netAPY` only. Kong never puts a gross value
   into `apr` or `apy`.
-- If the publisher sends no `netAPR`, `apr` is absent. Kong does not write a zero.
+- If the publisher sends no `netAPR`, `apr` is absent. Kong does not write a zero, on the
+  v3 path. The legacy v2 path does not follow this rule (see "Legacy v2 read path" below).
 - A promoted component is removed from `components`
   (`packages/ingest/helpers/apy-apr.ts:10`).
 - A row with a null value is not promoted and does not go into `components`.
@@ -68,9 +69,16 @@ of the parent vault `performance.estimated` (issue #409, issue #410).
 
 The vault composition path does not use these lookups. It reads the estimate rows with
 its own query in `fetchStrategyPerformance`
-(`packages/ingest/abis/yearn/3/vault/snapshot/hook.ts:420`), which filters by label only
+(`packages/ingest/abis/yearn/3/vault/snapshot/hook.ts:424`), which filters by label only
 and applies no scope rule, so a strategy estimate stays available for the composition
 entry.
+
+The composition path gets its label from the vault-scoped lookup. When that lookup
+returns nothing, for example when the vault address has only a strategy-scoped emission
+(issue #409), the hook falls back to the label of the latest emission without a scope
+rule (`packages/ingest/abis/yearn/3/vault/snapshot/hook.ts:111`,
+`packages/ingest/helpers/apy-apr.ts:37`). Thus the composition does not lose the
+strategy estimates when a publisher starts to send the `isStrategy` marker.
 
 An emission that has neither marker is vault-scoped. Thus a net-only emission keeps its
 current scope (issue #443).
@@ -93,3 +101,26 @@ do not always agree with the meaning of the value.
 | any | `debtRatio` | not an APR; a debt allocation in basis points |
 
 Kong does not correct these values. Kong promotes what the publisher sends.
+
+## Legacy v2 read path
+
+`getLatestEstimatedApr` (`packages/ingest/helpers/apy-apr.ts:51`) is a second, older read
+path. `packages/ingest/abis/yearn/2/vault/snapshot/hook.ts:95` and
+`packages/ingest/abis/yearn/2/strategy/snapshot/hook.ts:58` call it.
+
+This path does not use `promoteEstimatedApr`. It has its own rules:
+
+- It reads only the labels `crv-estimated-apr`, `velo-estimated-apr`, `aero-estimated-apr`,
+  hard-coded (`packages/ingest/helpers/apy-apr.ts:78,84`).
+- It whitelists only Curve-era components: `boost`, `poolAPY`, `boostedAPR`, `baseAPR`,
+  `rewardsAPR`, `rewardsAPY`, `cvxAPR`, `keepCRV`, `keepVelo`
+  (`packages/ingest/helpers/apy-apr.ts:59-67,100-108`). It never reads or surfaces
+  `grossAPR`, `grossAPY`, or `compoundingPeriodsPerYear`.
+- If `netAPR` or `netAPY` is absent, it writes `apr: 0` or `apy: 0`
+  (`packages/ingest/helpers/apy-apr.ts:96-97`, `result.apr || 0`). This is the opposite of
+  the v3 rule above.
+
+Scope decision: the "no gross value, no zero write" contract in this document applies to
+the v3 path only. The v2 path is frozen legacy. Gross values emitted by the
+`crv`/`velo`/`aero` publishers will not surface on v2 things until this path is migrated
+to `promoteEstimatedApr`. That migration is out of scope here.

--- a/docs/estimated-apr.md
+++ b/docs/estimated-apr.md
@@ -9,7 +9,7 @@ row for each component. Each row has a `chain_id`, an `address`, a `label`, a
 `component` name and a numeric `value`. Kong writes the rows into the `output` table.
 
 The label tells which publisher sent the row. Kong finds vault-level estimates with a
-label that ends in `-estimated-apr` (`packages/lib/estimated-apr.ts:74`).
+label that ends in `-estimated-apr` (`packages/lib/estimated-apr.ts:83`).
 
 One group of rows with the same chain, address, label and `block_time` is one emission.
 Kong reads the most recent emission and makes one `estimated` object from it.
@@ -56,7 +56,7 @@ vault at the same time (issue #409). Only the publisher knows the scope of each
 emission.
 
 Kong finds the scope from the emission itself
-(`packages/lib/estimated-apr.ts:78`):
+(`packages/lib/estimated-apr.ts:91`):
 
 1. If the emission has a non-zero `isStrategy` component, the emission is
    strategy-scoped.

--- a/docs/estimated-apr.md
+++ b/docs/estimated-apr.md
@@ -60,7 +60,7 @@ Kong finds the scope from the emission itself
 
 1. If the emission has a non-zero `isStrategy` component, the emission is
    strategy-scoped.
-2. If the emission has no `isStrategy` component, and it has a `debtRatio` component,
+2. If the emission has no `isStrategy` component (or its value is null), and it has a `debtRatio` component,
    the emission is strategy-scoped. This is the legacy rule.
 3. In all other conditions the emission is vault-scoped.
 

--- a/docs/estimated-apr.md
+++ b/docs/estimated-apr.md
@@ -46,7 +46,7 @@ path (`packages/ingest/abis/yearn/3/vault/snapshot/hook.ts:469`) use it.
 The schema `EstimatedAprSchema` holds the promoted shape
 (`packages/lib/types.ts:444`). The REST list schema
 (`packages/web/app/api/rest/list/db.ts:48`) and the GraphQL type
-(`packages/web/app/api/gql/typeDefs/vault.ts:129`) hold the same fields.
+(`packages/web/app/api/gql/typeDefs/vault.ts:132`) hold the same fields.
 
 ## Scope resolution
 

--- a/docs/estimated-apr.md
+++ b/docs/estimated-apr.md
@@ -1,0 +1,93 @@
+# Estimated APR
+
+This document tells how kong makes `performance.estimated` from publisher output rows.
+
+## Emission model
+
+An external publisher sends APR data to kong through a webhook. The publisher sends one
+row for each component. Each row has a `chain_id`, an `address`, a `label`, a
+`component` name and a numeric `value`. Kong writes the rows into the `output` table.
+
+The label tells which publisher sent the row. Kong finds vault-level estimates with a
+label that ends in `-estimated-apr` (`packages/lib/estimated-apr.ts:74`).
+
+One group of rows with the same chain, address, label and `block_time` is one emission.
+Kong reads the most recent emission and makes one `estimated` object from it.
+
+## Reserved components
+
+Kong promotes some component names to the top level of the `estimated` object. The
+other components stay in `components`.
+
+| Component | Result | Note |
+|-----------|--------|------|
+| `netAPR` | promoted to `apr` | net of all fees |
+| `netAPY` | promoted to `apy` | net of all fees |
+| `grossAPR` | promoted to `grossAPR` | before fees |
+| `grossAPY` | promoted to `grossAPY` | before fees |
+| `compoundingPeriodsPerYear` | stays in `components` | not an APR |
+| `isStrategy` | stays in `components` | scope marker, see below |
+| `debtRatio` | stays in `components` | not an APR, legacy scope marker |
+
+## Promotion rules
+
+`promoteEstimatedApr` does the promotion (`packages/ingest/helpers/apy-apr.ts:9`). Both
+the vault path (`packages/ingest/helpers/apy-apr.ts:34`) and the strategy composition
+path (`packages/ingest/abis/yearn/3/vault/snapshot/hook.ts:465`) use it.
+
+- `apr` and `apy` come from `netAPR` and `netAPY` only. Kong never puts a gross value
+  into `apr` or `apy`.
+- If the publisher sends no `netAPR`, `apr` is absent. Kong does not write a zero.
+- A promoted component is removed from `components`
+  (`packages/ingest/helpers/apy-apr.ts:10`).
+- A row with a null value is not promoted and does not go into `components`.
+
+The schema `EstimatedAprSchema` holds the promoted shape
+(`packages/lib/types.ts:444`). The REST list schema
+(`packages/web/app/api/rest/list/db.ts:48`) and the GraphQL type
+(`packages/web/app/api/gql/typeDefs/vault.ts:129`) hold the same fields.
+
+## Scope resolution
+
+A publisher can send an estimate for a vault or for a strategy. The `thing` table cannot
+tell the two apart, because one address can be a v3 vault and a strategy of a different
+vault at the same time (issue #409). Only the publisher knows the scope of each
+emission.
+
+Kong finds the scope from the emission itself
+(`packages/lib/estimated-apr.ts:78`):
+
+1. If the emission has a non-zero `isStrategy` component, the emission is
+   strategy-scoped.
+2. If the emission has no `isStrategy` component, and it has a `debtRatio` component,
+   the emission is strategy-scoped. This is the legacy rule.
+3. In all other conditions the emission is vault-scoped.
+
+The unlabeled lookup returns vault-scoped emissions only. This keeps a strategy APR out
+of the parent vault `performance.estimated` (issue #409, issue #410).
+
+The lookup with an explicit label does not apply the scope rule
+(`packages/lib/estimated-apr.ts:64`). The vault composition path uses that lookup, so a
+strategy estimate stays available for the composition entry.
+
+An emission that has neither marker is vault-scoped. Thus a net-only emission keeps its
+current scope (issue #443).
+
+## Legacy publisher components
+
+These publishers were in operation before the gross and net split. Their component names
+do not always agree with the meaning of the value.
+
+| Publisher label | Component | True meaning |
+|-----------------|-----------|--------------|
+| `katana-estimated-apr` (strategy) | `netAPR` | gross, not net |
+| `katana-estimated-apr` (strategy) | `netAPY` | gross, not net |
+| `katana-estimated-apr` | `katRewardsAPR` | gross; not in `netAPR` and not in `grossAPR` |
+| `crv-estimated-apr` | `netAPR` | net, but on an APY basis |
+| `velo-estimated-apr` | `netAPR` | net, but on an APY basis |
+| `aero-estimated-apr` | `netAPR` | net, but on an APY basis |
+| `yvusd-estimated-apr` | `baseNetAPR` | net leg of the total |
+| `yvusd-estimated-apr` | `lockerBonusAPR` | net leg of the total |
+| any | `debtRatio` | not an APR; a debt allocation in basis points |
+
+Kong does not correct these values. Kong promotes what the publisher sends.

--- a/docs/estimated-apr.md
+++ b/docs/estimated-apr.md
@@ -66,9 +66,11 @@ Kong finds the scope from the emission itself
 The unlabeled lookup returns vault-scoped emissions only. This keeps a strategy APR out
 of the parent vault `performance.estimated` (issue #409, issue #410).
 
-The lookup with an explicit label does not apply the scope rule
-(`packages/lib/estimated-apr.ts:64`). The vault composition path uses that lookup, so a
-strategy estimate stays available for the composition entry.
+The vault composition path does not use these lookups. It reads the estimate rows with
+its own query in `fetchStrategyPerformance`
+(`packages/ingest/abis/yearn/3/vault/snapshot/hook.ts:420`), which filters by label only
+and applies no scope rule, so a strategy estimate stays available for the composition
+entry.
 
 An emission that has neither marker is vault-scoped. Thus a net-only emission keeps its
 current scope (issue #443).

--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -1074,10 +1074,14 @@ Returns [`[RiskScoreLegacy]`](#riskscorelegacy).
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `apr` | `Float` | Estimated APR |
-| `apy` | `Float` | Estimated APY |
+| `apr` | `Float` | Estimated APR, net of fees |
+| `apy` | `Float` | Estimated APY, net of fees |
+| `grossAPR` | `Float` | Estimated APR before fees |
+| `grossAPY` | `Float` | Estimated APY before fees |
 | `type` | `String` | APR type |
 | `components` | [`EstimatedAprComponents`](#estimatedaprcomponents) | APR breakdown |
+
+See [Estimated APR](./estimated-apr.md) for the promotion rules.
 
 ### EstimatedAprComponents
 
@@ -1092,6 +1096,12 @@ Returns [`[RiskScoreLegacy]`](#riskscorelegacy).
 | `cvxAPR` | `Float` | Convex APR |
 | `keepCRV` | `Float` | Keep CRV |
 | `keepVelo` | `Float` | Keep VELO |
+| `grossAPR` | `Float` | Deprecated. Use `EstimatedApr.grossAPR` |
+| `baseNetAPR` | `Float` | Base net APR |
+| `baseNetAPY` | `Float` | Base net APY |
+| `lockerBonusAPR` | `Float` | Locker bonus APR |
+| `lockerBonusAPY` | `Float` | Locker bonus APY |
+| `compoundingPeriodsPerYear` | `Float` | Compounding periods per year |
 
 ### Historical
 

--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -1102,6 +1102,9 @@ See [Estimated APR](./estimated-apr.md) for the promotion rules.
 | `lockerBonusAPR` | `Float` | Locker bonus APR |
 | `lockerBonusAPY` | `Float` | Locker bonus APY |
 | `compoundingPeriodsPerYear` | `Float` | Compounding periods per year |
+| `katRewardsAPR` | `Float` | Katana rewards APR |
+| `debtRatio` | `Float` | Legacy scope marker; debt allocation in basis points |
+| `isStrategy` | `Float` | Scope marker. Non-zero means strategy-scoped |
 
 ### Historical
 

--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -125,6 +125,29 @@ Price per share tracking over time. This represents the value of one vault share
 
 ---
 
+### 5. `*-estimated-apr`
+
+**Status**: Active
+
+**Available for**: Yearn v3 (full contract), Yearn v2 (legacy read path only, see below)
+
+**Reserved components** (promoted out of `components`, see `docs/estimated-apr.md`):
+- `netAPR`: promoted to `apr`, net of all fees
+- `netAPY`: promoted to `apy`, net of all fees
+- `grossAPR`: promoted to `grossAPR`, before fees
+- `grossAPY`: promoted to `grossAPY`, before fees
+- `compoundingPeriodsPerYear`: stays in `components`, not an APR
+- `isStrategy`: stays in `components`, scope marker. A non-zero value marks the emission
+  strategy-scoped. If absent, Kong falls back to the legacy `debtRatio` heuristic.
+
+**Description**:
+An external publisher sends one row per component, under a label ending in
+`-estimated-apr`. Kong promotes the reserved components above; the rest stay in
+`components`. Full promotion rules, scope resolution, and the frozen legacy v2 read path
+are documented in `docs/estimated-apr.md`.
+
+---
+
 ## Protocol Coverage
 
 | Output Type | ERC4626 | Yearn v2 | Yearn v3 |
@@ -133,6 +156,7 @@ Price per share tracking over time. This represents the value of one vault share
 | `tvl-c` | ✓ | ✓ | ✓ |
 | `apy-bwd-delta-pps` | ✓ | ✓ | ✓ |
 | `pps` | ✓ | ✓ | ✓ |
+| `*-estimated-apr` | ✗ | legacy path only | ✓ |
 
 ## Querying Outputs
 

--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -138,7 +138,7 @@ Price per share tracking over time. This represents the value of one vault share
 - `grossAPY`: promoted to `grossAPY`, before fees
 - `compoundingPeriodsPerYear`: stays in `components`, not an APR
 - `isStrategy`: stays in `components`, scope marker. A non-zero value marks the emission
-  strategy-scoped. If absent, Kong falls back to the legacy `debtRatio` heuristic.
+  strategy-scoped. If absent or null, Kong falls back to the legacy `debtRatio` heuristic.
 
 **Description**:
 An external publisher sends one row per component, under a label ending in

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -51,7 +51,7 @@ curl -s 'https://kong.yearn.fi/api/rest/list/vaults?origin=yearn' | jq
     "performance": {
       "oracle": { "apr": 0.045, "apy": 0.046 },
       "historical": { "net": 0.042, "weeklyNet": 0.041, "monthlyNet": 0.043, "inceptionNet": 0.05 },
-      "estimated": { "apr": 0.044, "apy": 0.045, "type": "base", "components": {} }
+      "estimated": { "apr": 0.044, "apy": 0.045, "grossAPR": 0.052, "grossAPY": 0.053, "type": "base", "components": {} }
     },
     "fees": { "managementFee": 0, "performanceFee": 1000 },
     "category": "Stablecoin",

--- a/packages/ingest/abis/yearn/3/vault/snapshot/hook.spec.ts
+++ b/packages/ingest/abis/yearn/3/vault/snapshot/hook.spec.ts
@@ -226,9 +226,14 @@ describe('abis/yearn/3/vault/snapshot/hook', function() {
   })
 
   it('falls back to the unscoped label when the vault only has a strategy-scoped emission', async function() {
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = (async () => ({
+      json: async () => []
+    })) as unknown as typeof fetch
+
     const chainId = 1337
-    const vault = '0x7000000000000000000000000000000000000007' as `0x${string}`
-    const strategy = '0x8000000000000000000000000000000000000008' as `0x${string}`
+    const vault = '0xb00000000000000000000000000000000000000b' as `0x${string}`
+    const strategy = '0xc00000000000000000000000000000000000000c' as `0x${string}`
     const now = Math.floor(Date.now() / 1000)
     const label = 'katana-estimated-apr'
 
@@ -245,15 +250,48 @@ describe('abis/yearn/3/vault/snapshot/hook', function() {
       await db.query(toUpsertSql('output', 'chain_id, address, label, component, series_time', outputData), Object.values(outputData))
     }
 
-    const resolved = await resolveEstimatedApr(chainId, vault)
-    expect(resolved.estimatedApr).to.equal(undefined)
-    expect(resolved.estimatedAprLabel).to.equal(label)
+    try {
+      const resolved = await resolveEstimatedApr(chainId, vault)
+      expect(resolved.estimatedApr).to.equal(undefined)
+      expect(resolved.estimatedAprLabel).to.equal(label)
 
-    const composition = await extractComposition(chainId, vault, [strategy], [debtFor(strategy)], resolved.estimatedAprLabel)
-    expect(composition[0].performance?.estimated?.apr).to.equal(0.03)
+      const composition = await extractComposition(chainId, vault, [strategy], [debtFor(strategy)], resolved.estimatedAprLabel)
+      expect(composition[0].performance?.estimated?.apr).to.equal(0.03)
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  it('keeps the vault-scoped label when a newer strategy-scoped emission exists', async function() {
+    const chainId = 1337
+    const vault = '0xd00000000000000000000000000000000000000d' as `0x${string}`
+    const now = Math.floor(Date.now() / 1000)
+    const older = now - 60
+
+    for (const row of [
+      { label: 'crv-estimated-apr', component: 'netAPR', value: 0.02, time: older },
+      { label: 'yvusd-estimated-apr', component: 'netAPR', value: 0.08, time: now },
+      { label: 'yvusd-estimated-apr', component: 'isStrategy', value: 1, time: now }
+    ]) {
+      const outputData = {
+        chain_id: chainId, address: vault, label: row.label, component: row.component, value: row.value,
+        block_number: row.time, block_time: row.time, series_time: row.time
+      }
+      await db.query(toUpsertSql('output', 'chain_id, address, label, component, series_time', outputData), Object.values(outputData))
+    }
+
+    const resolved = await resolveEstimatedApr(chainId, vault)
+    expect(resolved.estimatedApr?.type).to.equal('crv-estimated-apr')
+    expect(resolved.estimatedApr?.apr).to.equal(0.02)
+    expect(resolved.estimatedAprLabel).to.equal('crv-estimated-apr')
   })
 
   it('drops null-valued estimated components instead of writing apr: null', async function() {
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = (async () => ({
+      json: async () => []
+    })) as unknown as typeof fetch
+
     const chainId = 1337
     const vault = '0x9000000000000000000000000000000000000009' as `0x${string}`
     const strategy = '0xa00000000000000000000000000000000000000a' as `0x${string}`
@@ -266,11 +304,15 @@ describe('abis/yearn/3/vault/snapshot/hook', function() {
     }
     await db.query(toUpsertSql('output', 'chain_id, address, label, component, series_time', outputData), Object.values(outputData))
 
-    const composition = await extractComposition(chainId, vault, [strategy], [debtFor(strategy)], label)
-    const estimated = composition[0].performance?.estimated
-    expect(estimated).to.not.equal(undefined)
-    expect(estimated).to.not.have.property('apr')
-    expect(estimated?.components).to.deep.equal({})
-    expect(() => EstimatedAprSchema.parse(estimated)).to.not.throw()
+    try {
+      const composition = await extractComposition(chainId, vault, [strategy], [debtFor(strategy)], label)
+      const estimated = composition[0].performance?.estimated
+      expect(estimated).to.not.equal(undefined)
+      expect(estimated).to.not.have.property('apr')
+      expect(estimated?.components).to.deep.equal({})
+      expect(() => EstimatedAprSchema.parse(estimated)).to.not.throw()
+    } finally {
+      globalThis.fetch = originalFetch
+    }
   })
 })

--- a/packages/ingest/abis/yearn/3/vault/snapshot/hook.spec.ts
+++ b/packages/ingest/abis/yearn/3/vault/snapshot/hook.spec.ts
@@ -122,6 +122,71 @@ describe('abis/yearn/3/vault/snapshot/hook', function() {
     }
   })
 
+  it('promotes gross and net estimated apr components in composition', async function() {
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = (async () => ({
+      json: async () => []
+    })) as unknown as typeof fetch
+
+    const chainId = 1337
+    const vault = '0x7000000000000000000000000000000000000007'
+    const strategy = '0x8000000000000000000000000000000000000008' as `0x${string}`
+    const latest = Math.floor(Date.now() / 1000)
+
+    const outputs = [
+      { component: 'netAPR', value: 0.03 },
+      { component: 'netAPY', value: 0.031 },
+      { component: 'grossAPR', value: 0.05 },
+      { component: 'grossAPY', value: 0.051 },
+      { component: 'compoundingPeriodsPerYear', value: 365 }
+    ]
+
+    for (const output of outputs) {
+      const outputData = {
+        chain_id: chainId,
+        address: strategy,
+        label: 'katana-estimated-apr',
+        component: output.component,
+        value: output.value,
+        block_number: latest,
+        block_time: latest,
+        series_time: latest
+      }
+      await db.query(toUpsertSql('output', 'chain_id, address, label, component, series_time', outputData), Object.values(outputData))
+    }
+
+    const debts = [{
+      strategy,
+      activation: 0n,
+      lastReport: 0n,
+      currentDebt: 1n,
+      currentDebtUsd: 1,
+      maxDebt: 1n,
+      maxDebtUsd: 1,
+      performanceFee: 0n,
+      totalGain: 0n,
+      totalGainUsd: 0,
+      totalLoss: 0n,
+      totalLossUsd: 0,
+      targetDebtRatio: undefined,
+      maxDebtRatio: undefined
+    }]
+
+    try {
+      const composition = await extractComposition(chainId, vault, [strategy], debts, 'katana-estimated-apr')
+
+      expect(composition).to.have.length(1)
+      const estimated = composition[0].performance?.estimated
+      expect(estimated?.apr).to.equal(0.03)
+      expect(estimated?.apy).to.equal(0.031)
+      expect(estimated?.grossAPR).to.equal(0.05)
+      expect(estimated?.grossAPY).to.equal(0.051)
+      expect(estimated?.components).to.deep.equal({ compoundingPeriodsPerYear: 365 })
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
   it('echoes snapshot pricePerShare to override stale hook keys', async function() {
     const originalFetch = globalThis.fetch
     globalThis.fetch = (async () => ({

--- a/packages/ingest/abis/yearn/3/vault/snapshot/hook.spec.ts
+++ b/packages/ingest/abis/yearn/3/vault/snapshot/hook.spec.ts
@@ -1,6 +1,15 @@
 import { expect } from 'chai'
-import process, { extractComposition } from './hook'
+import process, { extractComposition, resolveEstimatedApr } from './hook'
 import db, { toUpsertSql } from '../../../../../db'
+import { EstimatedAprSchema } from 'lib/types'
+
+function debtFor(strategy: `0x${string}`) {
+  return {
+    strategy, activation: 0n, lastReport: 0n, currentDebt: 1n, currentDebtUsd: 1, maxDebt: 1n, maxDebtUsd: 1,
+    performanceFee: 0n, totalGain: 0n, totalGainUsd: 0, totalLoss: 0n, totalLossUsd: 0,
+    targetDebtRatio: undefined, maxDebtRatio: undefined
+  }
+}
 
 describe('abis/yearn/3/vault/snapshot/hook', function() {
   it('uses one latest series_time for strategy performance components', async function() {
@@ -214,5 +223,54 @@ describe('abis/yearn/3/vault/snapshot/hook', function() {
     } finally {
       globalThis.fetch = originalFetch
     }
+  })
+
+  it('falls back to the unscoped label when the vault only has a strategy-scoped emission', async function() {
+    const chainId = 1337
+    const vault = '0x7000000000000000000000000000000000000007' as `0x${string}`
+    const strategy = '0x8000000000000000000000000000000000000008' as `0x${string}`
+    const now = Math.floor(Date.now() / 1000)
+    const label = 'katana-estimated-apr'
+
+    const rows = [
+      { address: vault, component: 'netAPR', value: 0.04 },
+      { address: vault, component: 'isStrategy', value: 1 },
+      { address: strategy, component: 'netAPR', value: 0.03 }
+    ]
+    for (const row of rows) {
+      const outputData = {
+        chain_id: chainId, address: row.address, label, component: row.component, value: row.value,
+        block_number: now, block_time: now, series_time: now
+      }
+      await db.query(toUpsertSql('output', 'chain_id, address, label, component, series_time', outputData), Object.values(outputData))
+    }
+
+    const resolved = await resolveEstimatedApr(chainId, vault)
+    expect(resolved.estimatedApr).to.equal(undefined)
+    expect(resolved.estimatedAprLabel).to.equal(label)
+
+    const composition = await extractComposition(chainId, vault, [strategy], [debtFor(strategy)], resolved.estimatedAprLabel)
+    expect(composition[0].performance?.estimated?.apr).to.equal(0.03)
+  })
+
+  it('drops null-valued estimated components instead of writing apr: null', async function() {
+    const chainId = 1337
+    const vault = '0x9000000000000000000000000000000000000009' as `0x${string}`
+    const strategy = '0xa00000000000000000000000000000000000000a' as `0x${string}`
+    const now = Math.floor(Date.now() / 1000)
+    const label = 'katana-estimated-apr'
+
+    const outputData = {
+      chain_id: chainId, address: strategy, label, component: 'netAPR', value: null,
+      block_number: now, block_time: now, series_time: now
+    }
+    await db.query(toUpsertSql('output', 'chain_id, address, label, component, series_time', outputData), Object.values(outputData))
+
+    const composition = await extractComposition(chainId, vault, [strategy], [debtFor(strategy)], label)
+    const estimated = composition[0].performance?.estimated
+    expect(estimated).to.not.equal(undefined)
+    expect(estimated).to.not.have.property('apr')
+    expect(estimated?.components).to.deep.equal({})
+    expect(() => EstimatedAprSchema.parse(estimated)).to.not.throw()
   })
 })

--- a/packages/ingest/abis/yearn/3/vault/snapshot/hook.ts
+++ b/packages/ingest/abis/yearn/3/vault/snapshot/hook.ts
@@ -6,7 +6,7 @@ import { EstimatedAprSchema, EvmAddressSchema, ThingSchema, TokenMetaSchema, Vau
 import { parseAbi, toEventSelector, zeroAddress } from 'viem'
 import { z } from 'zod'
 import db, { getSparkline } from '../../../../../db'
-import { getLatestApy, getLatestEstimatedAprV3, getLatestOracleApr, promoteEstimatedApr } from '../../../../../helpers/apy-apr'
+import { getLatestApy, getLatestEstimatedAprLabel, getLatestEstimatedAprV3, getLatestOracleApr, promoteEstimatedApr } from '../../../../../helpers/apy-apr'
 import { fetchErc20PriceUsd } from '../../../../../prices'
 import { rpcs } from '../../../../../rpcs'
 import * as things from '../../../../../things'
@@ -105,7 +105,11 @@ export default async function process(chainId: number, address: `0x${string}`, d
 
   const debts = await extractDebts(chainId, address, strategies, allocator)
   const estimatedApr = await getLatestEstimatedAprV3(chainId, address)
-  const composition = await extractComposition(chainId, address, strategies, debts, estimatedApr?.type)
+  // Composition needs the publisher label even when the vault's own emission is
+  // strategy-scoped (dual vault/strategy address, issue #409) and the scoped
+  // lookup returns nothing.
+  const estimatedAprLabel = estimatedApr?.type ?? await getLatestEstimatedAprLabel(chainId, address)
+  const composition = await extractComposition(chainId, address, strategies, debts, estimatedAprLabel)
   const fees = await extractFeesBps(chainId, address, snapshot)
   const locker = snapshot.accountant && snapshot.accountant !== zeroAddress
     && await things.exist(chainId, snapshot.accountant, 'vault')

--- a/packages/ingest/abis/yearn/3/vault/snapshot/hook.ts
+++ b/packages/ingest/abis/yearn/3/vault/snapshot/hook.ts
@@ -6,7 +6,7 @@ import { EstimatedAprSchema, EvmAddressSchema, ThingSchema, TokenMetaSchema, Vau
 import { parseAbi, toEventSelector, zeroAddress } from 'viem'
 import { z } from 'zod'
 import db, { getSparkline } from '../../../../../db'
-import { getLatestApy, getLatestEstimatedAprV3, getLatestOracleApr } from '../../../../../helpers/apy-apr'
+import { getLatestApy, getLatestEstimatedAprV3, getLatestOracleApr, promoteEstimatedApr } from '../../../../../helpers/apy-apr'
 import { fetchErc20PriceUsd } from '../../../../../prices'
 import { rpcs } from '../../../../../rpcs'
 import * as things from '../../../../../things'
@@ -440,6 +440,7 @@ async function fetchStrategyPerformance(
   `, [chainId, strategies, labels])
 
   const map = new Map<string, any>()
+  const estimatedComponents = new Map<string, Record<string, number>>()
 
   for (const row of result.rows) {
     const addr = row.address.toLowerCase()
@@ -455,11 +456,13 @@ async function fetchStrategyPerformance(
       if (row.component === 'monthlyNet') perf.historical.monthlyNet = row.value ?? null
       if (row.component === 'inceptionNet') perf.historical.inceptionNet = row.value ?? null
     } else if (estimatedAprLabel && row.label === estimatedAprLabel) {
-      if (!perf.estimated) perf.estimated = { type: estimatedAprLabel, components: {} }
-      if (row.component === 'netAPR') perf.estimated.apr = row.value
-      else if (row.component === 'netAPY') perf.estimated.apy = row.value
-      else perf.estimated.components[row.component] = row.value
+      if (!estimatedComponents.has(addr)) estimatedComponents.set(addr, {})
+      if (row.value != null && row.component != null) estimatedComponents.get(addr)![row.component] = row.value
     }
+  }
+
+  for (const [addr, components] of estimatedComponents) {
+    map.get(addr).estimated = promoteEstimatedApr(estimatedAprLabel!, components)
   }
 
   return map

--- a/packages/ingest/abis/yearn/3/vault/snapshot/hook.ts
+++ b/packages/ingest/abis/yearn/3/vault/snapshot/hook.ts
@@ -94,6 +94,15 @@ export const SnapshotSchema = z.object({
 
 type Snapshot = z.infer<typeof SnapshotSchema>
 
+// Composition needs the publisher label even when the vault's own emission is
+// strategy-scoped (dual vault/strategy address, issue #409) and the scoped
+// lookup returns nothing.
+export async function resolveEstimatedApr(chainId: number, address: `0x${string}`) {
+  const estimatedApr = await getLatestEstimatedAprV3(chainId, address)
+  const estimatedAprLabel = estimatedApr?.type ?? await getLatestEstimatedAprLabel(chainId, address)
+  return { estimatedApr, estimatedAprLabel }
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default async function process(chainId: number, address: `0x${string}`, data: any) {
   const snapshot = SnapshotSchema.parse(data)
@@ -104,11 +113,7 @@ export default async function process(chainId: number, address: `0x${string}`, d
   const allocator = await projectDebtAllocator(chainId, address)
 
   const debts = await extractDebts(chainId, address, strategies, allocator)
-  const estimatedApr = await getLatestEstimatedAprV3(chainId, address)
-  // Composition needs the publisher label even when the vault's own emission is
-  // strategy-scoped (dual vault/strategy address, issue #409) and the scoped
-  // lookup returns nothing.
-  const estimatedAprLabel = estimatedApr?.type ?? await getLatestEstimatedAprLabel(chainId, address)
+  const { estimatedApr, estimatedAprLabel } = await resolveEstimatedApr(chainId, address)
   const composition = await extractComposition(chainId, address, strategies, debts, estimatedAprLabel)
   const fees = await extractFeesBps(chainId, address, snapshot)
   const locker = snapshot.accountant && snapshot.accountant !== zeroAddress

--- a/packages/ingest/helpers/apy-apr.spec.ts
+++ b/packages/ingest/helpers/apy-apr.spec.ts
@@ -276,6 +276,23 @@ describe('getLatestEstimatedAprV3', function() {
     expect(result).to.be.undefined
   })
 
+  it('skips newer block_time with isStrategy, returns older vault-level rows', async function() {
+    const older = new Date(Date.now() - 60_000)
+    const newer = new Date()
+
+    await insertOutput(VAULT_ADDR, LABEL, 'netAPR', 0.04, older, 1)
+    await insertOutput(VAULT_ADDR, LABEL, 'netAPY', 0.041, older, 1)
+
+    await insertOutput(VAULT_ADDR, LABEL, 'netAPR', 0.08, newer, 2)
+    await insertOutput(VAULT_ADDR, LABEL, 'netAPY', 0.082, newer, 2)
+    await insertOutput(VAULT_ADDR, LABEL, 'isStrategy', 1, newer, 2)
+
+    const result = await getLatestEstimatedAprV3(TEST_CHAIN, VAULT_ADDR)
+    expect(result).to.not.be.undefined
+    expect(result!.apr).to.equal(0.04)
+    expect(result!.apy).to.equal(0.041)
+  })
+
   it('keeps an emission with isStrategy 0 even when debtRatio is present', async function() {
     const t = new Date()
     await insertOutput(VAULT_ADDR, LABEL, 'netAPR', 0.05, t)

--- a/packages/ingest/helpers/apy-apr.spec.ts
+++ b/packages/ingest/helpers/apy-apr.spec.ts
@@ -223,6 +223,83 @@ describe('getLatestEstimatedAprV3', function() {
     expect(result!.apy).to.equal(0.031)
     expect(result!.components).to.deep.equal({})
   })
+
+  it('promotes gross and net to top level', async function() {
+    const t = new Date()
+    await insertOutput(VAULT_ADDR, LABEL, 'netAPR', 0.05, t)
+    await insertOutput(VAULT_ADDR, LABEL, 'netAPY', 0.051, t)
+    await insertOutput(VAULT_ADDR, LABEL, 'grossAPR', 0.07, t)
+    await insertOutput(VAULT_ADDR, LABEL, 'grossAPY', 0.072, t)
+
+    const result = await getLatestEstimatedAprV3(TEST_CHAIN, VAULT_ADDR)
+    expect(result).to.deep.equal({
+      type: LABEL,
+      apr: 0.05,
+      apy: 0.051,
+      grossAPR: 0.07,
+      grossAPY: 0.072,
+      components: {}
+    })
+  })
+
+  it('leaves apr and apy undefined when only gross rows exist', async function() {
+    const t = new Date()
+    await insertOutput(VAULT_ADDR, LABEL, 'grossAPR', 0.07, t)
+    await insertOutput(VAULT_ADDR, LABEL, 'grossAPY', 0.072, t)
+
+    const result = await getLatestEstimatedAprV3(TEST_CHAIN, VAULT_ADDR)
+    expect(result).to.not.be.undefined
+    expect(result!.apr).to.be.undefined
+    expect(result!.apy).to.be.undefined
+    expect(result!.grossAPR).to.equal(0.07)
+    expect(result!.grossAPY).to.equal(0.072)
+  })
+
+  it('keeps unpromoted components alongside promoted ones', async function() {
+    const t = new Date()
+    await insertOutput(VAULT_ADDR, LABEL, 'netAPR', 0.05, t)
+    await insertOutput(VAULT_ADDR, LABEL, 'grossAPR', 0.07, t)
+    await insertOutput(VAULT_ADDR, LABEL, 'compoundingPeriodsPerYear', 365, t)
+
+    const result = await getLatestEstimatedAprV3(TEST_CHAIN, VAULT_ADDR)
+    expect(result).to.not.be.undefined
+    expect(result!.components).to.deep.equal({ compoundingPeriodsPerYear: 365 })
+  })
+
+  it('excludes an emission with a non-zero isStrategy marker and no debtRatio', async function() {
+    const t = new Date()
+    await insertOutput(VAULT_ADDR, LABEL, 'netAPR', 0.05, t)
+    await insertOutput(VAULT_ADDR, LABEL, 'netAPY', 0.051, t)
+    await insertOutput(VAULT_ADDR, LABEL, 'isStrategy', 1, t)
+
+    const result = await getLatestEstimatedAprV3(TEST_CHAIN, VAULT_ADDR)
+    expect(result).to.be.undefined
+  })
+
+  it('keeps an emission with isStrategy 0 even when debtRatio is present', async function() {
+    const t = new Date()
+    await insertOutput(VAULT_ADDR, LABEL, 'netAPR', 0.05, t)
+    await insertOutput(VAULT_ADDR, LABEL, 'netAPY', 0.051, t)
+    await insertOutput(VAULT_ADDR, LABEL, 'isStrategy', 0, t)
+    await insertOutput(VAULT_ADDR, LABEL, 'debtRatio', 5000, t)
+
+    const result = await getLatestEstimatedAprV3(TEST_CHAIN, VAULT_ADDR)
+    expect(result).to.not.be.undefined
+    expect(result!.apr).to.equal(0.05)
+    expect(result!.components).to.deep.equal({ isStrategy: 0, debtRatio: 5000 })
+  })
+
+  it('explicit label path ignores the isStrategy marker and keeps it in components', async function() {
+    const t = new Date()
+    await insertOutput(VAULT_ADDR, LABEL, 'netAPR', 0.05, t)
+    await insertOutput(VAULT_ADDR, LABEL, 'netAPY', 0.051, t)
+    await insertOutput(VAULT_ADDR, LABEL, 'isStrategy', 1, t)
+
+    const result = await getLatestEstimatedAprV3(TEST_CHAIN, VAULT_ADDR, LABEL)
+    expect(result).to.not.be.undefined
+    expect(result!.apr).to.equal(0.05)
+    expect(result!.components).to.deep.equal({ isStrategy: 1 })
+  })
 })
 
 describe('getLatestApy', function() {

--- a/packages/ingest/helpers/apy-apr.spec.ts
+++ b/packages/ingest/helpers/apy-apr.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai'
 import db from '../db'
-import { getLatestApy, getLatestEstimatedAprV3 } from './apy-apr'
+import { getLatestApy, getLatestEstimatedAprLabel, getLatestEstimatedAprV3 } from './apy-apr'
 
 const TEST_CHAIN = 99999
 const VAULT_ADDR = '0xtest_vault_apr_spec'
@@ -299,6 +299,33 @@ describe('getLatestEstimatedAprV3', function() {
     expect(result).to.not.be.undefined
     expect(result!.apr).to.equal(0.05)
     expect(result!.components).to.deep.equal({ isStrategy: 1 })
+  })
+})
+
+describe('getLatestEstimatedAprLabel', function() {
+  afterEach(cleanup)
+
+  it('returns undefined when no -estimated-apr rows exist', async function() {
+    const result = await getLatestEstimatedAprLabel(TEST_CHAIN, VAULT_ADDR)
+    expect(result).to.be.undefined
+  })
+
+  it('returns the label of the latest emission even when strategy-scoped by isStrategy marker', async function() {
+    const t = new Date()
+    await insertOutput(VAULT_ADDR, LABEL, 'netAPR', 0.08, t)
+    await insertOutput(VAULT_ADDR, LABEL, 'isStrategy', 1, t)
+
+    const result = await getLatestEstimatedAprLabel(TEST_CHAIN, VAULT_ADDR)
+    expect(result).to.equal(LABEL)
+  })
+
+  it('returns the label of the latest emission even when strategy-scoped by debtRatio', async function() {
+    const t = new Date()
+    await insertOutput(VAULT_ADDR, LABEL, 'netAPR', 0.08, t)
+    await insertOutput(VAULT_ADDR, LABEL, 'debtRatio', 5000, t)
+
+    const result = await getLatestEstimatedAprLabel(TEST_CHAIN, VAULT_ADDR)
+    expect(result).to.equal(LABEL)
   })
 })
 

--- a/packages/ingest/helpers/apy-apr.spec.ts
+++ b/packages/ingest/helpers/apy-apr.spec.ts
@@ -6,7 +6,7 @@ const TEST_CHAIN = 99999
 const VAULT_ADDR = '0xtest_vault_apr_spec'
 const LABEL = 'yvusd-estimated-apr'
 
-async function insertOutput(address: string, label: string, component: string, value: number, blockTime: Date, blockNumber = 1) {
+async function insertOutput(address: string, label: string, component: string, value: number | null, blockTime: Date, blockNumber = 1) {
   await db.query(
     `INSERT INTO output (chain_id, address, label, component, value, block_number, block_time, series_time)
      VALUES ($1, $2, $3, $4, $5, $6, $7, $7)`,
@@ -287,6 +287,16 @@ describe('getLatestEstimatedAprV3', function() {
     expect(result).to.not.be.undefined
     expect(result!.apr).to.equal(0.05)
     expect(result!.components).to.deep.equal({ isStrategy: 0, debtRatio: 5000 })
+  })
+
+  it('treats a null isStrategy marker as absent so debtRatio still excludes the emission', async function() {
+    const t = new Date()
+    await insertOutput(VAULT_ADDR, LABEL, 'netAPR', 0.05, t)
+    await insertOutput(VAULT_ADDR, LABEL, 'isStrategy', null, t)
+    await insertOutput(VAULT_ADDR, LABEL, 'debtRatio', 5000, t)
+
+    const result = await getLatestEstimatedAprV3(TEST_CHAIN, VAULT_ADDR)
+    expect(result).to.be.undefined
   })
 
   it('explicit label path ignores the isStrategy marker and keeps it in components', async function() {

--- a/packages/ingest/helpers/apy-apr.spec.ts
+++ b/packages/ingest/helpers/apy-apr.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai'
 import db from '../db'
-import { getLatestApy, getLatestEstimatedAprLabel, getLatestEstimatedAprV3 } from './apy-apr'
+import { getLatestApy, getLatestEstimatedAprLabel, getLatestEstimatedAprV3, promoteEstimatedApr } from './apy-apr'
 
 const TEST_CHAIN = 99999
 const VAULT_ADDR = '0xtest_vault_apr_spec'
@@ -299,6 +299,28 @@ describe('getLatestEstimatedAprV3', function() {
     expect(result).to.be.undefined
   })
 
+  it('treats a null isStrategy marker as absent so a net-only emission stays vault-scoped', async function() {
+    const t = new Date()
+    await insertOutput(VAULT_ADDR, LABEL, 'netAPR', 0.05, t)
+    await insertOutput(VAULT_ADDR, LABEL, 'isStrategy', null, t)
+
+    const result = await getLatestEstimatedAprV3(TEST_CHAIN, VAULT_ADDR)
+    expect(result).to.not.be.undefined
+    expect(result!.apr).to.equal(0.05)
+    expect(result!.components).to.deep.equal({})
+  })
+
+  it('omits null-valued components on the vault path', async function() {
+    const t = new Date()
+    await insertOutput(VAULT_ADDR, LABEL, 'netAPR', null, t)
+    await insertOutput(VAULT_ADDR, LABEL, 'grossAPR', 0.07, t)
+
+    const result = await getLatestEstimatedAprV3(TEST_CHAIN, VAULT_ADDR)
+    expect(result).to.not.be.undefined
+    expect(result).to.not.have.property('apr')
+    expect(result!.grossAPR).to.equal(0.07)
+  })
+
   it('explicit label path ignores the isStrategy marker and keeps it in components', async function() {
     const t = new Date()
     await insertOutput(VAULT_ADDR, LABEL, 'netAPR', 0.05, t)
@@ -309,6 +331,26 @@ describe('getLatestEstimatedAprV3', function() {
     expect(result).to.not.be.undefined
     expect(result!.apr).to.equal(0.05)
     expect(result!.components).to.deep.equal({ isStrategy: 1 })
+  })
+})
+
+describe('promoteEstimatedApr', function() {
+  it('keeps zero net and gross values instead of omitting them', function() {
+    expect(promoteEstimatedApr('x', { netAPR: 0, netAPY: 0, grossAPR: 0, grossAPY: 0 })).to.deep.equal({
+      type: 'x',
+      apr: 0,
+      apy: 0,
+      grossAPR: 0,
+      grossAPY: 0,
+      components: {}
+    })
+  })
+
+  it('omits absent promoted keys and leaves the rest in components', function() {
+    expect(promoteEstimatedApr('x', { katRewardsAPR: 0.01 })).to.deep.equal({
+      type: 'x',
+      components: { katRewardsAPR: 0.01 }
+    })
   })
 })
 

--- a/packages/ingest/helpers/apy-apr.ts
+++ b/packages/ingest/helpers/apy-apr.ts
@@ -34,6 +34,20 @@ export async function getLatestEstimatedAprV3(chainId: number, address: string, 
   return promoteEstimatedApr(rows[0].label, components)
 }
 
+export async function getLatestEstimatedAprLabel(chainId: number, address: string): Promise<string | undefined> {
+  const result = await firstRow(`
+  SELECT label FROM output
+  WHERE chain_id = $1
+    AND address = $2
+    AND label LIKE '%-estimated-apr'
+    AND series_time > NOW() - make_interval(days => $3::int)
+    AND block_time > NOW() - make_interval(days => $3::int)
+  ORDER BY block_time DESC
+  LIMIT 1
+  `, [chainId, address, CURRENT_PERFORMANCE_LOOKBACK_DAYS])
+  return result?.label
+}
+
 export async function getLatestEstimatedApr(chainId: number, address: string) {
   const result = await firstRow(`
   SELECT

--- a/packages/ingest/helpers/apy-apr.ts
+++ b/packages/ingest/helpers/apy-apr.ts
@@ -6,6 +6,18 @@ import { parsePositiveIntDays } from './env'
 
 const CURRENT_PERFORMANCE_LOOKBACK_DAYS = parsePositiveIntDays('CURRENT_PERFORMANCE_LOOKBACK_DAYS', 7)
 
+export function promoteEstimatedApr(type: string, components: Record<string, number>) {
+  const { netAPR, netAPY, grossAPR, grossAPY, ...rest } = components
+  return {
+    type,
+    ...(netAPR != null ? { apr: netAPR } : {}),
+    ...(netAPY != null ? { apy: netAPY } : {}),
+    ...(grossAPR != null ? { grossAPR } : {}),
+    ...(grossAPY != null ? { grossAPY } : {}),
+    components: rest
+  }
+}
+
 export async function getLatestEstimatedAprV3(chainId: number, address: string, label?: string) {
   const rows = await getLatestEstimatedAprRows(db, chainId, address, {
     label,
@@ -19,14 +31,7 @@ export async function getLatestEstimatedAprV3(chainId: number, address: string, 
     if (row.value != null && row.component != null) components[row.component] = row.value
   }
 
-  const { netAPR, netAPY, ...rest } = components
-
-  return {
-    type: rows[0].label,
-    ...(netAPR != null ? { apr: netAPR } : {}),
-    ...(netAPY != null ? { apy: netAPY } : {}),
-    components: rest
-  }
+  return promoteEstimatedApr(rows[0].label, components)
 }
 
 export async function getLatestEstimatedApr(chainId: number, address: string) {

--- a/packages/ingest/katana-estimated-apr.containers.spec.ts
+++ b/packages/ingest/katana-estimated-apr.containers.spec.ts
@@ -79,7 +79,7 @@ async function seedOutput(pool: Pool, address: string, components: Record<string
   }
 }
 
-type Estimated = { type?: string, apr?: number, apy?: number, components?: Record<string, number> }
+type Estimated = { type?: string, apr?: number, apy?: number, grossAPR?: number, grossAPY?: number, components?: Record<string, number> }
 
 async function fetchRestSnapshot(webUrl: string, address: string) {
   const res = await fetch(`${webUrl}/api/rest/snapshot/${CHAIN_ID}/${address.toLowerCase()}`)
@@ -143,6 +143,8 @@ describe('e2e: katana strategy rewards APR surfaces in parent composition (PR #4
     await seedOutput(pool, STRATEGY_VAULT, {
       netAPR: 0.05,
       netAPY: 0.051,
+      grossAPR: 0.07,
+      grossAPY: 0.072,
       katRewardsAPR: 0.012,
     })
     await seedOutput(pool, PARENT_VAULT, { netAPR: 0.04, netAPY: 0.041 })
@@ -184,6 +186,17 @@ describe('e2e: katana strategy rewards APR surfaces in parent composition (PR #4
     expect(entry, 'strategy missing from parent composition').to.not.be.undefined
     expect(entry!.performance?.estimated?.type).to.equal(LABEL)
     expect(entry!.performance?.estimated?.components?.katRewardsAPR).to.be.a('number')
+  })
+
+  it('parent composition promotes the strategy gross APR and APY', async function() {
+    const snapshot = await fetchRestSnapshot(webUrl, PARENT_VAULT)
+    const strategy = snapshot.composition?.find(c => c.address.toLowerCase() === STRATEGY_VAULT.toLowerCase())
+    expect(strategy!.performance?.estimated?.grossAPR).to.equal(0.07)
+    expect(strategy!.performance?.estimated?.grossAPY).to.equal(0.072)
+
+    const sibling = snapshot.composition?.find(c => c.address.toLowerCase() === SIBLING_STRATEGY.toLowerCase())
+    expect(sibling!.performance?.estimated?.grossAPR).to.be.undefined
+    expect(sibling!.performance?.estimated?.grossAPY).to.be.undefined
   })
 
   it('parent keeps its own top-level katana estimate', async function() {

--- a/packages/ingest/yvusd-estimated-apr.containers.spec.ts
+++ b/packages/ingest/yvusd-estimated-apr.containers.spec.ts
@@ -71,7 +71,7 @@ async function seedOutput(pool: Pool, address: string, components: Record<string
   }
 }
 
-type Estimated = { type?: string, apr?: number, apy?: number, components?: Record<string, number> }
+type Estimated = { type?: string, apr?: number, apy?: number, grossAPR?: number, grossAPY?: number, components?: Record<string, number> }
 
 async function fetchRestSnapshot(webUrl: string, address: string) {
   const res = await fetch(`${webUrl}/api/rest/snapshot/${CHAIN_ID}/${address.toLowerCase()}`)
@@ -96,7 +96,7 @@ async function fetchGqlEstimated(webUrl: string, address: string): Promise<Estim
     body: JSON.stringify({
       query: `query($chainId: Int!, $address: String!) {
         vault(chainId: $chainId, address: $address) {
-          performance { estimated { type apr apy } }
+          performance { estimated { type apr apy grossAPR grossAPY } }
         }
       }`,
       variables: { chainId: CHAIN_ID, address },
@@ -198,7 +198,7 @@ describe('e2e: yvusd-estimated-apr scoping (issue #409)', () => {
 
     // Seed the yvUSD APR service emissions BEFORE the snapshot hooks run, so the
     // first snapshot computation reads them. USDC-2 gets nothing — it must stay clean.
-    await seedOutput(pool, YVUSD_VAULT, { netAPR: 0.05, netAPY: 0.051 })
+    await seedOutput(pool, YVUSD_VAULT, { netAPR: 0.05, netAPY: 0.051, grossAPR: 0.06, grossAPY: 0.062 })
     await seedOutput(pool, STRATEGY_VAULT, { netAPR: 0.08, netAPY: 0.082, debtRatio: 5000 })
 
     // Drive fanout until composition is fully assembled (see compositionAssembledSql).
@@ -257,9 +257,15 @@ describe('e2e: yvusd-estimated-apr scoping (issue #409)', () => {
     expect(performance?.estimated?.type).to.equal(LABEL)
     expect(performance?.estimated?.apr).to.equal(0.05)
     expect(performance?.estimated?.apy).to.equal(0.051)
+    expect(performance?.estimated?.grossAPR).to.equal(0.06)
+    expect(performance?.estimated?.grossAPY).to.equal(0.062)
+    expect(performance?.estimated?.components?.grossAPR).to.equal(undefined)
+    expect(performance?.estimated?.components?.grossAPY).to.equal(undefined)
     expect(gql?.type).to.equal(performance?.estimated?.type)
     expect(gql?.apr).to.equal(performance?.estimated?.apr)
     expect(gql?.apy).to.equal(performance?.estimated?.apy)
+    expect(gql?.grossAPR).to.equal(performance?.estimated?.grossAPR)
+    expect(gql?.grossAPY).to.equal(performance?.estimated?.grossAPY)
   })
 })
 

--- a/packages/lib/estimated-apr.ts
+++ b/packages/lib/estimated-apr.ts
@@ -75,13 +75,16 @@ const LATEST_ROWS_BY_ESTIMATED_APR_SQL = latestEstimatedAprRowsSql(`
         AND o.label LIKE '%-estimated-apr'
         AND ($3::int IS NULL OR o.block_time > NOW() - ($3::int * INTERVAL '1 day'))
         AND ($3::int IS NULL OR o.series_time > NOW() - ($3::int * INTERVAL '1 day'))
-        AND NOT EXISTS (
-          SELECT 1 FROM output o2
-          WHERE o2.chain_id = o.chain_id
-            AND o2.address = o.address
-            AND o2.label = o.label
-            AND o2.block_time = o.block_time
-            AND o2.component = 'debtRatio'
+        -- Scope resolution: an emission is strategy-scoped when the publisher
+        -- emits a non-zero isStrategy marker. When no marker is present the
+        -- legacy debtRatio heuristic decides, so emissions that predate the
+        -- marker keep their current scope.
+        AND NOT COALESCE((
+          SELECT bool_or(o2.component = 'isStrategy' AND COALESCE(o2.value, 0) <> 0)
+              OR (NOT bool_or(o2.component = 'isStrategy') AND bool_or(o2.component = 'debtRatio'))
+          FROM output o2
+          WHERE o2.chain_id = o.chain_id AND o2.address = o.address
+            AND o2.label = o.label AND o2.block_time = o.block_time
             AND ($3::int IS NULL OR o2.series_time > NOW() - ($3::int * INTERVAL '1 day'))
-        )
+        ), false)
 `, '$4', '$3')

--- a/packages/lib/estimated-apr.ts
+++ b/packages/lib/estimated-apr.ts
@@ -69,22 +69,43 @@ const LATEST_ROWS_BY_LABEL_SQL = latestEstimatedAprRowsSql(`
         AND ($4::int IS NULL OR o.series_time > NOW() - ($4::int * INTERVAL '1 day'))
 `, '$5', '$4')
 
-const LATEST_ROWS_BY_ESTIMATED_APR_SQL = latestEstimatedAprRowsSql(`
-        o.chain_id = $1
+// Scope is decided per emission (same chain/address/label/block_time), then the
+// latest vault-scoped emission is kept. A correlated bool_or SubPlan cannot be
+// an anti-join: on prod (Timescale 2.13, 141 chunks) it BitmapAnds
+// output_series_time_idx (~360k rows/chunk) while still excluding 139/141
+// chunks. Uncorrelated GROUP BY keeps the series_time index seek.
+const LATEST_ROWS_BY_ESTIMATED_APR_SQL = `
+    WITH candidates AS (
+      SELECT o.block_time, o.label, o.component, o.value
+      FROM output o
+      WHERE o.chain_id = $1
         AND o.address = $2
         AND o.label LIKE '%-estimated-apr'
         AND ($3::int IS NULL OR o.block_time > NOW() - ($3::int * INTERVAL '1 day'))
         AND ($3::int IS NULL OR o.series_time > NOW() - ($3::int * INTERVAL '1 day'))
-        -- Scope resolution: an emission is strategy-scoped when the publisher
-        -- emits a non-zero isStrategy marker. When no marker (or a null one) is present the
-        -- legacy debtRatio heuristic decides, so emissions that predate the
-        -- marker keep their current scope.
-        AND NOT COALESCE((
-          SELECT bool_or(o2.component = 'isStrategy' AND COALESCE(o2.value, 0) <> 0)
-              OR (NOT bool_or(o2.component = 'isStrategy' AND o2.value IS NOT NULL) AND bool_or(o2.component = 'debtRatio'))
-          FROM output o2
-          WHERE o2.chain_id = o.chain_id AND o2.address = o.address
-            AND o2.label = o.label AND o2.block_time = o.block_time
-            AND ($3::int IS NULL OR o2.series_time > NOW() - ($3::int * INTERVAL '1 day'))
-        ), false)
-`, '$4', '$3')
+    ),
+    latest AS (
+      SELECT block_time, label
+      FROM candidates
+      GROUP BY block_time, label
+      HAVING NOT (
+        bool_or(component = 'isStrategy' AND COALESCE(value, 0) <> 0)
+        OR (
+          NOT bool_or(component = 'isStrategy' AND value IS NOT NULL)
+          AND bool_or(component = 'debtRatio')
+        )
+      )
+      ORDER BY block_time DESC
+      LIMIT 1
+    )
+    SELECT
+      label,
+      address,
+      component,
+      value::float8 AS value
+    FROM output
+    WHERE chain_id = $1
+      AND (block_time, label) = (SELECT block_time, label FROM latest)
+      AND ($3::int IS NULL OR series_time > NOW() - ($3::int * INTERVAL '1 day'))
+      AND (address = $2 OR address = ANY($4::text[]))
+`

--- a/packages/lib/estimated-apr.ts
+++ b/packages/lib/estimated-apr.ts
@@ -76,12 +76,12 @@ const LATEST_ROWS_BY_ESTIMATED_APR_SQL = latestEstimatedAprRowsSql(`
         AND ($3::int IS NULL OR o.block_time > NOW() - ($3::int * INTERVAL '1 day'))
         AND ($3::int IS NULL OR o.series_time > NOW() - ($3::int * INTERVAL '1 day'))
         -- Scope resolution: an emission is strategy-scoped when the publisher
-        -- emits a non-zero isStrategy marker. When no marker is present the
+        -- emits a non-zero isStrategy marker. When no marker (or a null one) is present the
         -- legacy debtRatio heuristic decides, so emissions that predate the
         -- marker keep their current scope.
         AND NOT COALESCE((
           SELECT bool_or(o2.component = 'isStrategy' AND COALESCE(o2.value, 0) <> 0)
-              OR (NOT bool_or(o2.component = 'isStrategy') AND bool_or(o2.component = 'debtRatio'))
+              OR (NOT bool_or(o2.component = 'isStrategy' AND o2.value IS NOT NULL) AND bool_or(o2.component = 'debtRatio'))
           FROM output o2
           WHERE o2.chain_id = o.chain_id AND o2.address = o.address
             AND o2.label = o.label AND o2.block_time = o.block_time

--- a/packages/lib/types.ts
+++ b/packages/lib/types.ts
@@ -444,6 +444,8 @@ export type Incept = z.infer<typeof InceptSchema>
 export const EstimatedAprSchema = z.object({
   apr: z.number().optional(),
   apy: z.number().optional(),
+  grossAPR: z.number().optional(),
+  grossAPY: z.number().optional(),
   type: z.string(),
   components: z.record(z.string(), z.number().nullish())
 })

--- a/packages/scripts/src/quality-assurance/compare-rest-prod-fork.ts
+++ b/packages/scripts/src/quality-assurance/compare-rest-prod-fork.ts
@@ -98,7 +98,7 @@ type ListItem = {
   performance?: {
     oracle?: Record<string, number | null | undefined>
     historical?: Record<string, number | null | undefined>
-    estimated?: { apr?: number; apy?: number; type?: string; components?: Record<string, unknown> }
+    estimated?: { apr?: number; apy?: number; grossAPR?: number; grossAPY?: number; type?: string; components?: Record<string, unknown> }
   } | null
   asset?: { address?: string; symbol?: string; decimals?: number | null } | null
 }
@@ -427,6 +427,16 @@ async function compareVault(
         `list.performance.historical.${key}`,
         toNumber(prodListItem?.performance?.historical?.[key]),
         toNumber(forkListItem?.performance?.historical?.[key]),
+        PRICE_THRESHOLD,
+      ),
+    )
+  }
+  for (const key of ['apr', 'apy', 'grossAPR', 'grossAPY'] as const) {
+    report.list.push(
+      makeDiff(
+        `list.performance.estimated.${key}`,
+        toNumber(prodListItem?.performance?.estimated?.[key]),
+        toNumber(forkListItem?.performance?.estimated?.[key]),
         PRICE_THRESHOLD,
       ),
     )

--- a/packages/web/app/api/gql/typeDefs/vault.spec.ts
+++ b/packages/web/app/api/gql/typeDefs/vault.spec.ts
@@ -1,0 +1,26 @@
+import { strict as assert } from 'node:assert'
+import { describe, it } from 'vitest'
+import { Kind, ObjectTypeDefinitionNode } from 'graphql'
+import vault from './vault'
+
+function fields(name: string) {
+  const def = vault.definitions.find(
+    (d): d is ObjectTypeDefinitionNode => d.kind === Kind.OBJECT_TYPE_DEFINITION && d.name.value === name
+  )
+  assert.ok(def, `missing type ${name}`)
+  return Object.fromEntries(def.fields!.map(f => [f.name.value, f]))
+}
+
+describe('vault typeDefs', () => {
+  it('exposes gross on EstimatedApr and the scope markers on components', () => {
+    const estimated = fields('EstimatedApr')
+    for (const key of ['apr', 'apy', 'grossAPR', 'grossAPY']) assert.ok(estimated[key], key)
+
+    const components = fields('EstimatedAprComponents')
+    for (const key of ['isStrategy', 'debtRatio', 'katRewardsAPR', 'compoundingPeriodsPerYear']) {
+      assert.ok(components[key], key)
+    }
+    const deprecated = components.grossAPR.directives?.find(d => d.name.value === 'deprecated')
+    assert.ok(deprecated, 'components.grossAPR should be @deprecated')
+  })
+})

--- a/packages/web/app/api/gql/typeDefs/vault.ts
+++ b/packages/web/app/api/gql/typeDefs/vault.ts
@@ -118,16 +118,19 @@ type EstimatedAprComponents {
   cvxAPR: Float
   keepCRV: Float
   keepVelo: Float
-  grossAPR: Float
+  grossAPR: Float @deprecated(reason: "Promoted to EstimatedApr.grossAPR")
   baseNetAPR: Float
   baseNetAPY: Float
   lockerBonusAPR: Float
   lockerBonusAPY: Float
+  compoundingPeriodsPerYear: Float
 }
 
 type EstimatedApr {
   apr: Float
   apy: Float
+  grossAPR: Float
+  grossAPY: Float
   type: String!
   components: EstimatedAprComponents!
 }

--- a/packages/web/app/api/gql/typeDefs/vault.ts
+++ b/packages/web/app/api/gql/typeDefs/vault.ts
@@ -124,6 +124,9 @@ type EstimatedAprComponents {
   lockerBonusAPR: Float
   lockerBonusAPY: Float
   compoundingPeriodsPerYear: Float
+  katRewardsAPR: Float
+  debtRatio: Float
+  isStrategy: Float
 }
 
 type EstimatedApr {

--- a/packages/web/app/api/rest/list/db.spec.ts
+++ b/packages/web/app/api/rest/list/db.spec.ts
@@ -125,4 +125,57 @@ describe('getVaultsWithSnapshots', () => {
     assert.equal(result.listItem?.performance?.estimated?.grossAPR, 0.07)
     assert.equal(result.listItem?.performance?.estimated?.grossAPY, 0.072)
   })
+
+  it('parses estimated performance when gross APR and APY are absent', async () => {
+    query.mockResolvedValueOnce({
+      rows: [{
+        chainId: 1,
+        address: '0x3333333333333333333333333333333333333333',
+        name: 'test vault',
+        symbol: null,
+        apiVersion: null,
+        decimals: null,
+        asset: null,
+        tvl: null,
+        performance: {
+          estimated: {
+            apr: 0.05,
+            apy: 0.051,
+            type: 'katana-estimated-apr',
+            components: { katRewardsAPR: 0.012 }
+          }
+        },
+        fees: null,
+        category: null,
+        type: null,
+        kind: null,
+        v3: false,
+        isRetired: false,
+        isHidden: false,
+        isBoosted: false,
+        isHighlighted: false,
+        inclusion: {},
+        strategiesCount: 0,
+        riskLevel: null,
+        migration: false,
+        origin: null,
+        inceptBlock: null,
+        inceptTime: null,
+        staking: null,
+        pricePerShare: null,
+        _defaults: null,
+        _snapshot: null,
+        _hook: null,
+        _hasSnapshot: false
+      }]
+    })
+
+    const { getVaultsWithSnapshots } = await import('./db')
+    const [result] = await getVaultsWithSnapshots()
+
+    assert.equal(result.listError, null)
+    assert.equal(result.listItem?.performance?.estimated?.apr, 0.05)
+    assert.equal(result.listItem?.performance?.estimated?.grossAPR, undefined)
+    assert.equal(result.listItem?.performance?.estimated?.grossAPY, undefined)
+  })
 })

--- a/packages/web/app/api/rest/list/db.spec.ts
+++ b/packages/web/app/api/rest/list/db.spec.ts
@@ -71,4 +71,58 @@ describe('getVaultsWithSnapshots', () => {
     assert.equal(result.listError, null)
     assert.equal(result.listItem?.name, address)
   })
+
+  it('keeps promoted gross APR and APY on the estimated performance block', async () => {
+    query.mockResolvedValueOnce({
+      rows: [{
+        chainId: 1,
+        address: '0x2222222222222222222222222222222222222222',
+        name: 'test vault',
+        symbol: null,
+        apiVersion: null,
+        decimals: null,
+        asset: null,
+        tvl: null,
+        performance: {
+          estimated: {
+            apr: 0.05,
+            apy: 0.051,
+            grossAPR: 0.07,
+            grossAPY: 0.072,
+            type: 'katana-estimated-apr',
+            components: { katRewardsAPR: 0.012 }
+          }
+        },
+        fees: null,
+        category: null,
+        type: null,
+        kind: null,
+        v3: false,
+        isRetired: false,
+        isHidden: false,
+        isBoosted: false,
+        isHighlighted: false,
+        inclusion: {},
+        strategiesCount: 0,
+        riskLevel: null,
+        migration: false,
+        origin: null,
+        inceptBlock: null,
+        inceptTime: null,
+        staking: null,
+        pricePerShare: null,
+        _defaults: null,
+        _snapshot: null,
+        _hook: null,
+        _hasSnapshot: false
+      }]
+    })
+
+    const { getVaultsWithSnapshots } = await import('./db')
+    const [result] = await getVaultsWithSnapshots()
+
+    assert.equal(result.listError, null)
+    assert.equal(result.listItem?.performance?.estimated?.grossAPR, 0.07)
+    assert.equal(result.listItem?.performance?.estimated?.grossAPY, 0.072)
+  })
 })

--- a/packages/web/app/api/rest/list/db.ts
+++ b/packages/web/app/api/rest/list/db.ts
@@ -45,6 +45,8 @@ export const VaultListItemSchema = z.object({
     estimated: z.object({
       apr: z.number().optional(),
       apy: z.number().optional(),
+      grossAPR: z.number().optional(),
+      grossAPY: z.number().optional(),
       type: z.string(),
       components: z.record(z.string(), z.union([z.number(), z.string()]).nullable()).optional(),
     }).nullish(),


### PR DESCRIPTION
### Summary
Estimated-APR publishers compute gross, net it, and publish only `netAPR`/`netAPY`; Kong had
nowhere to put gross. This adds optional `grossAPR`/`grossAPY` to `performance.estimated`
(schema, promotion, REST list, GraphQL) and replaces the `debtRatio` vault-vs-strategy
sentinel with a publisher-emitted `isStrategy` marker, keeping `debtRatio` as the legacy
fallback. Additive only: `apr`/`apy` still come from `netAPR`/`netAPY`, never gross, and no
publisher changes are required. `apr`/`apy` values stay identical; the observable output changes are
listed under Risk / impact.

### How to review
- Start at `packages/ingest/helpers/apy-apr.ts`: `promoteEstimatedApr` is the single
  promotion list, now shared by the vault path and `fetchStrategyPerformance`
  (`packages/ingest/abis/yearn/3/vault/snapshot/hook.ts`), which previously hand-rolled its
  own copy.
- Then `packages/lib/estimated-apr.ts`: the scope-resolution subquery. No publisher emits
  `isStrategy` yet, so it reduces to the old `debtRatio` filter today.
- Read-side gates: `packages/lib/types.ts`, `packages/web/app/api/rest/list/db.ts`,
  `packages/web/app/api/gql/typeDefs/vault.ts`. Zod default-strip means a missed gate drops
  gross silently; these three are the only whitelists. REST snapshot serves the untyped
  merged blob and needs no change.
- Contract + legacy component tables: `docs/estimated-apr.md` (new).
- Side effect worth checking: strategy rows with a null `netAPR` no longer write
  `apr: null`, which failed `EstimatedAprSchema` and froze composition (same class as #443).
- Observable change for one publisher: yvUSD's `grossAPR` moves from `components` to the
  top level. The GraphQL `components.grossAPR` field stays declared but `@deprecated`.

### Test plan
- [x] Automated: `bun --filter web test` (29/29), touched ingest specs
  `apy-apr.spec.ts` + `hook.spec.ts` (27/27) — counts from before the review-loop specs.
  Full ingest/lib suites have pre-existing failures from missing RPC `.env`, untouched by this diff.
- [x] Added: `hook.spec.ts` covers the composition label fallback, the null-value guard,
  and vault-scoped label winning over a newer unscoped emission;
  `apy-apr.spec.ts` covers `promoteEstimatedApr` zeros, null `isStrategy` without `debtRatio`,
  isStrategy walk-back to an older vault-scoped emission, and null `netAPR` on the vault path;
  `packages/web/app/api/gql/typeDefs/vault.spec.ts` asserts the new GQL fields;
  REST list spec asserts gross is kept when present and optional when absent.
  Review-loop specs were checked by reading, not executed.
- [x] Not run: `katana-estimated-apr.containers.spec.ts` and `yvusd-estimated-apr.containers.spec.ts`
  (both need live RPC env); katana
  edited to seed gross on STRATEGY only, SIBLING stays net-only as the #443 freeze guard.
- [x] Manual: diff one yvUSD, one katana, one crv vault snapshot before/after —
  `apr`/`apy` identical, gross absent until publishers emit it.

### Risk / impact
- Hot-path SQL change in `LATEST_ROWS_BY_ESTIMATED_APR_SQL`. Prod-shaped Neon
  (`output` Timescale 2.13, 141 chunks, 2 in the 7d window): chunk exclusion holds
  139/141 for old EXISTS, correlated `bool_or`, and grouped HAVING. The correlated
  `bool_or` SubPlan was the regression — planner cost ~257k vs ~2.5k, BitmapAnd of
  `output_series_time_idx` (~360k rows/chunk), yvUSD 628ms vs old 86ms. Split-EXISTS
  also stayed a Filter SubPlan. Uncorrelated `GROUP BY`/`HAVING` restores the
  series_time index seek (yvUSD 2.5ms, dual-role 2.4ms, crv 5.4ms) and matches old
  row sets. `getLatestEstimatedAprLabel` is already that index seek (1.3ms).
- Frozen snapshots caused by null-`netAPR` strategy rows start composing again. More generally any
  null-valued estimated component is now omitted from `components` instead of written as `null`.
- Dual vault/strategy addresses (#409) whose only emission is strategy-scoped now resolve a composition
  label via `getLatestEstimatedAprLabel`, so their composition strategies gain `performance.estimated`
  blocks they did not have before. Output change for existing data, not gated on publishers.
- `getLatestEstimatedAprLabel` adds one indexed round-trip (`idx_output_chain_address_label_series_time`
  prefix on chain_id/address) to the v3 snapshot hook for every vault with no vault-scoped estimate.
- yvUSD: GraphQL `components.grossAPR` now resolves null (value promoted to `estimated.grossAPR`).
  Audited yearn.fi, yearn-powerglove, ydaemon via GitHub code search: none read
  `estimated.components.grossAPR` (powerglove's `grossApr` comes from `oracle.apr` / timeseries points).
  yearn.fi `estimatedAprSchema` does not whitelist `estimated.grossAPR`/`grossAPY`; Zod default-strip
  drops them until they add the fields. They keep reading `apr`/`apy` and REST `components.katRewardsAPR`.
- GraphQL `EstimatedAprComponents` now resolves `compoundingPeriodsPerYear`, `katRewardsAPR`,
  `debtRatio`, and `isStrategy` (the typed object dropped them before). REST list/snapshot already
  passed those through a `z.record`. yearn.fi reads `katRewardsAPR` from REST snapshot components, not GQL.
- `compare-rest-prod-fork` diffs list `estimated.apr/apy/grossAPR/grossAPY`. yvUSD will report
  `grossAPR`/`grossAPY` as `missing` vs prod until prod is deployed; that is the promotion, not a
  price regression.
- Legacy v2 read path (`getLatestEstimatedApr`, crv/velo/aero) applies no scope rule; a v2 publisher
  emitting `isStrategy` would be ignored there. Out of scope, documented in `docs/estimated-apr.md`.
- No DB migration, no cache invalidation; gross appears per vault as snapshot hooks rerun.
  Rollback = revert, nothing persisted in a new shape.
