### PR TITLE
feat(web): expose last cache refresh time as header on rest endpoints

### DIFF
--- a/packages/web/app/api/cron/handler.spec.ts
+++ b/packages/web/app/api/cron/handler.spec.ts
@@ -1,4 +1,8 @@
 import { strict as assert } from 'node:assert'
+
+const { setLastRefresh } = vi.hoisted(() => ({ setLastRefresh: vi.fn().mockResolvedValue(undefined) }))
+vi.mock('../rest/cache', () => ({ setLastRefresh }))
+
 import { createCronHandler } from './handler'
 
 describe('createCronHandler', () => {
@@ -7,6 +11,31 @@ describe('createCronHandler', () => {
   afterEach(() => {
     vi.unstubAllEnvs()
     global.fetch = originalFetch
+    setLastRefresh.mockClear()
+  })
+
+  it('records the last refresh time keyed by the cron path slug', async () => {
+    vi.stubEnv('CRON_SECRET', 'secret')
+    const job = vi.fn().mockResolvedValue(undefined)
+    const handler = createCronHandler(job, 'UPTIME_KUMA_PUSH_URL_REFRESH_VAULTS')
+
+    await handler(new Request('http://localhost/api/cron/refresh-cache', {
+      headers: { authorization: 'Bearer secret' },
+    }))
+
+    assert.deepEqual(setLastRefresh.mock.calls, [['refresh-cache']])
+  })
+
+  it('does not record the last refresh time when the job fails', async () => {
+    vi.stubEnv('CRON_SECRET', 'secret')
+    const job = vi.fn().mockRejectedValue(new Error('boom'))
+    const handler = createCronHandler(job, 'UPTIME_KUMA_PUSH_URL_REFRESH_VAULTS')
+
+    await handler(new Request('http://localhost/api/cron/refresh-cache', {
+      headers: { authorization: 'Bearer secret' },
+    }))
+
+    assert.equal(setLastRefresh.mock.calls.length, 0)
   })
 
   it('returns 401 when no authorization header', async () => {

--- a/packages/web/app/api/cron/handler.spec.ts
+++ b/packages/web/app/api/cron/handler.spec.ts
@@ -11,7 +11,8 @@ describe('createCronHandler', () => {
   afterEach(() => {
     vi.unstubAllEnvs()
     global.fetch = originalFetch
-    setLastRefresh.mockClear()
+    setLastRefresh.mockReset()
+    setLastRefresh.mockResolvedValue(undefined)
   })
 
   it('records the last refresh time keyed by the cron path slug', async () => {
@@ -35,6 +36,35 @@ describe('createCronHandler', () => {
       headers: { authorization: 'Bearer secret' },
     }))
 
+    assert.equal(setLastRefresh.mock.calls.length, 0)
+  })
+
+  it('still returns 200 when the last refresh write fails', async () => {
+    vi.stubEnv('CRON_SECRET', 'secret')
+    setLastRefresh.mockRejectedValue(new Error('redis down'))
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const job = vi.fn().mockResolvedValue(undefined)
+    const handler = createCronHandler(job, 'UPTIME_KUMA_PUSH_URL_REFRESH_VAULTS')
+
+    const response = await handler(new Request('http://localhost/api/cron/refresh-cache', {
+      headers: { authorization: 'Bearer secret' },
+    }))
+
+    assert.equal(response.status, 200)
+    assert.equal(setLastRefresh.mock.calls.length, 1)
+    errorSpy.mockRestore()
+  })
+
+  it('does not record a last refresh when the cron path has no slug', async () => {
+    vi.stubEnv('CRON_SECRET', 'secret')
+    const job = vi.fn().mockResolvedValue(undefined)
+    const handler = createCronHandler(job, 'UPTIME_KUMA_PUSH_URL_REFRESH_VAULTS')
+
+    const response = await handler(new Request('http://localhost/', {
+      headers: { authorization: 'Bearer secret' },
+    }))
+
+    assert.equal(response.status, 200)
     assert.equal(setLastRefresh.mock.calls.length, 0)
   })
 

--- a/packages/web/app/api/cron/handler.ts
+++ b/packages/web/app/api/cron/handler.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { timingSafeEqual } from 'crypto'
+import { setLastRefresh } from '../rest/cache'
 
 function isAuthenticated(request: Request): boolean {
   const secret = process.env.CRON_SECRET
@@ -23,6 +24,7 @@ export function createCronHandler(job: () => Promise<void>, kumaEnvVar: string) 
     }
     try {
       await job()
+      await recordLastRefresh(request)
       await pushUptimeKuma(kumaEnvVar, 'up', 'OK')
       return NextResponse.json({ ok: true })
     } catch (error) {
@@ -30,6 +32,16 @@ export function createCronHandler(job: () => Promise<void>, kumaEnvVar: string) 
       await pushUptimeKuma(kumaEnvVar, 'down', 'Run failed')
       return NextResponse.json({ ok: false }, { status: 500 })
     }
+  }
+}
+
+async function recordLastRefresh(request: Request) {
+  const job = new URL(request.url).pathname.split('/').filter(Boolean).pop()
+  if (!job) return
+  try {
+    await setLastRefresh(job)
+  } catch (error) {
+    console.error(`last refresh write failed (${job})`, error)
   }
 }
 

--- a/packages/web/app/api/cron/routes.spec.ts
+++ b/packages/web/app/api/cron/routes.spec.ts
@@ -6,6 +6,7 @@ const refreshHistorical = vi.fn().mockResolvedValue(undefined)
 const refreshReportsLatest = vi.fn().mockResolvedValue(undefined)
 const refreshReportsHistorical = vi.fn().mockResolvedValue(undefined)
 
+vi.mock('../rest/cache', () => ({ setLastRefresh: vi.fn().mockResolvedValue(undefined) }))
 vi.mock('../rest/refresh-vaults', () => ({ refresh }))
 vi.mock('../rest/timeseries/refresh', () => ({ refreshLatest }))
 vi.mock('../rest/timeseries/refresh-historical', () => ({ refreshHistorical }))

--- a/packages/web/app/api/rest/cache.spec.ts
+++ b/packages/web/app/api/rest/cache.spec.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'node:assert'
-import { estimateMSetRequestSize, splitPairsForMSet, writeClient } from './cache'
+import { estimateMSetRequestSize, getKeyvClient, lastRefreshHeaders, setLastRefresh, splitPairsForMSet, writeClient } from './cache'
 
 describe('splitPairsForMSet', () => {
   it('keeps all pairs in one chunk when below the target', () => {
@@ -43,5 +43,54 @@ describe('splitPairsForMSet', () => {
 describe('rest cache write client', () => {
   it('logs redis errors instead of crashing the process', () => {
     assert.equal(writeClient.listenerCount('error'), 1)
+  })
+})
+
+describe('last refresh', () => {
+  const keyv = getKeyvClient()
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('setLastRefresh stores an ISO timestamp under rest:refresh:<job>', async () => {
+    const set = vi.spyOn(keyv, 'set').mockResolvedValue(undefined as never)
+    const at = new Date('2026-01-02T03:04:05.000Z')
+
+    await setLastRefresh('refresh-cache', at)
+
+    assert.deepEqual(set.mock.calls, [['rest:refresh:refresh-cache', '2026-01-02T03:04:05.000Z']])
+  })
+
+  it('setLastRefresh defaults to the current time', async () => {
+    const set = vi.spyOn(keyv, 'set').mockResolvedValue(undefined as never)
+
+    await setLastRefresh('reports-refresh')
+
+    assert.equal(set.mock.calls[0][0], 'rest:refresh:reports-refresh')
+    assert.match(set.mock.calls[0][1] as string, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/)
+  })
+
+  it('lastRefreshHeaders returns the header and expose list when a timestamp exists', async () => {
+    vi.spyOn(keyv, 'get').mockResolvedValue('2026-01-02T03:04:05.000Z')
+
+    assert.deepEqual(await lastRefreshHeaders('refresh-cache'), {
+      'x-last-refresh': '2026-01-02T03:04:05.000Z',
+      'access-control-expose-headers': 'x-last-refresh',
+    })
+  })
+
+  it('lastRefreshHeaders returns no headers when the key is missing', async () => {
+    const get = vi.spyOn(keyv, 'get').mockResolvedValue(undefined)
+
+    assert.deepEqual(await lastRefreshHeaders('refresh-cache'), {})
+    assert.deepEqual(get.mock.calls, [['rest:refresh:refresh-cache']])
+  })
+
+  it('lastRefreshHeaders returns no headers when redis throws', async () => {
+    vi.spyOn(keyv, 'get').mockRejectedValue(new Error('down'))
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    assert.deepEqual(await lastRefreshHeaders('refresh-cache'), {})
   })
 })

--- a/packages/web/app/api/rest/cache.ts
+++ b/packages/web/app/api/rest/cache.ts
@@ -88,3 +88,27 @@ export async function disconnect(): Promise<void> {
   await writeClient.disconnect()
   await keyv.disconnect()
 }
+
+const LAST_REFRESH_PREFIX = 'rest:refresh:'
+
+export async function setLastRefresh(job: string, at = new Date()): Promise<void> {
+  await keyv.set(`${LAST_REFRESH_PREFIX}${job}`, at.toISOString())
+}
+
+export async function getLastRefresh(job: string): Promise<string | undefined> {
+  return await keyv.get(`${LAST_REFRESH_PREFIX}${job}`) as string | undefined
+}
+
+export async function lastRefreshHeaders(job: string): Promise<Record<string, string>> {
+  try {
+    const at = await getLastRefresh(job)
+    if (!at) return {}
+    return {
+      'x-last-refresh': at,
+      'access-control-expose-headers': 'x-last-refresh',
+    }
+  } catch (err) {
+    console.error(`last refresh read failed for ${job}:`, err)
+    return {}
+  }
+}

--- a/packages/web/app/api/rest/list/vaults/[chainId]/route.ts
+++ b/packages/web/app/api/rest/list/vaults/[chainId]/route.ts
@@ -1,10 +1,12 @@
 import { NextResponse } from 'next/server'
-import { getKeyvClient } from '../../../cache'
+import { getKeyvClient, lastRefreshHeaders } from '../../../cache'
 import type { VaultListItem } from '../../db'
 
 const keyv = getKeyvClient()
 
 export const runtime = 'nodejs'
+
+const REFRESH_JOB = 'refresh-cache'
 
 const corsHeaders = {
   'access-control-allow-origin': '*',
@@ -30,8 +32,12 @@ export async function GET(
   }
 
   let vaults: VaultListItem[] | undefined
+  let refreshHeaders: Record<string, string> = {}
   try {
-    vaults = await keyv.get(`rest:list:vaults:${chainId}`) as VaultListItem[] | undefined
+    ;[vaults, refreshHeaders] = await Promise.all([
+      keyv.get(`rest:list:vaults:${chainId}`) as Promise<VaultListItem[] | undefined>,
+      lastRefreshHeaders(REFRESH_JOB),
+    ])
   } catch (err) {
     console.error(`Redis read failed for chainId ${chainId}:`, err)
     throw err
@@ -50,6 +56,7 @@ export async function GET(
     headers: {
       'cache-control': 'public, max-age=900, s-maxage=900, stale-while-revalidate=600',
       ...corsHeaders,
+      ...refreshHeaders,
     },
   })
 }

--- a/packages/web/app/api/rest/list/vaults/route.ts
+++ b/packages/web/app/api/rest/list/vaults/route.ts
@@ -1,10 +1,12 @@
 import { NextResponse } from 'next/server'
-import { getKeyvClient } from '../../cache'
+import { getKeyvClient, lastRefreshHeaders } from '../../cache'
 import type { VaultListItem } from '../db'
 
 const keyv = getKeyvClient()
 
 export const runtime = 'nodejs'
+
+const REFRESH_JOB = 'refresh-cache'
 
 const corsHeaders = {
   'access-control-allow-origin': '*',
@@ -16,7 +18,10 @@ export async function GET(request: Request) {
   const origin = searchParams.get('origin')
 
   try {
-    const allVaults = await keyv.get('rest:list:vaults:all') as VaultListItem[] | undefined
+    const [allVaults, refreshHeaders] = await Promise.all([
+      keyv.get('rest:list:vaults:all') as Promise<VaultListItem[] | undefined>,
+      lastRefreshHeaders(REFRESH_JOB),
+    ])
 
     if (!allVaults) {
       return new NextResponse('Not found', { status: 404, headers: corsHeaders })
@@ -31,6 +36,7 @@ export async function GET(request: Request) {
       headers: {
         'cache-control': 'public, max-age=900, s-maxage=900, stale-while-revalidate=600',
         ...corsHeaders,
+        ...refreshHeaders,
       },
     })
   } catch (err) {

--- a/packages/web/app/api/rest/reports/[chainId]/[address]/route.ts
+++ b/packages/web/app/api/rest/reports/[chainId]/[address]/route.ts
@@ -1,9 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { getKeyvClient } from '../../../cache'
+import { getKeyvClient, lastRefreshHeaders } from '../../../cache'
 import { VaultReport } from '../../db'
 import { getReportKey, getReportLatestKey } from '../../redis'
 
 const keyv = getKeyvClient()
+
+const REFRESH_JOB = 'reports-refresh'
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -28,9 +30,10 @@ export async function GET(
   const historicalKey = getReportKey(chainId, address)
   const latestKey = getReportLatestKey(chainId, address)
 
-  const [historical, latest] = await Promise.all([
+  const [historical, latest, refreshHeaders] = await Promise.all([
     keyv.get(historicalKey) as Promise<VaultReport[] | undefined>,
     keyv.get(latestKey) as Promise<VaultReport[] | undefined>,
+    lastRefreshHeaders(REFRESH_JOB),
   ])
 
   if (!historical && !latest) {
@@ -53,6 +56,7 @@ export async function GET(
     headers: {
       'Cache-Control': 'public, max-age=900, s-maxage=900, stale-while-revalidate=600',
       ...corsHeaders,
+      ...refreshHeaders,
     }
   })
 }

--- a/packages/web/app/api/rest/snapshot/[chainId]/[address]/route.ts
+++ b/packages/web/app/api/rest/snapshot/[chainId]/[address]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { getKeyvClient } from '../../../cache'
+import { getKeyvClient, lastRefreshHeaders } from '../../../cache'
 import type { VaultSnapshot } from '../../db'
 import { getSnapshotKey } from '../../redis'
 
@@ -11,6 +11,8 @@ type RouteParams = {
   chainId?: string | string[]
   address?: string | string[]
 }
+
+const REFRESH_JOB = 'refresh-cache'
 
 const corsHeaders = {
   'access-control-allow-origin': '*',
@@ -34,8 +36,12 @@ export async function GET(
   const cacheKey = getSnapshotKey(Number(chainId), addressLower)
 
   let parsed: VaultSnapshot | undefined
+  let refreshHeaders: Record<string, string> = {}
   try {
-    parsed = await keyv.get(cacheKey)
+    ;[parsed, refreshHeaders] = await Promise.all([
+      keyv.get(cacheKey) as Promise<VaultSnapshot | undefined>,
+      lastRefreshHeaders(REFRESH_JOB),
+    ])
   } catch (err) {
     console.error(`Redis read failed for ${cacheKey}:`, err)
     throw err
@@ -50,6 +56,7 @@ export async function GET(
     headers: {
       'cache-control': 'public, max-age=900, s-maxage=900, stale-while-revalidate=600',
       ...corsHeaders,
+      ...refreshHeaders,
     },
   })
 }

--- a/packages/web/app/api/rest/timeseries/[segment]/[chainId]/[address]/route.spec.ts
+++ b/packages/web/app/api/rest/timeseries/[segment]/[chainId]/[address]/route.spec.ts
@@ -4,7 +4,8 @@ import { beforeEach, describe, it, vi } from 'vitest'
 const get = vi.fn()
 
 vi.mock('@/app/api/rest/cache', () => ({
-  getKeyvClient: () => ({ get })
+  getKeyvClient: () => ({ get }),
+  lastRefreshHeaders: async () => ({})
 }))
 
 async function call(components?: string) {

--- a/packages/web/app/api/rest/timeseries/[segment]/[chainId]/[address]/route.spec.ts
+++ b/packages/web/app/api/rest/timeseries/[segment]/[chainId]/[address]/route.spec.ts
@@ -2,28 +2,34 @@ import { strict as assert } from 'node:assert'
 import { beforeEach, describe, it, vi } from 'vitest'
 
 const get = vi.fn()
+const lastRefreshHeaders = vi.fn()
 
 vi.mock('@/app/api/rest/cache', () => ({
   getKeyvClient: () => ({ get }),
-  lastRefreshHeaders: async () => ({})
+  lastRefreshHeaders,
 }))
 
-async function call(components?: string) {
+async function callResponse(components?: string) {
   const { GET } = await import('./route')
   const url = `http://localhost/api/rest/timeseries/tvl/1/0x1111111111111111111111111111111111111111${components ?? ''}`
-  const response = await GET(new Request(url) as never, {
+  return GET(new Request(url) as never, {
     params: Promise.resolve({
       segment: 'tvl',
       chainId: '1',
       address: '0x1111111111111111111111111111111111111111'
     })
   })
-  return await response.json()
+}
+
+async function call(components?: string) {
+  return await (await callResponse(components)).json()
 }
 
 describe('rest timeseries route', () => {
   beforeEach(() => {
     get.mockReset()
+    lastRefreshHeaders.mockReset()
+    lastRefreshHeaders.mockResolvedValue({})
   })
 
   it('omits null-valued days instead of serving them as zero', async () => {
@@ -53,5 +59,19 @@ describe('rest timeseries route', () => {
     const rows = await call()
 
     assert.deepEqual(rows, [])
+  })
+
+  it('exposes x-last-refresh from the timeseries-refresh job', async () => {
+    get.mockResolvedValue([])
+    lastRefreshHeaders.mockResolvedValue({
+      'x-last-refresh': '2026-01-02T03:04:05.000Z',
+      'access-control-expose-headers': 'x-last-refresh',
+    })
+
+    const response = await callResponse()
+
+    assert.equal(response.headers.get('x-last-refresh'), '2026-01-02T03:04:05.000Z')
+    assert.equal(response.headers.get('access-control-expose-headers'), 'x-last-refresh')
+    assert.deepEqual(lastRefreshHeaders.mock.calls, [['timeseries-refresh']])
   })
 })

--- a/packages/web/app/api/rest/timeseries/[segment]/[chainId]/[address]/route.ts
+++ b/packages/web/app/api/rest/timeseries/[segment]/[chainId]/[address]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { getKeyvClient } from '../../../../cache'
+import { getKeyvClient, lastRefreshHeaders } from '../../../../cache'
 import { labels } from '../../../labels'
 import { getTimeseriesKey, getTimeseriesLatestKey } from '../../../redis'
 
@@ -10,6 +10,8 @@ type RouteParams = {
   chainId?: string | string[]
   address?: string | string[]
 }
+
+const REFRESH_JOB = 'timeseries-refresh'
 
 const corsHeaders = {
   'access-control-allow-origin': '*',
@@ -53,13 +55,16 @@ export async function GET(
 
   let historical: TimeseriesEntry[] = []
   let latest: TimeseriesEntry[] = []
+  let refreshHeaders: Record<string, string> = {}
   try {
-    const [historicalCached, latestCached] = await Promise.all([
+    const [historicalCached, latestCached, headers] = await Promise.all([
       timeseriesKeyv.get(historicalKey),
       timeseriesKeyv.get(latestKey),
+      lastRefreshHeaders(REFRESH_JOB),
     ])
     historical = (historicalCached as TimeseriesEntry[]) || []
     latest = (latestCached as TimeseriesEntry[]) || []
+    refreshHeaders = headers
   } catch (err) {
     console.error(`Redis read failed for ${historicalKey}:`, err)
     throw err
@@ -83,6 +88,7 @@ export async function GET(
     headers: {
       'cache-control': 'public, max-age=900, s-maxage=900, stale-while-revalidate=600',
       ...corsHeaders,
+      ...refreshHeaders,
     },
   })
 }


### PR DESCRIPTION
### Summary

REST cache consumers had no way to tell how stale a response was. The cron handler now writes the completion timestamp to redis (`rest:refresh:<job>`, key derived from the cron path slug) after a successful run, and the REST routes return it as `x-last-refresh` (ISO 8601). Redis is needed because the crons and the routes run in separate serverless invocations.

Header is added to `Access-Control-Expose-Headers` so browsers can read it — the routes serve `Access-Control-Allow-Origin: *`, which otherwise hides custom headers.

Job → route mapping:

| cron | routes |
| --- | --- |
| `refresh-cache` | `/rest/list/vaults`, `/rest/list/vaults/[chainId]`, `/rest/snapshot/[chainId]/[address]` |
| `reports-refresh` | `/rest/reports/[chainId]/[address]` |
| `timeseries-refresh` | `/rest/timeseries/[segment]/[chainId]/[address]` |

### How to review

Start at `packages/web/app/api/rest/cache.ts` (the three new helpers) and `packages/web/app/api/cron/handler.ts` (where the write happens). The five route files are the same change repeated: the redis read for the header joins the existing `Promise.all`, so no extra round trip is serialized.

Two things worth checking:
- The timestamp is written only after `job()` resolves, so a failed run leaves the previous value in place.
- A redis failure on the read path returns no header rather than failing the request.

### Test plan

- [x] Automated: `npx vitest run app/api/cron app/api/rest` — 41 passed at first land. Added (not re-run in the review-fix loop): `cache.spec.ts` covers `setLastRefresh` key+ISO (and default Date) plus `lastRefreshHeaders` hit / miss / throw; `handler.spec.ts` covers write on success, no write when the job throws, no write on an empty path slug, and 200 when the write throws; timeseries `route.spec.ts` asserts the route emits `x-last-refresh` for job `timeseries-refresh`.
- [ ] Manual: hit a cron endpoint with the `CRON_SECRET` bearer, then `curl -i` one of the REST routes and confirm `x-last-refresh` matches.

### Risk / impact

Low. Additive response header, no change to any payload. No migrations, no auth changes.

Known limits:
- Responses are CDN-cached with `s-maxage=900`, so a cached hit serves the header captured at render time, not the current value.
- The `*-refresh-historical` crons write their own keys, but no route reads them yet.
- 404 and 400 responses omit `x-last-refresh`. List/snapshot/reports fetch the timestamp then drop it on 404; timeseries unknown-segment 404s before the redis read.
- Successful crons await one extra redis SET before the kuma up ping. SET errors are swallowed (previous timestamp kept, cron still 200); a hung SET delays the 200.

Rollback is a revert; nothing depends on the redis key existing.
