### PR TITLE
perf(web): cut gql vaults egress with sql merge, pagination and cache hints

### DIFF
--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -27,11 +27,11 @@ curl -s -X POST https://kong.yearn.fi/api/gql \
 
 #### `vaults`
 
-List all vaults, sorted by TVL descending.
+List a chain's vaults, one page at a time, sorted by TVL descending then address ascending.
 
 | Argument | Type | Description |
 |----------|------|-------------|
-| `chainId` | `Int` | Filter by chain |
+| `chainId` | `Int!` | Chain to list (required) |
 | `addresses` | `[String]` | Filter by addresses |
 | `apiVersion` | `String` | Minimum API version (e.g. `"3.0.0"`) |
 | `erc4626` | `Boolean` | ERC-4626 vaults only |
@@ -41,12 +41,19 @@ List all vaults, sorted by TVL descending.
 | `vaultType` | `Int` | Filter by vault type |
 | `riskLevel` | `Int` | Filter by risk level |
 | `unratedOnly` | `Boolean` | Only unrated vaults |
+| `limit` | `Int` | Page size, default `100`, clamped to `1..1000` |
+| `after` | `String` | Address of the last vault of the previous page |
+
+Paging is keyset, not offset. Pass the `address` of the last row you received as
+`after` to get the next page, repeating with the same filters until a page comes
+back empty. Vaults with no TVL sort last as `0`. An `after` that matches no vault
+on the chain returns an empty page, same as the end of the list.
 
 Returns [`Vault`](#vault-1).
 
 ```graphql
 {
-  vaults(chainId: 1, v3: true) {
+  vaults(chainId: 1, v3: true, limit: 50, after: "0x1234...") {
     address
     name
     symbol

--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -27,7 +27,7 @@ curl -s -X POST https://kong.yearn.fi/api/gql \
 
 #### `vaults`
 
-List vaults one page at a time, sorted by TVL descending then address ascending. Omit `chainId` to list every chain.
+List vaults one page at a time, sorted by TVL descending, address ascending, then chain ID ascending. Omit `chainId` to list every chain.
 
 | Argument | Type | Description |
 |----------|------|-------------|
@@ -42,12 +42,15 @@ List vaults one page at a time, sorted by TVL descending then address ascending.
 | `riskLevel` | `Int` | Filter by risk level |
 | `unratedOnly` | `Boolean` | Only unrated vaults |
 | `limit` | `Int` | Page size, default `100`, clamped to `1..1000` |
-| `after` | `String` | Address of the last vault of the previous page |
+| `after` | `String` | Address of the last vault of the previous page; when paging all chains, use `chainId:address` |
 
-Paging is keyset, not offset. Pass the `address` of the last row you received as
-`after` to get the next page, repeating with the same filters until a page comes
-back empty. Vaults with no TVL sort last as `0`. An `after` that matches no vault
-(on the given chain, if any) returns an empty page, same as the end of the list.
+Paging is keyset, not offset. Pass the address of the last row you received as
+`after` to get the next page. When `chainId` is omitted, pass
+`chainId:address` (for example `10:0x1234...`) so same-address vaults on
+different chains are not skipped. Repeat with the same filters until a page
+comes back empty. Vaults with no TVL sort last as `0`. An `after` that matches
+no vault (on the given chain, if any) returns an empty page, same as the end of
+the list.
 
 Returns [`Vault`](#vault-1).
 

--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -27,7 +27,7 @@ curl -s -X POST https://kong.yearn.fi/api/gql \
 
 #### `vaults`
 
-List vaults one page at a time, sorted by TVL descending, address ascending, then chain ID ascending. Omit `chainId` to list every chain.
+List vaults one page at a time, sorted by TVL descending, then chain ID ascending, then address ascending. Omit `chainId` to list every chain.
 
 | Argument | Type | Description |
 |----------|------|-------------|
@@ -42,21 +42,17 @@ List vaults one page at a time, sorted by TVL descending, address ascending, the
 | `riskLevel` | `Int` | Filter by risk level |
 | `unratedOnly` | `Boolean` | Only unrated vaults |
 | `limit` | `Int` | Page size, default `100`, clamped to `1..1000` |
-| `after` | `String` | Address of the last vault of the previous page; when paging all chains, use `chainId:address` |
+| `offset` | `Int` | Rows to skip, default `0` |
 
-Paging is keyset, not offset. Pass the address of the last row you received as
-`after` to get the next page. When `chainId` is omitted, pass
-`chainId:address` (for example `10:0x1234...`) so same-address vaults on
-different chains are not skipped. Repeat with the same filters until a page
-comes back empty. Vaults with no TVL sort last as `0`. An `after` that matches
-no vault (on the given chain, if any) returns an empty page, same as the end of
-the list.
+Paging is offset based: repeat the same filters and raise `offset` by `limit`
+for each page. Rows are ordered by TVL descending, then chain ID ascending,
+then address ascending; vaults with no TVL sort last as `0`.
 
 Returns [`Vault`](#vault-1).
 
 ```graphql
 {
-  vaults(chainId: 1, v3: true, limit: 50, after: "0x1234...") {
+  vaults(chainId: 1, v3: true, limit: 50, offset: 50) {
     address
     name
     symbol

--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -27,11 +27,11 @@ curl -s -X POST https://kong.yearn.fi/api/gql \
 
 #### `vaults`
 
-List a chain's vaults, one page at a time, sorted by TVL descending then address ascending.
+List vaults one page at a time, sorted by TVL descending then address ascending. Omit `chainId` to list every chain.
 
 | Argument | Type | Description |
 |----------|------|-------------|
-| `chainId` | `Int!` | Chain to list (required) |
+| `chainId` | `Int` | Filter by chain |
 | `addresses` | `[String]` | Filter by addresses |
 | `apiVersion` | `String` | Minimum API version (e.g. `"3.0.0"`) |
 | `erc4626` | `Boolean` | ERC-4626 vaults only |
@@ -47,7 +47,7 @@ List a chain's vaults, one page at a time, sorted by TVL descending then address
 Paging is keyset, not offset. Pass the `address` of the last row you received as
 `after` to get the next page, repeating with the same filters until a page comes
 back empty. Vaults with no TVL sort last as `0`. An `after` that matches no vault
-on the chain returns an empty page, same as the end of the list.
+(on the given chain, if any) returns an empty page, same as the end of the list.
 
 Returns [`Vault`](#vault-1).
 

--- a/packages/lib/types.ts
+++ b/packages/lib/types.ts
@@ -6,7 +6,7 @@ export const zhexstring = z.custom<`0x${string}`>((val: any) => /^0x/.test(val))
 export const zvaultType = z.string()
 export type HexString = z.infer<typeof zhexstring>
 
-export const EvmAddressSchema = zhexstring.transform(s => getAddress(s))
+export const EvmAddressSchema = zhexstring.refine(s => /^0x[0-9a-fA-F]{40}$/.test(s)).transform(s => getAddress(s))
 export type EvmAddress = z.infer<typeof EvmAddressSchema>
 
 export function compareEvmAddresses(a?: string, b?: string) {

--- a/packages/scripts/src/quality-assurance/README.md
+++ b/packages/scripts/src/quality-assurance/README.md
@@ -50,8 +50,7 @@ bun run tvl-detect-gaps.ts --start 2024-06-01 --end 2024-12-31
 
 Recomputes and backfills `tvl-c` timeseries data for specific vaults. Runs in two modes.
 
-Vault metadata is fetched independently per chain and paginated, so requested
-vaults are resolved even when they fall outside the first 100 TVL results.
+Vault metadata is fetched by address in one request via the `addresses` filter.
 
 ### Modes
 

--- a/packages/scripts/src/quality-assurance/README.md
+++ b/packages/scripts/src/quality-assurance/README.md
@@ -50,6 +50,9 @@ bun run tvl-detect-gaps.ts --start 2024-06-01 --end 2024-12-31
 
 Recomputes and backfills `tvl-c` timeseries data for specific vaults. Runs in two modes.
 
+Vault metadata is fetched independently per chain and paginated, so requested
+vaults are resolved even when they fall outside the first 100 TVL results.
+
 ### Modes
 
 **`--update totalAssets`** — Fetches on-chain `totalAssets()` via multicall at end-of-day blocks (resolved through DefiLlama) and upserts into the `output` table.

--- a/packages/scripts/src/quality-assurance/tvl-backfill.ts
+++ b/packages/scripts/src/quality-assurance/tvl-backfill.ts
@@ -80,8 +80,8 @@ const VaultsResponseSchema = z.object({
 
 async function fetchVaultMetadata(vaultKeys: { chainId: number; address: string }[]) {
   const query = `
-    query Vaults($chainId: Int!, $limit: Int!, $after: String) {
-      vaults(chainId: $chainId, limit: $limit, after: $after) {
+    query Vaults($addresses: [String], $limit: Int) {
+      vaults(addresses: $addresses, limit: $limit) {
         chainId
         address
         name
@@ -96,51 +96,20 @@ async function fetchVaultMetadata(vaultKeys: { chainId: number; address: string 
     }
   `
 
-  const PAGE_SIZE = 1000
-  const byChain = new Map<number, { chainId: number; address: string }[]>()
-  for (const key of vaultKeys) {
-    const keys = byChain.get(key.chainId) ?? []
-    keys.push(key)
-    byChain.set(key.chainId, keys)
+  const response = await fetch('https://kong.yearn.fi/api/gql', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      query,
+      variables: { addresses: vaultKeys.map(k => k.address), limit: 1000 },
+    }),
+  })
+
+  if (!response.ok) {
+    throw new Error(`GraphQL request failed: HTTP ${response.status}`)
   }
 
-  // A vaults query defaults to 100 rows. Fetch each chain independently and
-  // walk its keyset pages so a requested vault is never hidden below that cap.
-  const chainVaults = await Promise.all([...byChain.keys()].map(async chainId => {
-    const result: z.infer<typeof VaultSchema>[] = []
-    const requested = new Set((byChain.get(chainId) ?? []).map(v => v.address.toLowerCase()))
-    const found = new Set<string>()
-    let after: string | null = null
-
-    while (true) {
-      const response: Response = await fetch('https://kong.yearn.fi/api/gql', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          query,
-          variables: { chainId, limit: PAGE_SIZE, after },
-        }),
-      })
-
-      if (!response.ok) {
-        throw new Error(`GraphQL request failed: HTTP ${response.status}`)
-      }
-
-      const data: z.infer<typeof VaultSchema>[] = VaultsResponseSchema.parse(await response.json()).data.vaults
-      result.push(...data)
-      for (const vault of data) {
-        if (requested.has(vault.address.toLowerCase())) found.add(vault.address.toLowerCase())
-      }
-      if (found.size === requested.size || data.length < PAGE_SIZE) break
-
-      const last: z.infer<typeof VaultSchema> = data[data.length - 1]
-      after = `${last.chainId}:${last.address}`
-    }
-
-    return result
-  }))
-
-  const allVaults = chainVaults.flat()
+  const allVaults = VaultsResponseSchema.parse(await response.json()).data.vaults
 
   const result: typeof allVaults = []
   for (const key of vaultKeys) {

--- a/packages/scripts/src/quality-assurance/tvl-backfill.ts
+++ b/packages/scripts/src/quality-assurance/tvl-backfill.ts
@@ -80,8 +80,8 @@ const VaultsResponseSchema = z.object({
 
 async function fetchVaultMetadata(vaultKeys: { chainId: number; address: string }[]) {
   const query = `
-    query Vaults {
-      vaults {
+    query Vaults($chainId: Int!, $limit: Int!, $after: String) {
+      vaults(chainId: $chainId, limit: $limit, after: $after) {
         chainId
         address
         name
@@ -96,18 +96,51 @@ async function fetchVaultMetadata(vaultKeys: { chainId: number; address: string 
     }
   `
 
-  const response = await fetch('https://kong.yearn.fi/api/gql', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ query }),
-  })
-
-  if (!response.ok) {
-    throw new Error(`GraphQL request failed: HTTP ${response.status}`)
+  const PAGE_SIZE = 1000
+  const byChain = new Map<number, { chainId: number; address: string }[]>()
+  for (const key of vaultKeys) {
+    const keys = byChain.get(key.chainId) ?? []
+    keys.push(key)
+    byChain.set(key.chainId, keys)
   }
 
-  const data = await response.json()
-  const allVaults = VaultsResponseSchema.parse(data).data.vaults
+  // A vaults query defaults to 100 rows. Fetch each chain independently and
+  // walk its keyset pages so a requested vault is never hidden below that cap.
+  const chainVaults = await Promise.all([...byChain.keys()].map(async chainId => {
+    const result: z.infer<typeof VaultSchema>[] = []
+    const requested = new Set((byChain.get(chainId) ?? []).map(v => v.address.toLowerCase()))
+    const found = new Set<string>()
+    let after: string | null = null
+
+    while (true) {
+      const response: Response = await fetch('https://kong.yearn.fi/api/gql', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          query,
+          variables: { chainId, limit: PAGE_SIZE, after },
+        }),
+      })
+
+      if (!response.ok) {
+        throw new Error(`GraphQL request failed: HTTP ${response.status}`)
+      }
+
+      const data: z.infer<typeof VaultSchema>[] = VaultsResponseSchema.parse(await response.json()).data.vaults
+      result.push(...data)
+      for (const vault of data) {
+        if (requested.has(vault.address.toLowerCase())) found.add(vault.address.toLowerCase())
+      }
+      if (found.size === requested.size || data.length < PAGE_SIZE) break
+
+      const last: z.infer<typeof VaultSchema> = data[data.length - 1]
+      after = `${last.chainId}:${last.address}`
+    }
+
+    return result
+  }))
+
+  const allVaults = chainVaults.flat()
 
   const result: typeof allVaults = []
   for (const key of vaultKeys) {

--- a/packages/web/app/api/gql/resolvers/accountVaults.ts
+++ b/packages/web/app/api/gql/resolvers/accountVaults.ts
@@ -1,5 +1,5 @@
 import db from '@/app/api/db'
-import { mergeSnapshot } from '@/lib/mergeSnapshot'
+import { mergeSnapshotSql, VAULT_UNSERVED_KEYS } from '@/lib/mergeSnapshot'
 
 const accountVaults = async (_: object, args: { chainId?: number, account: `0x${string}` }) => {
   const { chainId, account } = args
@@ -10,9 +10,7 @@ const accountVaults = async (_: object, args: { chainId?: number, account: `0x${
     SELECT
       thing.chain_id,
       thing.address,
-      thing.defaults,
-      snapshot.snapshot,
-      snapshot.hook
+      ${mergeSnapshotSql(VAULT_UNSERVED_KEYS)} AS merged
     FROM thing
     JOIN snapshot
       ON thing.chain_id = snapshot.chain_id
@@ -27,7 +25,7 @@ const accountVaults = async (_: object, args: { chainId?: number, account: `0x${
     return result.rows.map(row => ({
       chainId: row.chain_id,
       address: row.address,
-      ...mergeSnapshot(row.defaults, row.snapshot, row.hook)
+      ...row.merged
     }))
 
   } catch (error) {

--- a/packages/web/app/api/gql/resolvers/vault.ts
+++ b/packages/web/app/api/gql/resolvers/vault.ts
@@ -1,5 +1,5 @@
 import db from '@/app/api/db'
-import { mergeSnapshot } from '@/lib/mergeSnapshot'
+import { mergeSnapshotSql, VAULT_UNSERVED_KEYS } from '@/lib/mergeSnapshot'
 import { getAddress } from 'viem'
 
 const vault = async (_: object, args: { chainId: number, address: `0x${string}` }) => {
@@ -10,9 +10,7 @@ const vault = async (_: object, args: { chainId: number, address: `0x${string}` 
     SELECT
       thing.chain_id,
       thing.address,
-      thing.defaults,
-      snapshot.snapshot,
-      snapshot.hook
+      ${mergeSnapshotSql(VAULT_UNSERVED_KEYS)} AS merged
     FROM thing
     JOIN snapshot
       ON thing.chain_id = snapshot.chain_id
@@ -25,7 +23,7 @@ const vault = async (_: object, args: { chainId: number, address: `0x${string}` 
     const [first] = result.rows.map(row => ({
       chainId: row.chain_id,
       address: row.address,
-      ...mergeSnapshot(row.defaults, row.snapshot, row.hook)
+      ...row.merged
     }))
 
     return first

--- a/packages/web/app/api/gql/resolvers/vaults.spec.ts
+++ b/packages/web/app/api/gql/resolvers/vaults.spec.ts
@@ -1,0 +1,58 @@
+import { strict as assert } from 'node:assert'
+import { beforeEach, describe, it, vi } from 'vitest'
+
+const query = vi.fn()
+
+vi.mock('@/app/api/db', () => ({
+  default: { query }
+}))
+
+const run = async (args: Record<string, unknown>) => {
+  query.mockResolvedValueOnce({ rows: [] })
+  const { default: vaults } = await import('./vaults')
+  await vaults({}, args)
+  return {
+    sql: query.mock.calls[0][0] as string,
+    params: query.mock.calls[0][1] as unknown[]
+  }
+}
+
+describe('vaults resolver', () => {
+  beforeEach(() => {
+    query.mockReset()
+  })
+
+  it('clamps limit into [1, 1000]', async () => {
+    const low = await run({ chainId: 1, limit: -1 })
+    assert.equal(low.params.at(-1), 1)
+
+    query.mockReset()
+    const high = await run({ chainId: 1, limit: 1_000_000 })
+    assert.equal(high.params.at(-1), 1000)
+
+    query.mockReset()
+    const dflt = await run({ chainId: 1 })
+    assert.equal(dflt.params.at(-1), 100)
+  })
+
+  it('advances past the cursor tie group instead of re-serving it', async () => {
+    const { sql } = await run({ chainId: 1, after: '0xAbC' })
+    const tvl = 'COALESCE((snapshot.hook->\'tvl\'->>\'close\')::numeric, 0)'
+    assert.equal(sql.includes(`${tvl} < (SELECT tvl FROM cursor)`), true)
+    assert.equal(sql.includes('lower(thing.address) > (SELECT address FROM cursor)'), true)
+    // the row-comparison form admitted every same-tvl row with a smaller address
+    assert.equal(sql.includes('thing.address) < (SELECT tvl, address FROM cursor)'), false)
+  })
+
+  it('orders on the same expression the cursor compares', async () => {
+    const { sql } = await run({ chainId: 1 })
+    assert.equal(sql.includes('ORDER BY COALESCE((snapshot.hook->\'tvl\'->>\'close\')::numeric, 0) DESC, lower(thing.address) ASC'), true)
+  })
+
+  it('resolves the cursor case-insensitively and binds chainId explicitly', async () => {
+    const { sql, params } = await run({ chainId: 10, after: '0xABCDEF' })
+    assert.equal(sql.includes('lower(thing.address) = lower($3)'), true)
+    assert.equal(sql.includes('thing.chain_id = $4::int'), true)
+    assert.deepEqual(params, ['vault', 10, '0xABCDEF', 10, 100])
+  })
+})

--- a/packages/web/app/api/gql/resolvers/vaults.spec.ts
+++ b/packages/web/app/api/gql/resolvers/vaults.spec.ts
@@ -62,4 +62,49 @@ describe('vaults resolver', () => {
     assert.equal(sql.includes('$3::int IS NULL OR thing.chain_id = $3::int'), true)
     assert.deepEqual(params, ['vault', '0xABCDEF', null, 100])
   })
+
+  it('treats a null chainId like an omitted chainId', async () => {
+    const omitted = await run({})
+    query.mockReset()
+    const nullable = await run({ chainId: null })
+    assert.equal(nullable.sql, omitted.sql)
+    assert.deepEqual(nullable.params, omitted.params)
+  })
+
+  it('uses the chain in an all-chain cursor to disambiguate same-address vaults', async () => {
+    const { sql, params } = await run({ after: '10:0xABCDEF' })
+    assert.match(sql, /lower\(thing\.address\) = lower\(\$2\)/)
+    assert.match(sql, /AND thing\.chain_id = 10/)
+    assert.match(sql, /thing\.chain_id > \(SELECT chain_id FROM cursor\)/)
+    assert.match(sql, /ORDER BY .*lower\(thing\.address\) ASC, thing\.chain_id ASC/)
+    assert.deepEqual(params, ['vault', '0xABCDEF', null, 100])
+  })
+
+  it('coalesces one concurrent query and evicts it after success', async () => {
+    let resolve: (value: { rows: unknown[] }) => void = () => undefined
+    query.mockImplementationOnce(() => new Promise<{ rows: unknown[] }>(r => { resolve = r }))
+    const { default: vaults } = await import('./vaults')
+
+    const first = vaults({}, { chainId: 1 })
+    const second = vaults({}, { chainId: 1 })
+    assert.equal(query.mock.calls.length, 1)
+    resolve({ rows: [] })
+    await Promise.all([first, second])
+
+    query.mockResolvedValueOnce({ rows: [] })
+    await vaults({}, { chainId: 1 })
+    assert.equal(query.mock.calls.length, 2)
+  })
+
+  it('evicts a rejected query so a retry can run', async () => {
+    const { default: vaults } = await import('./vaults')
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    query.mockRejectedValueOnce(new Error('temporary'))
+    await assert.rejects(vaults({}, { chainId: 1 }))
+
+    query.mockResolvedValueOnce({ rows: [] })
+    await vaults({}, { chainId: 1 })
+    errorSpy.mockRestore()
+    assert.equal(query.mock.calls.length, 2)
+  })
 })

--- a/packages/web/app/api/gql/resolvers/vaults.spec.ts
+++ b/packages/web/app/api/gql/resolvers/vaults.spec.ts
@@ -24,43 +24,39 @@ describe('vaults resolver', () => {
 
   it('clamps limit into [1, 1000]', async () => {
     const low = await run({ chainId: 1, limit: -1 })
-    assert.equal(low.params.at(-1), 1)
+    assert.equal(low.params.at(-2), 1)
 
     query.mockReset()
     const high = await run({ chainId: 1, limit: 1_000_000 })
-    assert.equal(high.params.at(-1), 1000)
+    assert.equal(high.params.at(-2), 1000)
 
     query.mockReset()
     const dflt = await run({ chainId: 1 })
-    assert.equal(dflt.params.at(-1), 100)
+    assert.equal(dflt.params.at(-2), 100)
   })
 
-  it('advances past the cursor tie group instead of re-serving it', async () => {
-    const { sql } = await run({ chainId: 1, after: '0xAbC' })
-    const tvl = 'COALESCE((snapshot.hook->\'tvl\'->>\'close\')::numeric, 0)'
-    assert.equal(sql.includes(`${tvl} < (SELECT tvl FROM cursor)`), true)
-    assert.equal(sql.includes('lower(thing.address) > (SELECT address FROM cursor)'), true)
-    // the row-comparison form admitted every same-tvl row with a smaller address
-    assert.equal(sql.includes('thing.address) < (SELECT tvl, address FROM cursor)'), false)
+  it('clamps offset to zero or more', async () => {
+    const negative = await run({ chainId: 1, offset: -5 })
+    assert.equal(negative.params.at(-1), 0)
+
+    query.mockReset()
+    const dflt = await run({ chainId: 1 })
+    assert.equal(dflt.params.at(-1), 0)
+
+    query.mockReset()
+    const given = await run({ chainId: 1, offset: 50 })
+    assert.equal(given.params.at(-1), 50)
   })
 
-  it('orders on the same expression the cursor compares', async () => {
+  it('binds limit and offset as the last two params', async () => {
+    const { sql, params } = await run({ chainId: 1, limit: 50, offset: 50 })
+    assert.match(sql, /LIMIT \$3 OFFSET \$4/)
+    assert.deepEqual(params, ['vault', 1, 50, 50])
+  })
+
+  it('orders by tvl, then chain, then address', async () => {
     const { sql } = await run({ chainId: 1 })
-    assert.equal(sql.includes('ORDER BY COALESCE((snapshot.hook->\'tvl\'->>\'close\')::numeric, 0) DESC, lower(thing.address) ASC'), true)
-  })
-
-  it('resolves the cursor case-insensitively and binds chainId explicitly', async () => {
-    const { sql, params } = await run({ chainId: 10, after: '0xABCDEF' })
-    assert.equal(sql.includes('lower(thing.address) = lower($3)'), true)
-    assert.equal(sql.includes('$4::int IS NULL OR thing.chain_id = $4::int'), true)
-    assert.deepEqual(params, ['vault', 10, '0xABCDEF', 10, 100])
-  })
-
-  it('treats omitted chainId as all chains', async () => {
-    const { sql, params } = await run({ after: '0xABCDEF' })
-    assert.equal(sql.includes('thing.chain_id = $2'), false)
-    assert.equal(sql.includes('$3::int IS NULL OR thing.chain_id = $3::int'), true)
-    assert.deepEqual(params, ['vault', '0xABCDEF', null, 100])
+    assert.equal(sql.includes('ORDER BY COALESCE((snapshot.hook->\'tvl\'->>\'close\')::numeric, 0) DESC, thing.chain_id ASC, lower(thing.address) ASC'), true)
   })
 
   it('treats a null chainId like an omitted chainId', async () => {
@@ -69,42 +65,5 @@ describe('vaults resolver', () => {
     const nullable = await run({ chainId: null })
     assert.equal(nullable.sql, omitted.sql)
     assert.deepEqual(nullable.params, omitted.params)
-  })
-
-  it('uses the chain in an all-chain cursor to disambiguate same-address vaults', async () => {
-    const { sql, params } = await run({ after: '10:0xABCDEF' })
-    assert.match(sql, /lower\(thing\.address\) = lower\(\$2\)/)
-    assert.match(sql, /AND thing\.chain_id = 10/)
-    assert.match(sql, /thing\.chain_id > \(SELECT chain_id FROM cursor\)/)
-    assert.match(sql, /ORDER BY .*lower\(thing\.address\) ASC, thing\.chain_id ASC/)
-    assert.deepEqual(params, ['vault', '0xABCDEF', null, 100])
-  })
-
-  it('coalesces one concurrent query and evicts it after success', async () => {
-    let resolve: (value: { rows: unknown[] }) => void = () => undefined
-    query.mockImplementationOnce(() => new Promise<{ rows: unknown[] }>(r => { resolve = r }))
-    const { default: vaults } = await import('./vaults')
-
-    const first = vaults({}, { chainId: 1 })
-    const second = vaults({}, { chainId: 1 })
-    assert.equal(query.mock.calls.length, 1)
-    resolve({ rows: [] })
-    await Promise.all([first, second])
-
-    query.mockResolvedValueOnce({ rows: [] })
-    await vaults({}, { chainId: 1 })
-    assert.equal(query.mock.calls.length, 2)
-  })
-
-  it('evicts a rejected query so a retry can run', async () => {
-    const { default: vaults } = await import('./vaults')
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
-    query.mockRejectedValueOnce(new Error('temporary'))
-    await assert.rejects(vaults({}, { chainId: 1 }))
-
-    query.mockResolvedValueOnce({ rows: [] })
-    await vaults({}, { chainId: 1 })
-    errorSpy.mockRestore()
-    assert.equal(query.mock.calls.length, 2)
   })
 })

--- a/packages/web/app/api/gql/resolvers/vaults.spec.ts
+++ b/packages/web/app/api/gql/resolvers/vaults.spec.ts
@@ -52,7 +52,14 @@ describe('vaults resolver', () => {
   it('resolves the cursor case-insensitively and binds chainId explicitly', async () => {
     const { sql, params } = await run({ chainId: 10, after: '0xABCDEF' })
     assert.equal(sql.includes('lower(thing.address) = lower($3)'), true)
-    assert.equal(sql.includes('thing.chain_id = $4::int'), true)
+    assert.equal(sql.includes('$4::int IS NULL OR thing.chain_id = $4::int'), true)
     assert.deepEqual(params, ['vault', 10, '0xABCDEF', 10, 100])
+  })
+
+  it('treats omitted chainId as all chains', async () => {
+    const { sql, params } = await run({ after: '0xABCDEF' })
+    assert.equal(sql.includes('thing.chain_id = $2'), false)
+    assert.equal(sql.includes('$3::int IS NULL OR thing.chain_id = $3::int'), true)
+    assert.deepEqual(params, ['vault', '0xABCDEF', null, 100])
   })
 })

--- a/packages/web/app/api/gql/resolvers/vaults.ts
+++ b/packages/web/app/api/gql/resolvers/vaults.ts
@@ -8,9 +8,30 @@ const tvl = 'COALESCE((snapshot.hook->\'tvl\'->>\'close\')::numeric, 0)'
 const DEFAULT_LIMIT = 100
 const MAX_LIMIT = 1000
 
-type VaultsArgs = VaultFilterArgs & { limit?: number, after?: string }
+type VaultsArgs = VaultFilterArgs & { limit?: number, after?: string | null }
 
 const inflight = new Map<string, Promise<unknown[]>>()
+
+type VaultCursor = { address: string, chainId?: number }
+
+/**
+ * Cursors are chainId:address when paging across all chains. Keep accepting
+ * the historical address-only form for callers that scope the query to one
+ * chain (and for backwards compatibility).
+ */
+export const parseVaultCursor = (after?: string | null): VaultCursor | undefined => {
+  if (after == null || after === '') return undefined
+  const separator = after.indexOf(':')
+  if (separator > 0 && /^\d+$/.test(after.slice(0, separator))) {
+    const chainId = Number(after.slice(0, separator))
+    if (Number.isSafeInteger(chainId)) {
+      return { chainId, address: after.slice(separator + 1) }
+    }
+  }
+  return { address: after }
+}
+
+export const formatVaultCursor = (chainId: number, address: string) => `${chainId}:${address}`
 
 const vaults = (_: object, args: VaultsArgs) => {
   const key = JSON.stringify(args)
@@ -24,18 +45,22 @@ const vaults = (_: object, args: VaultsArgs) => {
 const query = async (args: VaultsArgs) => {
   try {
     const { where, params } = buildVaultFilters(args)
+    const cursor = parseVaultCursor(args.after)
     params.push(
-      args.after ?? null,
+      cursor?.address ?? null,
       args.chainId ?? null,
       Math.min(Math.max(args.limit ?? DEFAULT_LIMIT, 1), MAX_LIMIT)
     )
     const after = `$${params.length - 2}`
     const chain = `$${params.length - 1}`
     const limit = `$${params.length}`
+    const cursorChainFilter = cursor?.chainId === undefined
+      ? ''
+      : `\n        AND thing.chain_id = ${cursor.chainId}`
 
     const result = await db.query(`
     WITH cursor AS (
-      SELECT ${tvl} AS tvl, lower(thing.address) AS address
+      SELECT ${tvl} AS tvl, lower(thing.address) AS address, thing.chain_id
       FROM thing
       JOIN snapshot
         ON thing.chain_id = snapshot.chain_id
@@ -43,7 +68,8 @@ const query = async (args: VaultsArgs) => {
       WHERE thing.label = $1
         AND (${chain}::int IS NULL OR thing.chain_id = ${chain}::int)
         AND lower(thing.address) = lower(${after})
-      ORDER BY ${tvl} DESC, lower(thing.address) ASC
+        ${cursorChainFilter}
+      ORDER BY ${tvl} DESC, lower(thing.address) ASC, thing.chain_id ASC
       LIMIT 1
     )
     SELECT
@@ -58,8 +84,10 @@ const query = async (args: VaultsArgs) => {
       AND (${after}::text IS NULL
         OR ${tvl} < (SELECT tvl FROM cursor)
         OR (${tvl} = (SELECT tvl FROM cursor)
-          AND lower(thing.address) > (SELECT address FROM cursor)))
-    ORDER BY ${tvl} DESC, lower(thing.address) ASC
+          AND (lower(thing.address) > (SELECT address FROM cursor)
+            OR (lower(thing.address) = (SELECT address FROM cursor)
+              AND thing.chain_id > (SELECT chain_id FROM cursor)))))
+    ORDER BY ${tvl} DESC, lower(thing.address) ASC, thing.chain_id ASC
     LIMIT ${limit}`,
     params)
 

--- a/packages/web/app/api/gql/resolvers/vaults.ts
+++ b/packages/web/app/api/gql/resolvers/vaults.ts
@@ -41,8 +41,10 @@ const query = async (args: VaultsArgs) => {
         ON thing.chain_id = snapshot.chain_id
         AND thing.address = snapshot.address
       WHERE thing.label = $1
-        AND thing.chain_id = ${chain}::int
+        AND (${chain}::int IS NULL OR thing.chain_id = ${chain}::int)
         AND lower(thing.address) = lower(${after})
+      ORDER BY ${tvl} DESC, lower(thing.address) ASC
+      LIMIT 1
     )
     SELECT
       thing.chain_id,

--- a/packages/web/app/api/gql/resolvers/vaults.ts
+++ b/packages/web/app/api/gql/resolvers/vaults.ts
@@ -22,17 +22,17 @@ const vaults = (_: object, args: VaultsArgs) => {
 }
 
 const query = async (args: VaultsArgs) => {
-  const { where, params } = buildVaultFilters(args)
-  params.push(
-    args.after ?? null,
-    args.chainId ?? null,
-    Math.min(Math.max(args.limit ?? DEFAULT_LIMIT, 1), MAX_LIMIT)
-  )
-  const after = `$${params.length - 2}`
-  const chain = `$${params.length - 1}`
-  const limit = `$${params.length}`
-
   try {
+    const { where, params } = buildVaultFilters(args)
+    params.push(
+      args.after ?? null,
+      args.chainId ?? null,
+      Math.min(Math.max(args.limit ?? DEFAULT_LIMIT, 1), MAX_LIMIT)
+    )
+    const after = `$${params.length - 2}`
+    const chain = `$${params.length - 1}`
+    const limit = `$${params.length}`
+
     const result = await db.query(`
     WITH cursor AS (
       SELECT ${tvl} AS tvl, lower(thing.address) AS address

--- a/packages/web/app/api/gql/resolvers/vaults.ts
+++ b/packages/web/app/api/gql/resolvers/vaults.ts
@@ -1,121 +1,60 @@
 import db from '@/app/api/db'
-import { compare } from '@/lib/compare'
-import { mergeSnapshot, SnapshotRow } from '@/lib/mergeSnapshot'
-import { DefaultRiskScore, EvmAddressSchema } from 'lib/types'
+import { mergeSnapshotSql, VAULT_UNSERVED_KEYS } from '@/lib/mergeSnapshot'
+import { buildVaultFilters, VaultFilterArgs } from '@/lib/vaultFilters'
+import { DefaultRiskScore } from 'lib/types'
 
-type VaultRow = SnapshotRow & { risk: typeof DefaultRiskScore }
+const tvl = 'COALESCE((snapshot.hook->\'tvl\'->>\'close\')::numeric, 0)'
 
-const vaults = async (_: object, args: {
-  chainId?: number,
-  apiVersion?: string,
-  erc4626?: boolean,
-  v3?: boolean,
-  yearn?: boolean,
-  origin?: string,
-  addresses?: string[],
-  vaultType?: number,
-  riskLevel?: number,
-  unratedOnly?: boolean
-}) => {
-  const { chainId, apiVersion, erc4626, v3, yearn, origin, addresses: rawAddresses, vaultType, riskLevel, unratedOnly } = args
+type VaultsArgs = VaultFilterArgs & { limit?: number, after?: string }
+
+const inflight = new Map<string, Promise<unknown[]>>()
+
+const vaults = (_: object, args: VaultsArgs) => {
+  const key = JSON.stringify(args)
+  const hit = inflight.get(key)
+  if (hit) return hit
+  const p = query(args).finally(() => inflight.delete(key))
+  inflight.set(key, p)
+  return p
+}
+
+const query = async (args: VaultsArgs) => {
+  const { where, params } = buildVaultFilters(args)
+  params.push(args.after ?? null, args.limit ?? 100)
+  const after = `$${params.length - 1}`
+  const limit = `$${params.length}`
 
   try {
-
     const result = await db.query(`
+    WITH cursor AS (
+      SELECT ${tvl} AS tvl, thing.address
+      FROM thing
+      JOIN snapshot
+        ON thing.chain_id = snapshot.chain_id
+        AND thing.address = snapshot.address
+      WHERE thing.label = $1 AND thing.chain_id = $2 AND thing.address = ${after}
+    )
     SELECT
       thing.chain_id,
       thing.address,
-      thing.defaults,
-      snapshot.snapshot,
-      snapshot.hook
+      ${mergeSnapshotSql(VAULT_UNSERVED_KEYS)} AS merged
     FROM thing
     JOIN snapshot
       ON thing.chain_id = snapshot.chain_id
       AND thing.address = snapshot.address
-    WHERE thing.label = $1 AND (thing.chain_id = $2 OR $2 IS NULL)
-    ORDER BY (snapshot.hook->'tvl'->>'close')::numeric DESC`,
-    ['vault', chainId])
+    WHERE ${where}
+      AND (${after}::text IS NULL OR (${tvl}, thing.address) < (SELECT tvl, address FROM cursor)
+        OR (${tvl} = (SELECT tvl FROM cursor) AND thing.address > (SELECT address FROM cursor)))
+    ORDER BY ${tvl} DESC, thing.address ASC
+    LIMIT ${limit}`,
+    params)
 
-    let rows: VaultRow[] = result.rows.map(row => ({
+    return result.rows.map(row => ({
       chainId: row.chain_id,
       address: row.address,
-      ...mergeSnapshot(row.defaults, row.snapshot, row.hook),
-      risk: row.hook.risk ?? DefaultRiskScore
+      ...row.merged,
+      risk: row.merged.risk ?? DefaultRiskScore
     }))
-
-    if (rawAddresses !== undefined) {
-      const validAddressesLowerCase: string[] = []
-
-      for (const rawAddress of rawAddresses) {
-        const address = EvmAddressSchema.safeParse(rawAddress)
-        if (address.success) { validAddressesLowerCase.push(address.data.toLowerCase()) }
-      }
-
-      rows = rows.filter(row => {
-        return validAddressesLowerCase.includes(row.address.toLowerCase())
-      })
-    }
-
-    if (apiVersion !== undefined) {
-      rows = rows.filter(row => {
-        const rowApiVersion = row.apiVersion
-        return compare(typeof rowApiVersion === 'string' ? rowApiVersion : '0', apiVersion, '>=')
-      })
-    }
-
-    if (erc4626 !== undefined) {
-      rows = rows.filter(row => {
-        return Boolean(row.erc4626 ?? false) === erc4626
-      })
-    }
-
-    if (v3 !== undefined) {
-      rows = rows.filter(row => {
-        return Boolean(row.v3 ?? false) === v3
-      })
-    }
-
-    if (yearn !== undefined) {
-      rows = rows.filter(row => {
-        if (yearn === true) {
-          return Boolean(row.yearn ?? false) === true || row.origin === 'yearn'
-        } else {
-          return Boolean(row.yearn ?? false) === false || row.origin !== 'yearn'
-        }
-      })
-    }
-
-    if (origin !== undefined) {
-      if (origin === 'yearn') {
-        rows = rows.filter(row => {
-          return Boolean(row.yearn ?? false) === true || row.origin === 'yearn'
-        })
-      } else {
-        rows = rows.filter(row => {
-          return row.origin === origin
-        })
-      }
-    }
-
-    if (vaultType !== undefined) {
-      rows = rows.filter(row => {
-        return Number(row.vaultType ?? 0) === vaultType
-      })
-    }
-
-    if (unratedOnly === true) {
-      rows = rows.filter(row => {
-        return row.risk?.riskLevel === undefined || row.risk?.riskLevel === 0
-      })
-    } else if (riskLevel !== undefined) {
-      rows = rows.filter(row => {
-        const rowRiskLevel = row.risk?.riskLevel
-        return rowRiskLevel !== undefined && rowRiskLevel > 0 && rowRiskLevel <= riskLevel
-      })
-    }
-
-    return rows
-
   } catch (error) {
     console.error(error)
     throw new Error('!vaults')

--- a/packages/web/app/api/gql/resolvers/vaults.ts
+++ b/packages/web/app/api/gql/resolvers/vaults.ts
@@ -8,70 +8,19 @@ const tvl = 'COALESCE((snapshot.hook->\'tvl\'->>\'close\')::numeric, 0)'
 const DEFAULT_LIMIT = 100
 const MAX_LIMIT = 1000
 
-type VaultsArgs = VaultFilterArgs & { limit?: number, after?: string | null }
+type VaultsArgs = VaultFilterArgs & { limit?: number | null, offset?: number | null }
 
-const inflight = new Map<string, Promise<unknown[]>>()
-
-type VaultCursor = { address: string, chainId?: number }
-
-/**
- * Cursors are chainId:address when paging across all chains. Keep accepting
- * the historical address-only form for callers that scope the query to one
- * chain (and for backwards compatibility).
- */
-export const parseVaultCursor = (after?: string | null): VaultCursor | undefined => {
-  if (after == null || after === '') return undefined
-  const separator = after.indexOf(':')
-  if (separator > 0 && /^\d+$/.test(after.slice(0, separator))) {
-    const chainId = Number(after.slice(0, separator))
-    if (Number.isSafeInteger(chainId)) {
-      return { chainId, address: after.slice(separator + 1) }
-    }
-  }
-  return { address: after }
-}
-
-export const formatVaultCursor = (chainId: number, address: string) => `${chainId}:${address}`
-
-const vaults = (_: object, args: VaultsArgs) => {
-  const key = JSON.stringify(args)
-  const hit = inflight.get(key)
-  if (hit) return hit
-  const p = query(args).finally(() => inflight.delete(key))
-  inflight.set(key, p)
-  return p
-}
-
-const query = async (args: VaultsArgs) => {
+export default async (_: object, args: VaultsArgs) => {
   try {
     const { where, params } = buildVaultFilters(args)
-    const cursor = parseVaultCursor(args.after)
     params.push(
-      cursor?.address ?? null,
-      args.chainId ?? null,
-      Math.min(Math.max(args.limit ?? DEFAULT_LIMIT, 1), MAX_LIMIT)
+      Math.min(Math.max(args.limit ?? DEFAULT_LIMIT, 1), MAX_LIMIT),
+      Math.max(args.offset ?? 0, 0)
     )
-    const after = `$${params.length - 2}`
-    const chain = `$${params.length - 1}`
-    const limit = `$${params.length}`
-    const cursorChainFilter = cursor?.chainId === undefined
-      ? ''
-      : `\n        AND thing.chain_id = ${cursor.chainId}`
+    const limit = `$${params.length - 1}`
+    const offset = `$${params.length}`
 
     const result = await db.query(`
-    WITH cursor AS (
-      SELECT ${tvl} AS tvl, lower(thing.address) AS address, thing.chain_id
-      FROM thing
-      JOIN snapshot
-        ON thing.chain_id = snapshot.chain_id
-        AND thing.address = snapshot.address
-      WHERE thing.label = $1
-        AND (${chain}::int IS NULL OR thing.chain_id = ${chain}::int)
-        AND lower(thing.address) = lower(${after})
-        ${cursorChainFilter}
-      ORDER BY ${tvl} DESC, lower(thing.address) ASC, thing.chain_id ASC
-      LIMIT 1
-    )
     SELECT
       thing.chain_id,
       thing.address,
@@ -81,14 +30,8 @@ const query = async (args: VaultsArgs) => {
       ON thing.chain_id = snapshot.chain_id
       AND thing.address = snapshot.address
     WHERE ${where}
-      AND (${after}::text IS NULL
-        OR ${tvl} < (SELECT tvl FROM cursor)
-        OR (${tvl} = (SELECT tvl FROM cursor)
-          AND (lower(thing.address) > (SELECT address FROM cursor)
-            OR (lower(thing.address) = (SELECT address FROM cursor)
-              AND thing.chain_id > (SELECT chain_id FROM cursor)))))
-    ORDER BY ${tvl} DESC, lower(thing.address) ASC, thing.chain_id ASC
-    LIMIT ${limit}`,
+    ORDER BY ${tvl} DESC, thing.chain_id ASC, lower(thing.address) ASC
+    LIMIT ${limit} OFFSET ${offset}`,
     params)
 
     return result.rows.map(row => ({
@@ -102,5 +45,3 @@ const query = async (args: VaultsArgs) => {
     throw new Error('!vaults')
   }
 }
-
-export default vaults

--- a/packages/web/app/api/gql/resolvers/vaults.ts
+++ b/packages/web/app/api/gql/resolvers/vaults.ts
@@ -5,6 +5,9 @@ import { DefaultRiskScore } from 'lib/types'
 
 const tvl = 'COALESCE((snapshot.hook->\'tvl\'->>\'close\')::numeric, 0)'
 
+const DEFAULT_LIMIT = 100
+const MAX_LIMIT = 1000
+
 type VaultsArgs = VaultFilterArgs & { limit?: number, after?: string }
 
 const inflight = new Map<string, Promise<unknown[]>>()
@@ -20,19 +23,26 @@ const vaults = (_: object, args: VaultsArgs) => {
 
 const query = async (args: VaultsArgs) => {
   const { where, params } = buildVaultFilters(args)
-  params.push(args.after ?? null, args.limit ?? 100)
-  const after = `$${params.length - 1}`
+  params.push(
+    args.after ?? null,
+    args.chainId ?? null,
+    Math.min(Math.max(args.limit ?? DEFAULT_LIMIT, 1), MAX_LIMIT)
+  )
+  const after = `$${params.length - 2}`
+  const chain = `$${params.length - 1}`
   const limit = `$${params.length}`
 
   try {
     const result = await db.query(`
     WITH cursor AS (
-      SELECT ${tvl} AS tvl, thing.address
+      SELECT ${tvl} AS tvl, lower(thing.address) AS address
       FROM thing
       JOIN snapshot
         ON thing.chain_id = snapshot.chain_id
         AND thing.address = snapshot.address
-      WHERE thing.label = $1 AND thing.chain_id = $2 AND thing.address = ${after}
+      WHERE thing.label = $1
+        AND thing.chain_id = ${chain}::int
+        AND lower(thing.address) = lower(${after})
     )
     SELECT
       thing.chain_id,
@@ -43,9 +53,11 @@ const query = async (args: VaultsArgs) => {
       ON thing.chain_id = snapshot.chain_id
       AND thing.address = snapshot.address
     WHERE ${where}
-      AND (${after}::text IS NULL OR (${tvl}, thing.address) < (SELECT tvl, address FROM cursor)
-        OR (${tvl} = (SELECT tvl FROM cursor) AND thing.address > (SELECT address FROM cursor)))
-    ORDER BY ${tvl} DESC, thing.address ASC
+      AND (${after}::text IS NULL
+        OR ${tvl} < (SELECT tvl FROM cursor)
+        OR (${tvl} = (SELECT tvl FROM cursor)
+          AND lower(thing.address) > (SELECT address FROM cursor)))
+    ORDER BY ${tvl} DESC, lower(thing.address) ASC
     LIMIT ${limit}`,
     params)
 

--- a/packages/web/app/api/gql/route.ts
+++ b/packages/web/app/api/gql/route.ts
@@ -1,22 +1,22 @@
 import { ApolloServer } from '@apollo/server'
-import { startServerAndCreateNextHandler } from '@as-integrations/next'
 import { ApolloServerPluginCacheControl } from '@apollo/server/plugin/cacheControl'
 import { ApolloServerPluginLandingPageLocalDefault } from '@apollo/server/plugin/landingPage/default'
-import responseCachePlugin from './responseCachePlugin'
-import typeDefs from './typeDefs'
-import resolvers from './resolvers'
+import { startServerAndCreateNextHandler } from '@as-integrations/next'
+import KeyvRedis from '@keyv/redis'
+import Keyv from 'keyv'
 import { NextRequest } from 'next/server'
 import { CORS_HEADERS } from '../headers'
 import { CustomKeyvAdapter } from './CustomKeyvAdapter'
-import Keyv from 'keyv'
-import KeyvRedis from '@keyv/redis'
+import resolvers from './resolvers'
+import responseCachePlugin from './responseCachePlugin'
+import typeDefs from './typeDefs'
 
 const enableCache = process.env.GQL_ENABLE_CACHE === 'true'
 const defaultCacheMaxAge = Number(process.env.GQL_DEFAULT_CACHE_MAX_AGE || 60 * 5)
 const redisUrl = process.env.GQL_CACHE_REDIS_URL || 'redis://localhost:6379'
 
 const defaultQuery = `query Query {
-  vaults {
+  vaults(chainId: 1) {
     chainId
     address
     name
@@ -57,4 +57,5 @@ async function OPTIONS() {
   return response
 }
 
-export { respondTo as GET, respondTo as POST, OPTIONS }
+export { respondTo as GET, OPTIONS, respondTo as POST }
+

--- a/packages/web/app/api/gql/typeDefs/index.ts
+++ b/packages/web/app/api/gql/typeDefs/index.ts
@@ -40,8 +40,8 @@ const query = gql`
     latestBlocks(chainId: Int): [LatestBlock] @cacheControl(maxAge: 2)
     monitor: Monitor @cacheControl(maxAge: 2)
     allocator(chainId: Int!, vault: String!): Allocator
-    vaults(chainId: Int, apiVersion: String, erc4626: Boolean, v3: Boolean, yearn: Boolean, origin: String, addresses: [String], vaultType: Int, riskLevel: Int, unratedOnly: Boolean): [Vault]
-    vault(chainId: Int, address: String): Vault @cacheControl(maxAge: 3000)
+    vaults(chainId: Int!, apiVersion: String, erc4626: Boolean, v3: Boolean, yearn: Boolean, origin: String, addresses: [String], vaultType: Int, riskLevel: Int, unratedOnly: Boolean, limit: Int = 100, after: String): [Vault] @cacheControl(maxAge: 300)
+    vault(chainId: Int, address: String): Vault @cacheControl(maxAge: 300)
     vaultAccounts(chainId: Int, vault: String): [AccountRole]
     vaultReports(chainId: Int, address: String): [VaultReport]
     vaultStrategies(chainId: Int, vault: String): [Strategy]
@@ -53,7 +53,7 @@ const query = gql`
     strategyReports(chainId: Int, address: String): [StrategyReport]
     transfers(chainId: Int, address: String): [Transfer]
     deposits(chainId: Int, address: String): [Deposit]
-    timeseries(chainId: Int, address: String, label: String!, component: String, period: String, limit: Int, timestamp: BigInt, yearn: Boolean): [Output]
+    timeseries(chainId: Int, address: String, label: String!, component: String, period: String, limit: Int, timestamp: BigInt, yearn: Boolean): [Output] @cacheControl(maxAge: 300)
     tvls(chainId: Int!, address: String, period: String, limit: Int, timestamp: BigInt): [Tvl]
     accountRoles(chainId: Int, account: String!): [AccountRole]
     accountVaults(chainId: Int, account: String!): [Vault]

--- a/packages/web/app/api/gql/typeDefs/index.ts
+++ b/packages/web/app/api/gql/typeDefs/index.ts
@@ -40,7 +40,25 @@ const query = gql`
     latestBlocks(chainId: Int): [LatestBlock] @cacheControl(maxAge: 2)
     monitor: Monitor @cacheControl(maxAge: 2)
     allocator(chainId: Int!, vault: String!): Allocator
-    vaults(chainId: Int, apiVersion: String, erc4626: Boolean, v3: Boolean, yearn: Boolean, origin: String, addresses: [String], vaultType: Int, riskLevel: Int, unratedOnly: Boolean, limit: Int = 100, after: String): [Vault] @cacheControl(maxAge: 300)
+    vaults(
+      chainId: Int
+      apiVersion: String
+      erc4626: Boolean
+      v3: Boolean
+      yearn: Boolean
+      origin: String
+      addresses: [String]
+      vaultType: Int
+      riskLevel: Int
+      unratedOnly: Boolean
+      limit: Int = 100
+      """
+      Address of the last vault from the previous page. Repeat the same filters until a page comes back empty.
+
+      Example: vaults(chainId: 1, limit: 100, after: "0x6FAF8b7c34C1...")
+      """
+      after: String
+    ): [Vault] @cacheControl(maxAge: 300)
     vault(chainId: Int, address: String): Vault @cacheControl(maxAge: 300)
     vaultAccounts(chainId: Int, vault: String): [AccountRole]
     vaultReports(chainId: Int, address: String): [VaultReport]

--- a/packages/web/app/api/gql/typeDefs/index.ts
+++ b/packages/web/app/api/gql/typeDefs/index.ts
@@ -52,14 +52,7 @@ const query = gql`
       riskLevel: Int
       unratedOnly: Boolean
       limit: Int = 100
-      """
-      Address of the last vault from the previous page. When chainId is omitted,
-      include the chain as chainId:address so the cursor is unambiguous.
-      Repeat the same filters until a page comes back empty.
-
-      Example: vaults(chainId: 1, limit: 100, after: "0x6FAF8b7c34C1...")
-      """
-      after: String
+      offset: Int = 0
     ): [Vault] @cacheControl(maxAge: 300)
     vault(chainId: Int, address: String): Vault @cacheControl(maxAge: 300)
     vaultAccounts(chainId: Int, vault: String): [AccountRole]

--- a/packages/web/app/api/gql/typeDefs/index.ts
+++ b/packages/web/app/api/gql/typeDefs/index.ts
@@ -40,7 +40,7 @@ const query = gql`
     latestBlocks(chainId: Int): [LatestBlock] @cacheControl(maxAge: 2)
     monitor: Monitor @cacheControl(maxAge: 2)
     allocator(chainId: Int!, vault: String!): Allocator
-    vaults(chainId: Int!, apiVersion: String, erc4626: Boolean, v3: Boolean, yearn: Boolean, origin: String, addresses: [String], vaultType: Int, riskLevel: Int, unratedOnly: Boolean, limit: Int = 100, after: String): [Vault] @cacheControl(maxAge: 300)
+    vaults(chainId: Int, apiVersion: String, erc4626: Boolean, v3: Boolean, yearn: Boolean, origin: String, addresses: [String], vaultType: Int, riskLevel: Int, unratedOnly: Boolean, limit: Int = 100, after: String): [Vault] @cacheControl(maxAge: 300)
     vault(chainId: Int, address: String): Vault @cacheControl(maxAge: 300)
     vaultAccounts(chainId: Int, vault: String): [AccountRole]
     vaultReports(chainId: Int, address: String): [VaultReport]

--- a/packages/web/app/api/gql/typeDefs/index.ts
+++ b/packages/web/app/api/gql/typeDefs/index.ts
@@ -53,7 +53,9 @@ const query = gql`
       unratedOnly: Boolean
       limit: Int = 100
       """
-      Address of the last vault from the previous page. Repeat the same filters until a page comes back empty.
+      Address of the last vault from the previous page. When chainId is omitted,
+      include the chain as chainId:address so the cursor is unambiguous.
+      Repeat the same filters until a page comes back empty.
 
       Example: vaults(chainId: 1, limit: 100, after: "0x6FAF8b7c34C1...")
       """

--- a/packages/web/lib/mergeSnapshot.spec.ts
+++ b/packages/web/lib/mergeSnapshot.spec.ts
@@ -1,8 +1,20 @@
 import { strict as assert } from 'node:assert'
 import { describe, it } from 'vitest'
-import { mergeSnapshot } from './mergeSnapshot'
+import { mergeSnapshot, mergeSnapshotSql } from './mergeSnapshot'
 
 describe('mergeSnapshot', () => {
+  it('keeps SQL blob precedence and hook asset override aligned with mergeSnapshot', () => {
+    const sql = mergeSnapshotSql(['composition'])
+    const defaults = 'COALESCE(thing.defaults, \'{}\')'
+    const hook = 'COALESCE(snapshot.hook, \'{}\')'
+    const snapshot = 'COALESCE(snapshot.snapshot, \'{}\')'
+
+    assert.ok(sql.indexOf(defaults) < sql.indexOf(hook))
+    assert.ok(sql.indexOf(hook) < sql.indexOf(snapshot))
+    assert.match(sql, /jsonb_strip_nulls\(jsonb_build_object\('asset', snapshot\.hook->'asset'\)\)/)
+    assert.match(sql, /- ARRAY\['composition'\]::text\[\]/)
+  })
+
   it('lets contract state override stale hook keys while retaining hook-only data', () => {
     const result = mergeSnapshot(
       { origin: 'yearn', defaultOnly: true },

--- a/packages/web/lib/mergeSnapshot.ts
+++ b/packages/web/lib/mergeSnapshot.ts
@@ -26,7 +26,12 @@ export const VAULT_UNSERVED_KEYS = [
   'pendingManagement', 'performanceFeeRecipient', 'roleManager', 'vaults', 'MAX_FEE', 'MIN_FEE'
 ]
 
+const MERGED_BLOBS =
+  '(COALESCE(thing.defaults, \'{}\') || COALESCE(snapshot.hook, \'{}\') || COALESCE(snapshot.snapshot, \'{}\'))'
+
+export const mergedFieldSql = (key: string) => `(${MERGED_BLOBS}->>'${key}')`
+
 export const mergeSnapshotSql = (omit: string[] = []) =>
-  `(COALESCE(thing.defaults, '{}') || COALESCE(snapshot.hook, '{}') || COALESCE(snapshot.snapshot, '{}')
+  `(${MERGED_BLOBS}
     || COALESCE(jsonb_strip_nulls(jsonb_build_object('asset', snapshot.hook->'asset')), '{}'))
     - ARRAY[${omit.map(k => `'${k}'`).join(', ')}]::text[]`

--- a/packages/web/lib/mergeSnapshot.ts
+++ b/packages/web/lib/mergeSnapshot.ts
@@ -31,6 +31,8 @@ const MERGED_BLOBS =
 
 export const mergedFieldSql = (key: string) => `(${MERGED_BLOBS}->>'${key}')`
 
+export const mergedJsonSql = (key: string) => `(${MERGED_BLOBS}->'${key}')`
+
 export const mergeSnapshotSql = (omit: string[] = []) =>
   `(${MERGED_BLOBS}
     || COALESCE(jsonb_strip_nulls(jsonb_build_object('asset', snapshot.hook->'asset')), '{}'))

--- a/packages/web/lib/mergeSnapshot.ts
+++ b/packages/web/lib/mergeSnapshot.ts
@@ -20,3 +20,13 @@ export function mergeSnapshot(defaults: Blob, snapshot: Blob, hook: Blob): Recor
     ...(hook?.asset != null ? { asset: hook.asset } : {}),
   }
 }
+
+export const VAULT_UNSERVED_KEYS = [
+  'composition', 'allocators', 'blockNumber', 'blockTime', 'factory', 'keeper',
+  'pendingManagement', 'performanceFeeRecipient', 'roleManager', 'vaults', 'MAX_FEE', 'MIN_FEE'
+]
+
+export const mergeSnapshotSql = (omit: string[] = []) =>
+  `(COALESCE(thing.defaults, '{}') || COALESCE(snapshot.hook, '{}') || COALESCE(snapshot.snapshot, '{}')
+    || COALESCE(jsonb_strip_nulls(jsonb_build_object('asset', snapshot.hook->'asset')), '{}'))
+    - ARRAY[${omit.map(k => `'${k}'`).join(', ')}]::text[]`

--- a/packages/web/lib/vaultFilters.spec.ts
+++ b/packages/web/lib/vaultFilters.spec.ts
@@ -49,6 +49,13 @@ describe('buildVaultFilters', () => {
     assert.deepEqual(params, ['vault'])
   })
 
+  it('apiVersion captures the whole version, not just the major', () => {
+    const { where } = buildVaultFilters({ apiVersion: '0.4.6' })
+    // a non-greedy prefix makes the whole RE non-greedy in postgres: '3.0.4' captured as '3'
+    assert.doesNotMatch(where, /\*\?/)
+    assert.match(where, /\^\[a-zA-Z\]\*\(/)
+  })
+
   it('apiVersion compares padded int arrays on both sides', () => {
     const { where, params } = buildVaultFilters({ apiVersion: '3.0' })
     assert.match(where, /'apiVersion'\) from .*\[1:3\] >= \(string_to_array.*\$2.*\[1:3\]/)

--- a/packages/web/lib/vaultFilters.spec.ts
+++ b/packages/web/lib/vaultFilters.spec.ts
@@ -23,6 +23,12 @@ describe('buildVaultFilters', () => {
     assert.deepEqual(params, ['vault', ['0xabcdefabcdefabcdefabcdefabcdefabcdefabcd']])
   })
 
+  it('drops 0x-prefixed non-addresses without throwing', () => {
+    const { where, params } = buildVaultFilters({ addresses: ['0xdead'] })
+    assert.match(where, /lower\(thing\.address\) = ANY\(\$2\)/)
+    assert.deepEqual(params, ['vault', []])
+  })
+
   it('yearn and origin=yearn share the isYearn clause', () => {
     const a = buildVaultFilters({ yearn: true })
     const b = buildVaultFilters({ origin: 'yearn' })

--- a/packages/web/lib/vaultFilters.spec.ts
+++ b/packages/web/lib/vaultFilters.spec.ts
@@ -9,6 +9,13 @@ describe('buildVaultFilters', () => {
     assert.deepEqual(params, ['vault'])
   })
 
+  it('treats an explicit null chainId like an omitted chainId', () => {
+    const omitted = buildVaultFilters({})
+    const nullable = buildVaultFilters({ chainId: null })
+    assert.equal(nullable.where, omitted.where)
+    assert.deepEqual(nullable.params, omitted.params)
+  })
+
   it('numbers params in order', () => {
     const { where, params } = buildVaultFilters({ chainId: 1, vaultType: 2, riskLevel: 3 })
     assert.match(where, /thing\.chain_id = \$2/)

--- a/packages/web/lib/vaultFilters.spec.ts
+++ b/packages/web/lib/vaultFilters.spec.ts
@@ -28,15 +28,22 @@ describe('buildVaultFilters', () => {
 
   it('filters risk on the same merged blob the resolver serves', () => {
     const { where } = buildVaultFilters({ riskLevel: 3 })
-    assert.match(where, /COALESCE\(thing\.defaults.*->'risk'\)->>'riskLevel'\)::numeric BETWEEN 1 AND \$2/)
+    assert.match(where, /COALESCE\(thing\.defaults.*->'risk'\)->'riskLevel' BETWEEN to_jsonb\(1\) AND to_jsonb\(\$2::numeric\)/)
     assert.doesNotMatch(where, /snapshot\.hook->'risk'/)
+  })
+
+  it('compares jsonb without text casts', () => {
+    const { where } = buildVaultFilters({ erc4626: true, v3: true, yearn: true, vaultType: 1, riskLevel: 2 })
+    assert.doesNotMatch(where, /\)::boolean/)
+    assert.doesNotMatch(where, /->>'vaultType'/)
+    assert.doesNotMatch(where, /->>'riskLevel'/)
   })
 
   it('numbers params in order', () => {
     const { where, params } = buildVaultFilters({ chainId: 1, vaultType: 2, riskLevel: 3 })
     assert.match(where, /thing\.chain_id = \$2/)
-    assert.match(where, /'vaultType'.*= \$3/)
-    assert.match(where, /BETWEEN 1 AND \$4/)
+    assert.match(where, /'vaultType'\).*to_jsonb\(\$3::numeric\)/)
+    assert.match(where, /BETWEEN to_jsonb\(1\) AND to_jsonb\(\$4::numeric\)/)
     assert.deepEqual(params, ['vault', 1, 2, 3])
   })
 
@@ -56,13 +63,13 @@ describe('buildVaultFilters', () => {
     const a = buildVaultFilters({ yearn: true })
     const b = buildVaultFilters({ origin: 'yearn' })
     assert.equal(a.where, b.where)
-    assert.match(a.where, /'yearn'\)::boolean, false\) OR .*'origin'\) = 'yearn'\)/)
+    assert.match(a.where, /'yearn'\) = to_jsonb\(true\)\) IS TRUE OR .*'origin'\) = 'yearn'\)/)
     assert.deepEqual(a.params, ['vault'])
   })
 
   it('yearn=false negates', () => {
     const { where } = buildVaultFilters({ yearn: false })
-    assert.match(where, /NOT COALESCE.*IS DISTINCT FROM 'yearn'/)
+    assert.match(where, /NOT \(.*'yearn'\) = to_jsonb\(true\)\) IS TRUE OR .*IS DISTINCT FROM 'yearn'/)
   })
 
   it('non-yearn origin is parameterized', () => {
@@ -73,7 +80,7 @@ describe('buildVaultFilters', () => {
 
   it('unratedOnly wins over riskLevel', () => {
     const { where, params } = buildVaultFilters({ unratedOnly: true, riskLevel: 3 })
-    assert.match(where, /riskLevel'\)::numeric, 0\) = 0/)
+    assert.match(where, /'riskLevel', '0'::jsonb\) = to_jsonb\(0\)/)
     assert.doesNotMatch(where, /BETWEEN/)
     assert.deepEqual(params, ['vault'])
   })

--- a/packages/web/lib/vaultFilters.spec.ts
+++ b/packages/web/lib/vaultFilters.spec.ts
@@ -85,7 +85,7 @@ describe('buildVaultFilters', () => {
     assert.match(where, /\^\[a-zA-Z\]\*\(/)
   })
 
-  it('apiVersion compares padded int arrays on both sides', () => {
+  it('apiVersion compares padded numeric arrays on both sides', () => {
     const { where, params } = buildVaultFilters({ apiVersion: '3.0' })
     assert.match(where, /'apiVersion'\) from .*\[1:3\] >= \(string_to_array.*\$2.*\[1:3\]/)
     assert.deepEqual(params, ['vault', '3.0'])

--- a/packages/web/lib/vaultFilters.spec.ts
+++ b/packages/web/lib/vaultFilters.spec.ts
@@ -39,6 +39,13 @@ describe('buildVaultFilters', () => {
     assert.doesNotMatch(where, /->>'riskLevel'/)
   })
 
+  it('matches vaultType as jsonb number or jsonb string', () => {
+    const { where, params } = buildVaultFilters({ vaultType: 1 })
+    assert.match(where, /COALESCE\(.*, '0'::jsonb\) IN \(to_jsonb\(\$2::numeric\), to_jsonb\(\$2::text\)\)/)
+    assert.doesNotMatch(where, /->'vaultType'\)::numeric/)
+    assert.deepEqual(params, ['vault', 1])
+  })
+
   it('numbers params in order', () => {
     const { where, params } = buildVaultFilters({ chainId: 1, vaultType: 2, riskLevel: 3 })
     assert.match(where, /thing\.chain_id = \$2/)

--- a/packages/web/lib/vaultFilters.spec.ts
+++ b/packages/web/lib/vaultFilters.spec.ts
@@ -1,0 +1,57 @@
+import { strict as assert } from 'node:assert'
+import { describe, it } from 'vitest'
+import { buildVaultFilters } from './vaultFilters'
+
+describe('buildVaultFilters', () => {
+  it('defaults to label filter only', () => {
+    const { where, params } = buildVaultFilters({})
+    assert.equal(where, 'thing.label = $1')
+    assert.deepEqual(params, ['vault'])
+  })
+
+  it('numbers params in order', () => {
+    const { where, params } = buildVaultFilters({ chainId: 1, vaultType: 2, riskLevel: 3 })
+    assert.match(where, /thing\.chain_id = \$2/)
+    assert.match(where, /'vaultType'.*= \$3/)
+    assert.match(where, /BETWEEN 1 AND \$4/)
+    assert.deepEqual(params, ['vault', 1, 2, 3])
+  })
+
+  it('lowercases valid addresses and drops invalid ones', () => {
+    const { where, params } = buildVaultFilters({ addresses: ['0xABCDEFABCDEFABCDEFABCDEFABCDEFABCDEFABCD', 'nope'] })
+    assert.match(where, /lower\(thing\.address\) = ANY\(\$2\)/)
+    assert.deepEqual(params, ['vault', ['0xabcdefabcdefabcdefabcdefabcdefabcdefabcd']])
+  })
+
+  it('yearn and origin=yearn share the isYearn clause', () => {
+    const a = buildVaultFilters({ yearn: true })
+    const b = buildVaultFilters({ origin: 'yearn' })
+    assert.equal(a.where, b.where)
+    assert.match(a.where, /'yearn'\)::boolean, false\) OR .*'origin'\) = 'yearn'\)/)
+    assert.deepEqual(a.params, ['vault'])
+  })
+
+  it('yearn=false negates', () => {
+    const { where } = buildVaultFilters({ yearn: false })
+    assert.match(where, /NOT COALESCE.*IS DISTINCT FROM 'yearn'/)
+  })
+
+  it('non-yearn origin is parameterized', () => {
+    const { where, params } = buildVaultFilters({ origin: 'morpho' })
+    assert.match(where, /'origin'\) = \$2/)
+    assert.deepEqual(params, ['vault', 'morpho'])
+  })
+
+  it('unratedOnly wins over riskLevel', () => {
+    const { where, params } = buildVaultFilters({ unratedOnly: true, riskLevel: 3 })
+    assert.match(where, /riskLevel'\)::numeric, 0\) = 0/)
+    assert.doesNotMatch(where, /BETWEEN/)
+    assert.deepEqual(params, ['vault'])
+  })
+
+  it('apiVersion compares padded int arrays on both sides', () => {
+    const { where, params } = buildVaultFilters({ apiVersion: '3.0' })
+    assert.match(where, /'apiVersion'\) from .*\[1:3\] >= \(string_to_array.*\$2.*\[1:3\]/)
+    assert.deepEqual(params, ['vault', '3.0'])
+  })
+})

--- a/packages/web/lib/vaultFilters.spec.ts
+++ b/packages/web/lib/vaultFilters.spec.ts
@@ -79,6 +79,15 @@ describe('buildVaultFilters', () => {
     assert.match(where, /NOT \(.*'yearn'\) = to_jsonb\(true\)\) IS TRUE OR .*IS DISTINCT FROM 'yearn'/)
   })
 
+  it('erc4626=false and v3=false treat missing jsonb as false', () => {
+    for (const key of ['erc4626', 'v3'] as const) {
+      const { where, params } = buildVaultFilters({ [key]: false })
+      assert.match(where, new RegExp(`->'${key}'\\) = to_jsonb\\(true\\)\\) IS TRUE = \\$2::boolean`))
+      assert.doesNotMatch(where, /to_jsonb\(\$/)
+      assert.deepEqual(params, ['vault', false])
+    }
+  })
+
   it('non-yearn origin is parameterized', () => {
     const { where, params } = buildVaultFilters({ origin: 'morpho' })
     assert.match(where, /'origin'\) = \$2/)

--- a/packages/web/lib/vaultFilters.spec.ts
+++ b/packages/web/lib/vaultFilters.spec.ts
@@ -16,6 +16,22 @@ describe('buildVaultFilters', () => {
     assert.deepEqual(nullable.params, omitted.params)
   })
 
+  it('treats every explicit null filter like an omitted filter', () => {
+    const omitted = buildVaultFilters({})
+    const nullable = buildVaultFilters({
+      apiVersion: null, erc4626: null, v3: null, yearn: null, origin: null,
+      addresses: null, vaultType: null, riskLevel: null, unratedOnly: null
+    })
+    assert.equal(nullable.where, omitted.where)
+    assert.deepEqual(nullable.params, omitted.params)
+  })
+
+  it('filters risk on the same merged blob the resolver serves', () => {
+    const { where } = buildVaultFilters({ riskLevel: 3 })
+    assert.match(where, /COALESCE\(thing\.defaults.*->'risk'\)->>'riskLevel'\)::numeric BETWEEN 1 AND \$2/)
+    assert.doesNotMatch(where, /snapshot\.hook->'risk'/)
+  })
+
   it('numbers params in order', () => {
     const { where, params } = buildVaultFilters({ chainId: 1, vaultType: 2, riskLevel: 3 })
     assert.match(where, /thing\.chain_id = \$2/)

--- a/packages/web/lib/vaultFilters.ts
+++ b/packages/web/lib/vaultFilters.ts
@@ -1,3 +1,4 @@
+import { mergedFieldSql } from '@/lib/mergeSnapshot'
 import { EvmAddressSchema } from 'lib/types'
 
 export type VaultFilterArgs = {
@@ -13,13 +14,12 @@ export type VaultFilterArgs = {
   unratedOnly?: boolean
 }
 
-const field = (key: string) =>
-  `COALESCE(snapshot.snapshot->>'${key}', snapshot.hook->>'${key}', thing.defaults->>'${key}')`
+const field = mergedFieldSql
 
 const bool = (key: string) => `COALESCE(${field(key)}::boolean, false)`
 
 const version = (expr: string) =>
-  `(string_to_array(COALESCE(substring(${expr} from '^[a-zA-Z]*?(\\d+(\\.\\d+){0,2})'), '0'), '.')::int[] || ARRAY[0,0,0])[1:3]`
+  `(string_to_array(COALESCE(substring(${expr} from '^[a-zA-Z]*(\\d+(\\.\\d+){0,2})'), '0'), '.')::int[] || ARRAY[0,0,0])[1:3]`
 
 const isYearn = `(${bool('yearn')} OR ${field('origin')} = 'yearn')`
 

--- a/packages/web/lib/vaultFilters.ts
+++ b/packages/web/lib/vaultFilters.ts
@@ -16,12 +16,12 @@ export type VaultFilterArgs = {
 
 const field = mergedFieldSql
 
-const bool = (key: string) => `COALESCE(${field(key)}::boolean, false)`
+const bool = (key: string) => `(${mergedJsonSql(key)} = to_jsonb(true)) IS TRUE`
 
 const version = (expr: string) =>
   `(string_to_array(COALESCE(substring(${expr} from '^[a-zA-Z]*(\\d+(\\.\\d+){0,2})'), '0'), '.')::numeric[] || ARRAY[0,0,0])[1:3]`
 
-const riskLevelSql = `(${mergedJsonSql('risk')}->>'riskLevel')`
+const riskLevelSql = `${mergedJsonSql('risk')}->'riskLevel'`
 
 const isYearn = `(${bool('yearn')} OR ${field('origin')} = 'yearn')`
 
@@ -47,20 +47,20 @@ export function buildVaultFilters(args: VaultFilterArgs): { where: string, param
   }
 
   if (apiVersion != null) add(p => `${version(field('apiVersion'))} >= ${version(p)}`, apiVersion)
-  if (erc4626 != null) add(p => `${bool('erc4626')} = ${p}`, erc4626)
-  if (v3 != null) add(p => `${bool('v3')} = ${p}`, v3)
+  if (erc4626 != null) add(p => `${bool('erc4626')} = ${p}::boolean`, erc4626)
+  if (v3 != null) add(p => `${bool('v3')} = ${p}::boolean`, v3)
   if (yearn === true) where.push(isYearn)
   if (yearn === false) where.push(`(NOT ${bool('yearn')} OR ${field('origin')} IS DISTINCT FROM 'yearn')`)
 
   if (origin === 'yearn') where.push(isYearn)
   else if (origin != null) add(p => `${field('origin')} = ${p}`, origin)
 
-  if (vaultType != null) add(p => `COALESCE(${field('vaultType')}, '0')::numeric = ${p}`, vaultType)
+  if (vaultType != null) add(p => `COALESCE(${mergedJsonSql('vaultType')}, '0'::jsonb) = to_jsonb(${p}::numeric)`, vaultType)
 
   if (unratedOnly === true) {
-    where.push(`COALESCE(${riskLevelSql}::numeric, 0) = 0`)
+    where.push(`COALESCE(${riskLevelSql}, '0'::jsonb) = to_jsonb(0)`)
   } else if (riskLevel != null) {
-    add(p => `${riskLevelSql}::numeric BETWEEN 1 AND ${p}`, riskLevel)
+    add(p => `${riskLevelSql} BETWEEN to_jsonb(1) AND to_jsonb(${p}::numeric)`, riskLevel)
   }
 
   return { where: where.join('\n      AND '), params }

--- a/packages/web/lib/vaultFilters.ts
+++ b/packages/web/lib/vaultFilters.ts
@@ -2,7 +2,7 @@ import { mergedFieldSql } from '@/lib/mergeSnapshot'
 import { EvmAddressSchema } from 'lib/types'
 
 export type VaultFilterArgs = {
-  chainId?: number,
+  chainId?: number | null,
   apiVersion?: string,
   erc4626?: boolean,
   v3?: boolean,
@@ -33,7 +33,9 @@ export function buildVaultFilters(args: VaultFilterArgs): { where: string, param
     where.push(clause(`$${params.length}`))
   }
 
-  if (chainId !== undefined) add(p => `thing.chain_id = ${p}`, chainId)
+  // GraphQL nullable variables arrive here as an explicit null. Treat that
+  // the same as an omitted filter rather than generating `chain_id = NULL`.
+  if (chainId != null) add(p => `thing.chain_id = ${p}`, chainId)
 
   if (addresses !== undefined) {
     const valid = addresses

--- a/packages/web/lib/vaultFilters.ts
+++ b/packages/web/lib/vaultFilters.ts
@@ -19,7 +19,7 @@ const field = mergedFieldSql
 const bool = (key: string) => `COALESCE(${field(key)}::boolean, false)`
 
 const version = (expr: string) =>
-  `(string_to_array(COALESCE(substring(${expr} from '^[a-zA-Z]*(\\d+(\\.\\d+){0,2})'), '0'), '.')::int[] || ARRAY[0,0,0])[1:3]`
+  `(string_to_array(COALESCE(substring(${expr} from '^[a-zA-Z]*(\\d+(\\.\\d+){0,2})'), '0'), '.')::numeric[] || ARRAY[0,0,0])[1:3]`
 
 const riskLevelSql = `(${mergedJsonSql('risk')}->>'riskLevel')`
 

--- a/packages/web/lib/vaultFilters.ts
+++ b/packages/web/lib/vaultFilters.ts
@@ -1,0 +1,63 @@
+import { EvmAddressSchema } from 'lib/types'
+
+export type VaultFilterArgs = {
+  chainId?: number,
+  apiVersion?: string,
+  erc4626?: boolean,
+  v3?: boolean,
+  yearn?: boolean,
+  origin?: string,
+  addresses?: string[],
+  vaultType?: number,
+  riskLevel?: number,
+  unratedOnly?: boolean
+}
+
+const field = (key: string) =>
+  `COALESCE(snapshot.snapshot->>'${key}', snapshot.hook->>'${key}', thing.defaults->>'${key}')`
+
+const bool = (key: string) => `COALESCE(${field(key)}::boolean, false)`
+
+const version = (expr: string) =>
+  `(string_to_array(COALESCE(substring(${expr} from '^[a-zA-Z]*?(\\d+(\\.\\d+){0,2})'), '0'), '.')::int[] || ARRAY[0,0,0])[1:3]`
+
+const isYearn = `(${bool('yearn')} OR ${field('origin')} = 'yearn')`
+
+export function buildVaultFilters(args: VaultFilterArgs): { where: string, params: unknown[] } {
+  const { chainId, apiVersion, erc4626, v3, yearn, origin, addresses, vaultType, riskLevel, unratedOnly } = args
+
+  const where = ['thing.label = $1']
+  const params: unknown[] = ['vault']
+  const add = (clause: (p: string) => string, value: unknown) => {
+    params.push(value)
+    where.push(clause(`$${params.length}`))
+  }
+
+  if (chainId !== undefined) add(p => `thing.chain_id = ${p}`, chainId)
+
+  if (addresses !== undefined) {
+    const valid = addresses
+      .map(a => EvmAddressSchema.safeParse(a))
+      .flatMap(r => r.success ? [r.data.toLowerCase()] : [])
+    add(p => `lower(thing.address) = ANY(${p})`, valid)
+  }
+
+  if (apiVersion !== undefined) add(p => `${version(field('apiVersion'))} >= ${version(p)}`, apiVersion)
+  if (erc4626 !== undefined) add(p => `${bool('erc4626')} = ${p}`, erc4626)
+  if (v3 !== undefined) add(p => `${bool('v3')} = ${p}`, v3)
+  if (yearn === true) where.push(isYearn)
+  if (yearn === false) where.push(`(NOT ${bool('yearn')} OR ${field('origin')} IS DISTINCT FROM 'yearn')`)
+
+  if (origin === 'yearn') where.push(isYearn)
+  else if (origin !== undefined) add(p => `${field('origin')} = ${p}`, origin)
+
+  if (vaultType !== undefined) add(p => `COALESCE(${field('vaultType')}, '0')::numeric = ${p}`, vaultType)
+
+  if (unratedOnly === true) {
+    where.push('COALESCE((snapshot.hook->\'risk\'->>\'riskLevel\')::numeric, 0) = 0')
+  } else if (riskLevel !== undefined) {
+    add(p => `(snapshot.hook->'risk'->>'riskLevel')::numeric BETWEEN 1 AND ${p}`, riskLevel)
+  }
+
+  return { where: where.join('\n      AND '), params }
+}

--- a/packages/web/lib/vaultFilters.ts
+++ b/packages/web/lib/vaultFilters.ts
@@ -55,7 +55,7 @@ export function buildVaultFilters(args: VaultFilterArgs): { where: string, param
   if (origin === 'yearn') where.push(isYearn)
   else if (origin != null) add(p => `${field('origin')} = ${p}`, origin)
 
-  if (vaultType != null) add(p => `COALESCE(${mergedJsonSql('vaultType')}, '0'::jsonb) = to_jsonb(${p}::numeric)`, vaultType)
+  if (vaultType != null) add(p => `COALESCE(${mergedJsonSql('vaultType')}, '0'::jsonb) IN (to_jsonb(${p}::numeric), to_jsonb(${p}::text))`, vaultType)
 
   if (unratedOnly === true) {
     where.push(`COALESCE(${riskLevelSql}, '0'::jsonb) = to_jsonb(0)`)

--- a/packages/web/lib/vaultFilters.ts
+++ b/packages/web/lib/vaultFilters.ts
@@ -1,17 +1,17 @@
-import { mergedFieldSql } from '@/lib/mergeSnapshot'
+import { mergedFieldSql, mergedJsonSql } from '@/lib/mergeSnapshot'
 import { EvmAddressSchema } from 'lib/types'
 
 export type VaultFilterArgs = {
   chainId?: number | null,
-  apiVersion?: string,
-  erc4626?: boolean,
-  v3?: boolean,
-  yearn?: boolean,
-  origin?: string,
-  addresses?: string[],
-  vaultType?: number,
-  riskLevel?: number,
-  unratedOnly?: boolean
+  apiVersion?: string | null,
+  erc4626?: boolean | null,
+  v3?: boolean | null,
+  yearn?: boolean | null,
+  origin?: string | null,
+  addresses?: string[] | null,
+  vaultType?: number | null,
+  riskLevel?: number | null,
+  unratedOnly?: boolean | null
 }
 
 const field = mergedFieldSql
@@ -20,6 +20,8 @@ const bool = (key: string) => `COALESCE(${field(key)}::boolean, false)`
 
 const version = (expr: string) =>
   `(string_to_array(COALESCE(substring(${expr} from '^[a-zA-Z]*(\\d+(\\.\\d+){0,2})'), '0'), '.')::int[] || ARRAY[0,0,0])[1:3]`
+
+const riskLevelSql = `(${mergedJsonSql('risk')}->>'riskLevel')`
 
 const isYearn = `(${bool('yearn')} OR ${field('origin')} = 'yearn')`
 
@@ -34,31 +36,31 @@ export function buildVaultFilters(args: VaultFilterArgs): { where: string, param
   }
 
   // GraphQL nullable variables arrive here as an explicit null. Treat that
-  // the same as an omitted filter rather than generating `chain_id = NULL`.
+  // the same as an omitted filter rather than generating `x = NULL`.
   if (chainId != null) add(p => `thing.chain_id = ${p}`, chainId)
 
-  if (addresses !== undefined) {
+  if (addresses != null) {
     const valid = addresses
       .map(a => EvmAddressSchema.safeParse(a))
       .flatMap(r => r.success ? [r.data.toLowerCase()] : [])
     add(p => `lower(thing.address) = ANY(${p})`, valid)
   }
 
-  if (apiVersion !== undefined) add(p => `${version(field('apiVersion'))} >= ${version(p)}`, apiVersion)
-  if (erc4626 !== undefined) add(p => `${bool('erc4626')} = ${p}`, erc4626)
-  if (v3 !== undefined) add(p => `${bool('v3')} = ${p}`, v3)
+  if (apiVersion != null) add(p => `${version(field('apiVersion'))} >= ${version(p)}`, apiVersion)
+  if (erc4626 != null) add(p => `${bool('erc4626')} = ${p}`, erc4626)
+  if (v3 != null) add(p => `${bool('v3')} = ${p}`, v3)
   if (yearn === true) where.push(isYearn)
   if (yearn === false) where.push(`(NOT ${bool('yearn')} OR ${field('origin')} IS DISTINCT FROM 'yearn')`)
 
   if (origin === 'yearn') where.push(isYearn)
-  else if (origin !== undefined) add(p => `${field('origin')} = ${p}`, origin)
+  else if (origin != null) add(p => `${field('origin')} = ${p}`, origin)
 
-  if (vaultType !== undefined) add(p => `COALESCE(${field('vaultType')}, '0')::numeric = ${p}`, vaultType)
+  if (vaultType != null) add(p => `COALESCE(${field('vaultType')}, '0')::numeric = ${p}`, vaultType)
 
   if (unratedOnly === true) {
-    where.push('COALESCE((snapshot.hook->\'risk\'->>\'riskLevel\')::numeric, 0) = 0')
-  } else if (riskLevel !== undefined) {
-    add(p => `(snapshot.hook->'risk'->>'riskLevel')::numeric BETWEEN 1 AND ${p}`, riskLevel)
+    where.push(`COALESCE(${riskLevelSql}::numeric, 0) = 0`)
+  } else if (riskLevel != null) {
+    add(p => `${riskLevelSql}::numeric BETWEEN 1 AND ${p}`, riskLevel)
   }
 
   return { where: where.join('\n      AND '), params }


### PR DESCRIPTION
### Summary
`vaults` returned every vault on every chain, filtered in JS, and shipped three overlapping jsonb
blobs per row from Postgres. Filters now run in SQL, the blobs merge in the query, keys no typeDef
serves are stripped, paging is offset based, and the hot queries carry response-cache hints.

- `vaults(chainId: Int)`: chainId stays optional (omit to list every chain). `limit: Int = 100`
  (clamped to `1..1000`) and `offset: Int = 0` added. Ordered by tvl desc, chain id asc, address asc
  (case-insensitive). Vaults with no tvl sort last as `0`. Return type unchanged.
- `buildVaultFilters` (new `lib/vaultFilters.ts`) builds the WHERE clause; the JS post-filters are gone.
  Filters read the same merged jsonb the SELECT serves. Boolean and numeric filters compare jsonb
  values directly (`= to_jsonb(...)`, `BETWEEN to_jsonb(1) AND ...`) instead of casting text with
  `::boolean` / `::numeric`, so an odd stored value filters the row out rather than failing the query.
- `apiVersion` compares the whole version as a padded `numeric[]`, not just the major. The old pattern
  opened with a non-greedy quantifier, which makes the whole regex non-greedy in postgres: `3.0.4`
  captured as `3`.
- `mergeSnapshotSql` merges `defaults || hook || snapshot` in SQL (hook `asset` wins, as before) and
  strips `VAULT_UNSERVED_KEYS`. Used by `vault`, `vaults`, `accountVaults`.
- `@cacheControl(maxAge: 300)` on `vault`, `vaults`, `timeseries`. `vault` was 3000.
- `EvmAddressSchema` gains a regex refine before its `getAddress` transform. zod does not catch throws in
  transforms, so `safeParse` was never safe and a 0x-prefixed non-address escaped as a raw viem
  `InvalidAddressError`. Also affects `ingest/extract/evmlogs.ts`, the other `safeParse` caller.
- `scripts/quality-assurance/tvl-backfill.ts` fetches its vaults with the `addresses` filter instead
  of the full list.
- `docs/graphql.md` updated for optional `chainId`, `limit`, `offset`.

Measured on the read replica for label=vault (2203 rows): blobs 11.7 MB raw, SQL merge -4%, key strip
-12% (`composition` alone is 1.27 MB).

Keyset paging (`after` cursor) was tried first and dropped: the sort key is a computed, unindexed tvl,
so keyset costs the same full sort as OFFSET at this row count while adding a cursor CTE with modes
that cannot be fixed (cursor row deleted, tvl churn between pages, ambiguous address across chains).

### How to review
- Start with `lib/vaultFilters.ts` against the deleted JS filters in
  `resolvers/vaults.ts`; each branch maps 1:1.
- `lib/mergeSnapshot.ts`: the SQL expression mirrors `mergeSnapshot()` (kept for other callers).
- `resolvers/vaults.ts`: ORDER BY + LIMIT/OFFSET. Null `chainId` must not empty the page.
- Ignore `route.ts` beyond the landing-page default query and import order.
- Smoke: `vaults { address }` then `vaults(chainId: 1) { address }` then
  `vaults(chainId: 1, offset: 100)`; pages must not overlap.

### Test plan
- [x] Manual: paged chain 1 (1302 vaults) on the Neon read replica, no overlap, tvl order held
- [x] Manual: `vaults { chainId address }` without chainId returns mixed chains
- [x] Automated: `bunx vitest run lib/mergeSnapshot.spec.ts lib/vaultFilters.spec.ts app/api/gql/resolvers/vaults.spec.ts` (24 passed)

### Risk / impact
- Breaking for clients expecting the full list (now 100 per page). Known callers: cms
  sync-vaults, tvl-backfill; tvl-backfill is updated here, cms sync-vaults must loop `offset` or pass
  a larger `limit`.
- Offset paging over a sort key the indexer keeps rewriting can duplicate or skip a row between pages.
  The 300s response cache pins pages within a walk when filters stay identical.
- `apiVersion` filtering gets stricter: a request for `>= 3.0.4` no longer matches on major alone.
- A stored JSON `null` boolean (`erc4626`, `v3`, `yearn`) reads as `false`, same as before.
- `VAULT_UNSERVED_KEYS` is a hand-picked list from the current `type Vault`; adding a typeDef field
  for one of those keys requires removing it from the list.
- `EvmAddressSchema.parse` now throws `ZodError` instead of viem's `InvalidAddressError` on a
  0x-prefixed non-address. Callers catching the viem error type specifically would miss it.
- Cache plugin only active with `GQL_ENABLE_CACHE=true`; prod env not verified from this branch.
- Rollback: revert the commits; no migrations.
