### PR TITLE
fix(ingest): retry price-service 5xx and stop genesis BlockNotFound spam

### DIFF
--- a/packages/ingest/abis/yearn/lib/tvl.ts
+++ b/packages/ingest/abis/yearn/lib/tvl.ts
@@ -38,8 +38,8 @@ export default async function _process(chainId: number, address: `0x${string}`, 
 
   // 'unavailable' (price service failure) still writes rows for past days: null for
   // the usd components, real values for the on-chain ones. Returning [] left the day
-  // permanently missing, so every fanout cycle re-enqueued it forever. Null days heal
-  // by replay (fanout/timeseries.ts).
+  // with no row; fanout would re-enqueue every cycle during a long outage. Null USD
+  // days are treated as missing by findMissingDays and heal once the service recovers.
   const priceUnavailable = priceSource === 'unavailable'
 
   // The current day is skipped outright: fanout re-extracts it every cycle anyway, and
@@ -49,8 +49,8 @@ export default async function _process(chainId: number, address: `0x${string}`, 
 
   const usdUnknown = priceUnavailable && totalAssets !== 0n
 
-  // findMissingDays counts a null row as computed, so overwriting a real value here
-  // would lose it for good.
+  // Do not clobber a real (non-null) tvl with null during an outage. Null USD days
+  // stay healable via findMissingDays.
   if (priceUnavailable && await hasComputedTvl(chainId, address, data.outputLabel, data.blockTime)) return []
 
   if (components) {

--- a/packages/ingest/fanout/timeseries.spec.ts
+++ b/packages/ingest/fanout/timeseries.spec.ts
@@ -44,14 +44,34 @@ describe('fanout/timeseries', () => {
       expect(missing).to.deep.equal([])
     })
 
-    it('counts a null-value row as computed', async () => {
+    it('treats a null-value tvl row as missing so price outages can heal', async () => {
       await seed([day(1), day(3)])
       await db.query(`
         INSERT INTO output (chain_id, address, label, component, value, block_number, block_time, series_time)
         VALUES ($1, $2, $3, 'tvl', NULL, 1, to_timestamp($4), to_timestamp($4))`,
       [CHAIN_ID, ADDRESS, LABEL, Number(day(2))])
       const missing = await findMissingDays(CHAIN_ID, ADDRESS, LABEL, day(1), day(3))
+      expect(missing).to.deep.equal([day(2)])
+    })
+
+    it('counts a real-zero tvl row as computed', async () => {
+      await seed([day(1), day(3)])
+      await db.query(`
+        INSERT INTO output (chain_id, address, label, component, value, block_number, block_time, series_time)
+        VALUES ($1, $2, $3, 'tvl', 0, 1, to_timestamp($4), to_timestamp($4))`,
+      [CHAIN_ID, ADDRESS, LABEL, Number(day(2))])
+      const missing = await findMissingDays(CHAIN_ID, ADDRESS, LABEL, day(1), day(3))
       expect(missing).to.deep.equal([])
+    })
+
+    it('still counts any row as computed for non-tvl labels', async () => {
+      const apy = 'apy-bwd-delta-pps'
+      await db.query(`
+        INSERT INTO output (chain_id, address, label, component, value, block_number, block_time, series_time)
+        VALUES ($1, $2, $3, 'net', NULL, 1, to_timestamp($4), to_timestamp($4))`,
+      [CHAIN_ID, ADDRESS, apy, Number(day(2))])
+      const missing = await findMissingDays(CHAIN_ID, ADDRESS, apy, day(1), day(3))
+      expect(missing).to.deep.equal([day(1), day(3)])
     })
   })
 

--- a/packages/ingest/fanout/timeseries.ts
+++ b/packages/ingest/fanout/timeseries.ts
@@ -54,8 +54,9 @@ export default class TimeseriesFanout {
 // For tvl / tvl-c, a day counts as computed only when component=tvl has a non-null
 // value: null USD from a price-service outage must re-enter the queue (abis/yearn/lib/tvl.ts).
 // Real 0 (na / empty vault) stays computed. Other labels keep #462's "any row closes
-// the day" rule so apy/pps cannot loop. The BETWEEN range keeps the prunable
-// index-only scan on idx_output_chain_address_label_series_time; NOT IN is safe
+// the day" rule so apy/pps cannot loop. The BETWEEN range keeps the prunable scan
+// on idx_output_chain_address_label_series_time (index-only for non-tvl labels; the
+// tvl path reads component/value off the heap, ~one row per day); NOT IN is safe
 // because series_time is NOT NULL.
 export async function findMissingDays(chainId: number, address: `0x${string}`, label: string, start: bigint, end: bigint): Promise<bigint[]> {
   const timeline = makeTimeline(start, end)

--- a/packages/ingest/fanout/timeseries.ts
+++ b/packages/ingest/fanout/timeseries.ts
@@ -27,8 +27,11 @@ export default class TimeseriesFanout {
       const start = endOfDay(await getBlockTime(chainId, from))
       const end = endOfDay(await getBlockTime(chainId, to))
 
-      // Replay is the only path back for days the anti-join counts as computed but
-      // hold a null value (abis/yearn/lib/tvl.ts).
+      // Null tvl/tvl-c USD rows (price-service 5xx → unavailable) are treated as missing
+      // so they heal when the service recovers. jobId dedupe prevents stacking in-flight
+      // copies; negative price cache (#463) stops a service stampede. Other labels still
+      // treat any row as computed so #462's apy/pps loop does not return. Replay still
+      // clears negative price-cache markers first.
       const missing = data.replay?.enabled
         ? makeTimeline(data.replay.since ?? start, end)
         : await findMissingDays(chainId, address, outputLabel, start, end)
@@ -48,11 +51,12 @@ export default class TimeseriesFanout {
 }
 
 // series_time is endOfDay(block_time) at write time (packages/ingest/load/index.ts).
-// The anti-join returns only the missing days, not every computed day — the full
-// computed list was ~50M calls x O(history) rows of egress per fanout cycle. The
-// BETWEEN range keeps the single prunable index-only scan on
-// idx_output_chain_address_label_series_time; NOT IN is safe because series_time
-// is NOT NULL.
+// For tvl / tvl-c, a day counts as computed only when component=tvl has a non-null
+// value: null USD from a price-service outage must re-enter the queue (abis/yearn/lib/tvl.ts).
+// Real 0 (na / empty vault) stays computed. Other labels keep #462's "any row closes
+// the day" rule so apy/pps cannot loop. The BETWEEN range keeps the prunable
+// index-only scan on idx_output_chain_address_label_series_time; NOT IN is safe
+// because series_time is NOT NULL.
 export async function findMissingDays(chainId: number, address: `0x${string}`, label: string, start: bigint, end: bigint): Promise<bigint[]> {
   const timeline = makeTimeline(start, end)
   return (await db.query(`
@@ -62,6 +66,10 @@ export async function findMissingDays(chainId: number, address: `0x${string}`, l
     FROM output
     WHERE chain_id = $1 AND address = $2 AND label = $3
       AND series_time BETWEEN to_timestamp($5::double precision) AND to_timestamp($6::double precision)
+      AND (
+        $3 NOT IN ('tvl', 'tvl-c')
+        OR (component = 'tvl' AND value IS NOT NULL)
+      )
   )
   ORDER BY t.day ASC`,
   [chainId, address, label, timeline.map(String), Number(start), Number(end)]))

--- a/packages/ingest/prices.service-cache.mock.spec.ts
+++ b/packages/ingest/prices.service-cache.mock.spec.ts
@@ -242,7 +242,7 @@ describe('fetchErc20PriceUsd (USE_PRICE_SERVICE, past-day path)', () => {
       expect(priceUsd).to.equal(0)
     }
 
-    expect(fetchMock).toHaveBeenCalledTimes(2) // batch miss, then the exact endpoint
+    expect(fetchMock).toHaveBeenCalledTimes(4) // batch miss, then exact endpoint retried through 5xx
   })
 
   it('skips the day key for a current-day block (routes through the block cache)', async () => {

--- a/packages/ingest/prices.service.mock.spec.ts
+++ b/packages/ingest/prices.service.mock.spec.ts
@@ -136,7 +136,7 @@ describe('fetchErc20PriceUsd (USE_PRICE_SERVICE=true)', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 
-  it('falls back to the exact endpoint when the batch call fails', async () => {
+  it('does not stampede the exact endpoint when the batch keeps returning 5xx', async () => {
     const fetchMock = vi.fn(async (url: string) => url.includes('batchHistorical')
       ? { ok: false, status: 500 }
       : { ok: true, json: async () => ({ coins: { [WETH_COIN]: { symbol: 'WETH', price: 4 } } }) })
@@ -144,9 +144,73 @@ describe('fetchErc20PriceUsd (USE_PRICE_SERVICE=true)', () => {
 
     const { priceSource, priceUsd } = await fetchErc20PriceUsd(CHAIN_ID, WETH, 1n)
 
+    expect(priceSource).to.equal('unavailable')
+    expect(priceUsd).to.equal(0)
+    const batchCalls = fetchMock.mock.calls.filter(([url]) => url.includes('batchHistorical'))
+    const exactCalls = fetchMock.mock.calls.filter(([url]) => url.includes('/historical/'))
+    expect(batchCalls.length).to.equal(3)
+    expect(exactCalls.length).to.equal(0)
+  })
+
+  it('retries when fetch throws and returns the price once it recovers', async () => {
+    let exactAttempts = 0
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('batchHistorical')) return batchResponse({})
+      exactAttempts++
+      if (exactAttempts < 3) throw new Error('network down')
+      return { ok: true, json: async () => ({ coins: { [WETH_COIN]: { symbol: 'WETH', price: 8 } } }) }
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { priceSource, priceUsd } = await fetchErc20PriceUsd(CHAIN_ID, WETH, 1n)
+
     expect(priceSource).to.equal('priceservice')
-    expect(priceUsd).to.equal(4)
-    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(priceUsd).to.equal(8)
+    expect(exactAttempts).to.equal(3)
+  })
+
+  it('does not retry a 404 on the exact endpoint', async () => {
+    const fetchMock = vi.fn(async (url: string) => url.includes('batchHistorical')
+      ? batchResponse({})
+      : { ok: false, status: 404 })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { priceSource } = await fetchErc20PriceUsd(CHAIN_ID, WETH, 1n)
+
+    expect(priceSource).to.equal('na')
+    const exactCalls = fetchMock.mock.calls.filter(([url]) => url.includes('/historical/'))
+    expect(exactCalls.length).to.equal(1)
+  })
+
+  it('retries exact endpoint 5xx and returns the price once it recovers', async () => {
+    let exactAttempts = 0
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('batchHistorical')) return batchResponse({})
+      exactAttempts++
+      if (exactAttempts < 3) return { ok: false, status: 500 }
+      return { ok: true, json: async () => ({ coins: { [WETH_COIN]: { symbol: 'WETH', price: 9 } } }) }
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { priceSource, priceUsd } = await fetchErc20PriceUsd(CHAIN_ID, WETH, 1n)
+
+    expect(priceSource).to.equal('priceservice')
+    expect(priceUsd).to.equal(9)
+    expect(exactAttempts).to.equal(3)
+  })
+
+  it('returns unavailable after exact endpoint keeps returning 5xx', async () => {
+    const fetchMock = vi.fn(async (url: string) => url.includes('batchHistorical')
+      ? batchResponse({})
+      : { ok: false, status: 500 })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { priceSource, priceUsd } = await fetchErc20PriceUsd(CHAIN_ID, WETH, 1n)
+
+    expect(priceSource).to.equal('unavailable')
+    expect(priceUsd).to.equal(0)
+    const exactCalls = fetchMock.mock.calls.filter(([url]) => url.includes('/historical/'))
+    expect(exactCalls.length).to.equal(3)
   })
 
   it('coalesces concurrent lookups into one batch call', async () => {

--- a/packages/ingest/prices.ts
+++ b/packages/ingest/prices.ts
@@ -258,6 +258,8 @@ async function fetchPriceServiceUsdResult(chainId: number, token: `0x${string}`,
       if (!priceUsd || !Number.isFinite(priceUsd)) { warn('empty coins'); return { type: 'missing' } }
       return { type: 'price', price: PriceSchema.parse({ chainId, address: token, priceUsd, priceSource: 'priceservice', blockNumber, blockTime }) }
     }
+    // A 5xx/timeout batch is not a table miss: falling through would stampede /historical once per token.
+    if ('unavailable' in batched && batched.unavailable) return { type: 'unavailable' }
 
     // batchHistorical reads the table only; the exact route also resolves upstream on a table miss.
     return await fetchPriceServiceExactResult({ chainId, token, blockNumber, blockTime, coinId, baseUrl, warn })
@@ -279,9 +281,13 @@ async function fetchPriceServiceExactResult(request: {
   const { chainId, token, blockNumber, blockTime, coinId, baseUrl, warn } = request
   const url = `${baseUrl}/api/prices/historical/${Number(blockTime)}/${coinId}`
 
-  const response = await fetch(url, {
+  const response = await fetchPriceServiceResponse(url, {
     headers: { Authorization: `Bearer ${process.env.PRICE_SERVICE_API_KEY}` }
   })
+  if (!response) {
+    warn('http', 'fetch failed after retries')
+    return { type: 'unavailable' }
+  }
   if (!response.ok) {
     warn('http', response.status)
     return response.status === 404 ? { type: 'missing' } : { type: 'unavailable' }
@@ -295,7 +301,33 @@ async function fetchPriceServiceExactResult(request: {
   return { type: 'price', price: PriceSchema.parse({ chainId, address: token, priceUsd, priceSource: 'priceservice', blockNumber, blockTime }) }
 }
 
-type PriceServiceBatchOutcome = { found: true, priceUsd: number } | { found: false }
+const PRICE_SERVICE_FETCH_ATTEMPTS = 3
+const PRICE_SERVICE_FETCH_TIMEOUT_MS = 5_000
+
+/** Retry transient transport / 5xx failures. 404 and other 4xx are final. */
+async function fetchPriceServiceResponse(url: string, init: RequestInit): Promise<Response | undefined> {
+  let lastError: unknown
+  for (let attempt = 0; attempt < PRICE_SERVICE_FETCH_ATTEMPTS; attempt++) {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), PRICE_SERVICE_FETCH_TIMEOUT_MS)
+    try {
+      const response = await fetch(url, { ...init, signal: controller.signal })
+      if (response.ok || response.status < 500) return response
+      lastError = new Error(`http ${response.status}`)
+    } catch (error) {
+      lastError = error
+    } finally {
+      clearTimeout(timer)
+    }
+    if (attempt < PRICE_SERVICE_FETCH_ATTEMPTS - 1) {
+      await new Promise(resolve => setTimeout(resolve, 50 * (2 ** attempt)))
+    }
+  }
+  if (lastError) console.warn('🚨', 'price service fetch retries exhausted', url, lastError)
+  return undefined
+}
+
+type PriceServiceBatchOutcome = { found: true, priceUsd: number } | { found: false } | { found: false, unavailable: true }
 
 type PriceServiceBatchEntry = {
   coinId: string
@@ -335,7 +367,7 @@ function flushPriceServiceBatch() {
   }
 }
 
-// Never throws: an unresolved entry falls through to the exact endpoint, same as a table miss.
+// Table miss -> found:false so exact can fill in. Transport/5xx after retries -> unavailable (no stampede).
 async function sendPriceServiceBatch(entries: PriceServiceBatchEntry[]) {
   try {
     const coins: Record<string, number[]> = {}
@@ -344,10 +376,18 @@ async function sendPriceServiceBatch(entries: PriceServiceBatchEntry[]) {
     const baseUrl = process.env.PRICE_SERVICE_URL || PRICE_SERVICE_DEFAULT_URL
     const url = `${baseUrl}/api/prices/batchHistorical?coins=${encodeURIComponent(JSON.stringify(coins))}`
 
-    const response = await fetch(url, {
+    const response = await fetchPriceServiceResponse(url, {
       headers: { Authorization: `Bearer ${process.env.PRICE_SERVICE_API_KEY}` }
     })
-    if (!response.ok) throw new Error(`batchHistorical ${response.status} ${url}`)
+    if (!response) throw new Error(`batchHistorical fetch failed ${url}`)
+    if (!response.ok) {
+      // 404 is a table miss: let the exact route resolve. Other 4xx (auth) are unavailable.
+      if (response.status === 404) {
+        for (const entry of entries) entry.resolve({ found: false })
+        return
+      }
+      throw new Error(`batchHistorical ${response.status} ${url}`)
+    }
 
     const data = await response.json() as { coins?: Record<string, { prices?: { timestamp: number, price: number }[] }> }
     // The service echoes the key it parsed, which checksums the address.
@@ -359,9 +399,8 @@ async function sendPriceServiceBatch(entries: PriceServiceBatchEntry[]) {
       entry.resolve(hit ? { found: true, priceUsd: hit.price } : { found: false })
     }
   } catch (error) {
-    // Distinguish a broken batch route from a legitimate table miss, which resolves the same way.
     console.warn('🚨', 'price service batch failed', entries.length, error)
-    for (const entry of entries) entry.resolve({ found: false })
+    for (const entry of entries) entry.resolve({ found: false, unavailable: true })
   }
 }
 

--- a/packages/lib/blocks.spec.ts
+++ b/packages/lib/blocks.spec.ts
@@ -125,4 +125,36 @@ describe('blocks', function() {
       )
     }
   })
+
+  it('does not cache a transient RPC error as the earliest reachable block', async function() {
+    const originalNext = rpcs.next
+    const chainId = 31340
+    const tip = 200n
+    const keys = Array.from({ length: 201 }, (_, n) => `getBlock:${chainId}:${String(n)}`)
+      .concat([`getBlock:${chainId}:undefined`, `earliestReachableBlock:${chainId}`])
+
+    await Promise.all(keys.map(key => cache.del(key)))
+
+    rpcs.next = ((chain: number) => {
+      expect(chain).to.equal(chainId)
+      return {
+        getBlock: async ({ blockNumber }: { blockNumber?: bigint } = {}) => {
+          const number = blockNumber ?? tip
+          if (number <= 1n) throw new Error(`Block at number "${number}" could not be found.`)
+          if (number === tip - 1n) throw new Error('429 Too Many Requests')
+          return { number, timestamp: number * 10n }
+        }
+      }
+    }) as unknown as typeof rpcs.next
+
+    try {
+      let thrown: unknown
+      try { await __estimateHeight(chainId, 1_500n) } catch (error) { thrown = error }
+      expect(String(thrown)).to.include('429')
+      expect(await cache.get(`earliestReachableBlock:${chainId}`)).to.be.undefined
+    } finally {
+      rpcs.next = originalNext
+      await Promise.all(keys.map(key => cache.del(key)))
+    }
+  })
 })

--- a/packages/lib/blocks.spec.ts
+++ b/packages/lib/blocks.spec.ts
@@ -49,6 +49,7 @@ describe('blocks', function() {
   it('returns first block at or after timestamp when adjacent timestamps repeat', async function() {
     const originalNext = rpcs.next
     const blocks = new Map<bigint, bigint>([
+      [0n, 0n],
       [1n, 0n],
       [2n, 90n],
       [3n, 90n],
@@ -58,7 +59,8 @@ describe('blocks', function() {
     const chainId = 31338
 
     await Promise.all(
-      ['undefined', '1', '2', '3', '4', '5'].map(blockNumber => cache.del(`getBlock:${chainId}:${blockNumber}`))
+      ['undefined', '0', '1', '2', '3', '4', '5'].map(blockNumber => cache.del(`getBlock:${chainId}:${blockNumber}`))
+        .concat([cache.del(`earliestReachableBlock:${chainId}`)])
     )
 
     rpcs.next = ((chain: number) => {
@@ -77,7 +79,49 @@ describe('blocks', function() {
     } finally {
       rpcs.next = originalNext
       await Promise.all(
-        ['undefined', '1', '2', '3', '4', '5'].map(blockNumber => cache.del(`getBlock:${chainId}:${blockNumber}`))
+        ['undefined', '0', '1', '2', '3', '4', '5'].map(blockNumber => cache.del(`getBlock:${chainId}:${blockNumber}`))
+          .concat([cache.del(`earliestReachableBlock:${chainId}`)])
+      )
+    }
+  })
+
+  it('estimates height when block 0 and 1 are missing from the RPC', async function() {
+    const originalNext = rpcs.next
+    const chainId = 31339
+    const earliest = 100n
+    const tip = 200n
+
+    await Promise.all(
+      Array.from({ length: 201 }, (_, n) => cache.del(`getBlock:${chainId}:${String(n)}`))
+        .concat([
+          cache.del(`getBlock:${chainId}:undefined`),
+          cache.del(`earliestReachableBlock:${chainId}`)
+        ])
+    )
+
+    rpcs.next = ((chain: number) => {
+      expect(chain).to.equal(chainId)
+      return {
+        getBlock: async ({ blockNumber }: { blockNumber?: bigint } = {}) => {
+          const number = blockNumber ?? tip
+          if (number < earliest) {
+            throw new Error(`Block at number "${number}" could not be found.`)
+          }
+          return { number, timestamp: number * 10n }
+        }
+      }
+    }) as unknown as typeof rpcs.next
+
+    try {
+      expect(await __estimateHeight(chainId, 1_500n)).to.equal(150n)
+    } finally {
+      rpcs.next = originalNext
+      await Promise.all(
+        Array.from({ length: 201 }, (_, n) => cache.del(`getBlock:${chainId}:${String(n)}`))
+          .concat([
+          cache.del(`getBlock:${chainId}:undefined`),
+          cache.del(`earliestReachableBlock:${chainId}`)
+        ])
       )
     }
   })

--- a/packages/lib/blocks.ts
+++ b/packages/lib/blocks.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { BlockNotFoundError } from 'viem'
 import { cache } from './cache'
 import { rpcs } from './rpcs'
 import { dates } from '.'
@@ -79,8 +80,9 @@ async function estimateHeightManual(chainId: number, timestamp: bigint) {
   if (timestamp >= hiTime) return hi
 
   // Do not hard-require block 1: pruned archives and some chains throw
-  // BlockNotFoundError there (~800/h on ingest-v-2). Prefer genesis (0), then 1,
-  // then the earliest height the RPC can actually serve.
+  // BlockNotFoundError there (~800/h on ingest-v-2). Prefer block 1, then genesis
+  // (0, whose timestamp is 0 on mainnet and ruins the interpolation slope), then
+  // the earliest height the RPC can actually serve.
   const { number: lo, timestamp: loTime } = await earliestReachableBlock(chainId, hi)
   if (timestamp <= loTime) return lo
 
@@ -109,13 +111,13 @@ async function earliestReachableBlock(chainId: number, hi: bigint): Promise<Bloc
 
 async function findEarliestReachableBlock(chainId: number, hi: bigint): Promise<Block> {
   // Missing genesis / block 1 is expected on pruned archives (~800/h BlockNotFound
-  // when estimateHeight required lo=1). Swallow those two probes; cache the frontier
-  // so later estimates never hit 0/1 again.
-  for (const candidate of [0n, 1n]) {
+  // when estimateHeight required lo=1). Swallow only BlockNotFound; any other RPC
+  // failure must propagate or a transient error would be cached as the frontier.
+  for (const candidate of [1n, 0n]) {
     try {
       return await getBlock(chainId, candidate)
-    } catch {
-      // pruned or missing
+    } catch (error) {
+      if (!isBlockNotFound(error)) throw error
     }
   }
 
@@ -127,7 +129,8 @@ async function findEarliestReachableBlock(chainId: number, hi: bigint): Promise<
     try {
       await getBlock(chainId, probe)
       ok = probe
-    } catch {
+    } catch (error) {
+      if (!isBlockNotFound(error)) throw error
       miss = probe
       break
     }
@@ -138,12 +141,18 @@ async function findEarliestReachableBlock(chainId: number, hi: bigint): Promise<
     try {
       await getBlock(chainId, mid)
       ok = mid
-    } catch {
+    } catch (error) {
+      if (!isBlockNotFound(error)) throw error
       miss = mid
     }
   }
 
   return await getBlock(chainId, ok)
+}
+
+function isBlockNotFound(error: unknown) {
+  return error instanceof BlockNotFoundError
+    || (error instanceof Error && error.message.includes('could not be found'))
 }
 
 export async function estimateCreationBlock(chainId: number, contract: `0x${string}`): Promise<Block> {

--- a/packages/lib/blocks.ts
+++ b/packages/lib/blocks.ts
@@ -78,21 +78,72 @@ async function estimateHeightManual(chainId: number, timestamp: bigint) {
   let hi = top.number, hiTime = top.timestamp
   if (timestamp >= hiTime) return hi
 
-  let lo = 1n, loTime = (await getBlock(chainId, lo)).timestamp
+  // Do not hard-require block 1: pruned archives and some chains throw
+  // BlockNotFoundError there (~800/h on ingest-v-2). Prefer genesis (0), then 1,
+  // then the earliest height the RPC can actually serve.
+  const { number: lo, timestamp: loTime } = await earliestReachableBlock(chainId, hi)
   if (timestamp <= loTime) return lo
 
-  while (hi - lo > 1n) {
-    let probe = hiTime > loTime
-      ? lo + ((hi - lo) * (timestamp - loTime)) / (hiTime - loTime)
-      : (lo + hi) / 2n
-    if (probe <= lo) probe = lo + 1n
+  let loBlock = lo, loBlockTime = loTime
+  while (hi - loBlock > 1n) {
+    let probe = hiTime > loBlockTime
+      ? loBlock + ((hi - loBlock) * (timestamp - loBlockTime)) / (hiTime - loBlockTime)
+      : (loBlock + hi) / 2n
+    if (probe <= loBlock) probe = loBlock + 1n
     else if (probe >= hi) probe = hi - 1n
     const block = await getBlock(chainId, probe)
-    if (block.timestamp < timestamp) { lo = probe; loTime = block.timestamp }
+    if (block.timestamp < timestamp) { loBlock = probe; loBlockTime = block.timestamp }
     else { hi = probe; hiTime = block.timestamp }
   }
 
   return hi
+}
+
+/** Lowest block number this RPC can serve, used as the estimateHeight low bound. */
+async function earliestReachableBlock(chainId: number, hi: bigint): Promise<Block> {
+  const result = cache.wrap(`earliestReachableBlock:${chainId}`, async () => {
+    return await findEarliestReachableBlock(chainId, hi)
+  }, HISTORICAL_BLOCK_TTL)
+  return BlockSchema.parse(await result)
+}
+
+async function findEarliestReachableBlock(chainId: number, hi: bigint): Promise<Block> {
+  // Missing genesis / block 1 is expected on pruned archives (~800/h BlockNotFound
+  // when estimateHeight required lo=1). Swallow those two probes; cache the frontier
+  // so later estimates never hit 0/1 again.
+  for (const candidate of [0n, 1n]) {
+    try {
+      return await getBlock(chainId, candidate)
+    } catch {
+      // pruned or missing
+    }
+  }
+
+  // Exponential walk back from tip until a miss, then binary-search the frontier.
+  let ok = hi
+  let miss = 0n
+  for (let delta = 1n; delta < hi; delta *= 2n) {
+    const probe = hi - delta
+    try {
+      await getBlock(chainId, probe)
+      ok = probe
+    } catch {
+      miss = probe
+      break
+    }
+  }
+
+  while (ok - miss > 1n) {
+    const mid = miss + (ok - miss) / 2n
+    try {
+      await getBlock(chainId, mid)
+      ok = mid
+    } catch {
+      miss = mid
+    }
+  }
+
+  return await getBlock(chainId, ok)
 }
 
 export async function estimateCreationBlock(chainId: number, contract: `0x${string}`): Promise<Block> {


### PR DESCRIPTION
### Summary
Price-service 5xx/timeouts were either stampeded onto `/historical` per token or persisted as a fake USD 0. `estimateHeight` also hard-required block 1, which pruned RPCs throw as BlockNotFound (~800/h). This PR retries transport/5xx with a 5s timeout (404 stays final), treats a failed batch as unavailable instead of fanning out to exact, lets **null** tvl/tvl-c USD rows heal without looping apy/pps (#462), and bounds interpolation to the earliest reachable block (cached).

### Related
- Service-side complement: [yearn/yearn-prices#51](https://github.com/yearn/yearn-prices/pull/51) — look up requested UTC EOD in `token_prices`; miss → DeFiLlama; persist today's EOD so later same-day requests are table hits (stops Llama 429 stampede). Does **not** serve yesterday's close for the open day.

### How to review
- `packages/ingest/prices.ts`: `fetchPriceServiceResponse` timeout+retry; batch 5xx → `unavailable` (no exact stampede); batch 404 still falls through to exact; exact 5xx → unavailable, 404 → na.
- `packages/ingest/fanout/timeseries.ts`: `findMissingDays` treats null **tvl** component as missing only for labels `tvl`/`tvl-c`. Real 0 stays computed. Other labels keep “any row closes the day”.
- `packages/lib/blocks.ts`: do not require genesis/1; swallow those misses; cache `earliestReachableBlock`.

### Test plan
- [x] `bunx vitest run --project mocks prices.service.mock.spec.ts prices.service-cache.mock.spec.ts` — 27/27 passed
- [ ] ingest `fanout/timeseries.spec.ts` and lib `blocks.spec.ts` need Docker/testcontainers (not available in this environment)

### Risk / impact
Null-USD days re-enter the extract queue. jobId dedupe prevents in-flight stacks; `#463` negative cache (2m→6h) limits price-service load. `removeOnComplete` count is 100, so jobIds recycle and extract can re-run ~each fanout cycle during a long outage (RPC for totalAssets + estimateHeight). That is not the #462 Neon anti-join egress loop. Non-tvl labels are unchanged so apy/pps cannot loop. 5xx is never stored as a real 0; na/404 still is.