### PR TITLE
Fix timeseries fanout compile error on optional outputLabel

### DIFF
--- a/packages/ingest/fanout/timeseries.ts
+++ b/packages/ingest/fanout/timeseries.ts
@@ -19,6 +19,7 @@ export default class TimeseriesFanout {
     const hooks = this.resolveHooks(abiPath, 'timeseries')
     for (const hook of hooks) {
       const outputLabel = hook.module.outputLabel
+      if (!outputLabel) throw new Error(`!outputLabel, ${abiPath} timeseries hook`)
 
       const from = startBlock !== undefined
         ? startBlock


### PR DESCRIPTION
### Summary
`bun dev` in `packages/ingest` fails to boot on `main` with a TypeScript error in `fanout/timeseries.ts`. The `findMissingDays` call added in #462 passes `hook.module.outputLabel`, which is typed optional, into a required `string` parameter. ts-node type checks at startup, so the whole ingest service refuses to start.

This adds a guard at the top of the timeseries hook loop that throws if a hook exports no `outputLabel`. That narrows the type for both `findMissingDays` and the job id, and fails earlier with a clearer message than the extract side's existing `!hook` error.

### How to review
One line in `packages/ingest/fanout/timeseries.ts`. Every timeseries hook under `packages/ingest/abis` already exports `outputLabel`, and `extract/timeseries.ts` already requires it as a string via zod, so the throw is unreachable for current hooks.

### Test plan
- [x] Manual: `cd packages/ingest && bun dev` boots all processors, workers, and crons and runs fanout cycles
- [x] Automated: `bunx vitest run fanout/timeseries` passes (7 tests across `timeseries.spec.ts` and `timeseries.replay.mock.spec.ts`)
- [x] `tsc --noEmit` in `packages/ingest` reports no errors outside pre-existing spec-file and vitest config errors

### Risk / impact
None at runtime for existing hooks. A future timeseries hook without `outputLabel` now fails at fanout instead of at extract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
